### PR TITLE
attempt to implement deposit functionality

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,10 @@
-reorder_imports = true
-imports_granularity = "Crate"
-use_small_heuristics = "Max"
-comment_width = 100
-wrap_comments = true
 binop_separator = "Back"
+comment_width = 100
+imports_granularity = "Crate"
+max_width = 80
+reorder_imports = true
 trailing_comma = "Vertical"
 trailing_semicolon = false
 use_field_init_shorthand = true
+use_small_heuristics = "Max"
+wrap_comments = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
currently l1 l2 deposits are not working

unable to instantiate a Provider compatible with zksync sdk

## Info

### Issue 1
getting RPC: Transport Error: Port not provided in url:

```bash
The application panicked (crashed).
Message:  error wallet: RpcError(Transport(Invalid Url: Port number is missing in the URL))
```

When attempting to instantiate a wallet that could instantiate the EthereumProvider using the `ethereum` method in the Wallet struct here:
 https://github.com/matter-labs/foundry-zksync/blob/252607be0db155f80af09de2fa7f4604e8b2e4a9/cli/src/cmd/cast/zk_send.rs#L137

if the first argument provided (rpc url) does not contain a port number, it fails


### Issue 2
Alternatively trying to instantiate the Ethereum provider  here: 

https://github.com/matter-labs/zksync-era/blob/48fe6e27110c1fe1a438c5375fb256890e8017b1/sdk/zksync-rs/src/ethereum/mod.rs#L60

This struct has a `new()` method that requires a provider that implements: ZksNameSpaceClient + Sync

https://github.com/matter-labs/zksync-era/blob/48fe6e27110c1fe1a438c5375fb256890e8017b1/sdk/zksync-rs/src/ethereum/mod.rs#L71-81

![image](https://github.com/matter-labs/foundry-zksync/assets/76663878/4a791fc1-3388-4d06-8534-146f4b036423)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
## To Replicate

pull sample project repo from [here](https://github.com/sammyshakes/sample-fzksync-project)
also pull [deposits](https://github.com/matter-labs/foundry-zksync/tree/deposits)`branch in adjacent directory

```bash
# Command line: (you can use this private key and address)
../foundry-zksync/target/debug/zkcast zk-send 0x42C7eF198f8aC9888E2B1b73e5B71f1D4535194A --amount 1000000 --rpc-url https://goerli.infura.io/v3/33978c8e5245402d8c8388ddc806ef1d --private-key d5b54c3da4bd2722bb9dd3df5aa86e71b8db43560be88b1a271feb4df3268b54 --chain 5 --deposit
```
 

## Proposed Solutions
- Assistance from matter Labs team in instantiating an wallet with an rpc url that does not contain a port number. 
- And/or assistance instantiating an Ethereum Provider using the zksync-rs sdk that implements `ZksNameSpaceClient + Sync` traits. 



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
