### PR TITLE
improve the error message for missing zk compiler output

### DIFF
--- a/cli/src/cmd/forge/zk_create.rs
+++ b/cli/src/cmd/forge/zk_create.rs
@@ -321,8 +321,10 @@ impl ZkCreateArgs {
     ///
     /// A `serde_json::Value` that represents the contract output.
     fn get_contract_output(output_path: PathBuf) -> Value {
-        let data = fs::read_to_string(output_path).expect("Unable to read file");
-        let res: serde_json::Value = serde_json::from_str(&data).expect("Unable to parse");
+        let data = fs::read_to_string(&output_path)
+            .expect(&format!("Unable to read contract output file at {}", output_path.display()));
+        let res: serde_json::Value = serde_json::from_str(&data)
+            .expect(&format!("Unable to read contract output file at {}", output_path.display()));
         res["contracts"].clone()
     }
 


### PR DESCRIPTION
Command:
```
zkforge zk-create src/Counter.sol:Counter --chain 280 --rpc-url https://zksync2-testnet.zksync.dev:443 --private-key "PK"
```

Before:
```
The application panicked (crashed).
Message:  Unable to read file: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Location: cli/src/cmd/forge/zk_create.rs:324
```

After:
```
The application panicked (crashed).
Message:  Unable to read contract output file at /onchain/hello-world/zkout/Counter.sol/artifacts.json: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Location: cli/src/cmd/forge/zk_create.rs:325
```