### PR TITLE
string to path conversions

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -107,6 +107,8 @@ zksync_utils = {path = "../../zksync-era/core/lib/utils"}
 
 zk_evm = {git = "https://github.com/matter-labs/era-zk_evm.git"}
 
+# compiler-solidity = {git = "https://github.com/matter-labs/era-compiler-solidity.git"}
+
 [dev-dependencies]
 anvil = {path = "../anvil"}
 criterion = "0.4.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Some Paths were typed as strings. for os specific delimiters, these strings need to be changed to Paths

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Changed string based paths to std::path::Paths

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
