### PR TITLE
Added a dependency on ethers-rs fork to support latest solidity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "terminal_size 0.2.3",
+ "terminal_size",
  "textwrap 0.16.0",
  "unicase",
 ]
@@ -1197,7 +1197,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "terminal_size 0.2.3",
+ "terminal_size",
  "unicase",
  "unicode-width",
 ]
@@ -1472,21 +1472,6 @@ dependencies = [
  "async-trait",
  "nix 0.26.1",
  "tokio",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size 0.1.17",
- "unicode-width",
  "winapi 0.3.9",
 ]
 
@@ -2119,23 +2104,11 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
-dependencies = [
- "console 0.14.1",
- "lazy_static",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
-name = "dialoguer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
 dependencies = [
- "console 0.15.5",
+ "console",
  "shell-words",
 ]
 
@@ -2592,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2607,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2618,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -2636,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -2663,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -2677,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -2708,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -2725,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -2750,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -2789,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2816,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#09f8e3b5113201d570f3f1658cf4f7fa7cc9cc28"
+source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
@@ -3175,10 +3148,10 @@ dependencies = [
  "clap_complete_fig",
  "color-eyre",
  "comfy-table",
- "console 0.15.5",
+ "console",
  "criterion",
  "data-encoding",
- "dialoguer 0.10.3",
+ "dialoguer",
  "dirs 5.0.0",
  "dotenvy",
  "downloader",
@@ -3197,7 +3170,7 @@ dependencies = [
  "futures",
  "globset",
  "hex",
- "indicatif 0.17.3",
+ "indicatif",
  "itertools",
  "once_cell",
  "parking_lot 0.12.1",
@@ -4461,23 +4434,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console 0.15.5",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
- "console 0.15.5",
+ "console",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
@@ -7771,7 +7732,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
- "sha2-asm",
 ]
 
 [[package]]
@@ -8083,40 +8043,29 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.19"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18bbb2b229a2cc0d8ba58603adb0e460ad49a3451b1540fd6f7a5d37fd03b80"
+checksum = "3a04fc4f5cd35c700153b233f5575ccb3237e0f941fa5049d9e98254d10bf2fe"
 dependencies = [
- "anyhow",
- "cfg-if 1.0.0",
- "clap 3.2.23",
- "console 0.14.1",
- "dialoguer 0.8.0",
  "fs2",
  "hex",
  "home",
- "indicatif 0.16.2",
- "itertools",
  "once_cell",
- "rand 0.8.5",
  "reqwest",
  "semver",
  "serde",
  "serde_json",
- "sha2 0.9.9",
- "tempfile",
+ "sha2 0.10.6",
  "thiserror",
- "tokio",
- "tracing",
  "url",
  "zip",
 ]
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.1.11"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf4cc09b0dd1cd78bc8ca82c5e22bbcd0cca126ad0d584e2fc47d4dc0a3dd73"
+checksum = "32deae08684d03d8a4ba99b8a3b0a1575364820339930f6fa2afdfa3a6d98c84"
 dependencies = [
  "build_const",
  "hex",
@@ -8245,16 +8194,6 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
@@ -8302,7 +8241,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
- "terminal_size 0.2.3",
+ "terminal_size",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ panic = "abort"
 strip = true
 
 # # Patch ethers-rs with a local checkout then run `cargo update -p ethers`
-# [patch."https://github.com/gakonst/ethers-rs"]
+# [patch."https://github.com/mm-zk/ethers-rs"]
 # ethers = { path = "../ethers-rs" }
 # ethers-addressbook = { path = "../ethers-rs/ethers-addressbook" }
 # ethers-core = { path = "../ethers-rs/ethers-core" }

--- a/README.md
+++ b/README.md
@@ -660,6 +660,8 @@ There are 2 workarounds:
 
 You can get the lastest compiler version for MacOs AARCH here: https://github.com/ethers-rs/solc-builds/tree/master/macosx/aarch64
 
+You might have to remove the `zkout` directory (that holds the compilation artifacts) - and in some rare scenarios also cleanup the installed solc versions (by removing `~/.svm/` directory)
+
 ### `solc` versions >0.8.19 are not supported, found 0.8.20
 
 This means that our zksync compiler doesn't support that version of solidity yet.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ git submodule update --init --recursive
 ```
 ---
 
-## Version 0.0 (Linux & Mac)
+## Version Alpha - 0.0 (Linux & Mac)
 
 We need to establish the functionality we want for release v0.0 of this implementation. Below we will specify the exact features to accomplish our v0.0 release.
 
@@ -59,6 +59,8 @@ We need to establish the functionality we want for release v0.0 of this implemen
 - ***Send transactions to deployed contracts on zkSync Testnet or Local Test Node***
 
 NOTE: All commands are entered from the project root folder
+
+NOTE: in this version we also have a dependency on our fork of ethers-rs, so that we can support the new solidity binaries on Apple Silicon. This dependency should be removed in a near future.
 
 ---
 

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -28,7 +28,7 @@ foundry-config = { path = "../config" }
 
 # evm support
 bytes = "1.1.0"
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["ws"] }
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",features = ["ws"] }
 trie-db = { version = "0.23" }
 hash-db = { version = "0.15" }
 memory-db = { version = "0.29" }
@@ -68,13 +68,13 @@ ethereum-forkid = "0.11"
 
 # ethers
 [target.'cfg(not(windows))'.dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["rustls", "ws", "ipc"] }
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",features = ["rustls", "ws", "ipc"] }
 [target.'cfg(windows)'.dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["rustls", "ws"] }
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",features = ["rustls", "ws"] }
 
 [dev-dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen"] }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", features = ["project-util", "full"] }
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",features = ["abigen"] }
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",features = ["project-util", "full"] }
 pretty_assertions = "1.2.1"
 tokio = { version = "1", features = ["full"] }
 crc = "3.0.0"

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -14,7 +14,7 @@ revm = { version = "2.3", default-features = false, features = [
     "memory_limit",
 ] }
 
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0" }
 bytes = { version = "1.1" }

--- a/binder/Cargo.toml
+++ b/binder/Cargo.toml
@@ -10,12 +10,12 @@ keywords = ["ethereum", "web3", "solidity"]
 
 [dependencies]
 foundry-config = { path = "../config" }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "async",
     "svm-solc",
     "project-util",
 ] }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-contract = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "abigen",
 ] }
 curl = { version = "0.4", default-features = false, features = ["http2"] }

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -14,13 +14,13 @@ foundry-config = { path = "./../config" }
 foundry-common = { path = "./../common" }
 
 futures = "0.3.17"
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-etherscan = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-contract = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "abigen",
 ] }
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-providers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-signers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
 serde = "1.0.136"

--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -30,8 +30,8 @@ foundry-common = { path = "../common" }
 forge-fmt = { path = "../fmt" }
 
 # ethers
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", features = ["project-util", "full"] }
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix" }
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",features = ["project-util", "full"] }
 
 # async
 tokio = { version = "1.21.2", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ ui = {path = "../ui"}
 web3 = "0.18"
 
 # eth
-ethers = {git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["rustls"]}
+ethers = {git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = ["rustls"]}
 solang-parser = "=0.2.1"
 
 # cli

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
 tempfile = "3.3.0"
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "project-util",
 ] }
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
 
 walkdir = "2.3.2"
 once_cell = "1.13"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/foundry-rs/foundry"
 foundry-config = { path = "../config" }
 
 # eth
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["ethers-solc"] }
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-providers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-middleware = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-etherscan = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = ["ethers-solc"] }
 
 # io
 reqwest = { version = "0.11", default-features = false }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,12 +9,12 @@ readme = "README.md"
 
 [dependencies]
 # eth
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "async",
     "svm-solc",
 ] }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
 
 # formats
 Inflector = "0.11.4"

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -16,8 +16,8 @@ foundry-config = { path = "../config" }
 foundry-utils = { path = "../utils" }
 
 # ethers
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["async"] }
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = ["async"] }
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
 
 # cli
 clap = { version = "3.0.10", features = [

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -16,7 +16,7 @@ foundry-macros = { path = "../macros" }
 serde_json = "1.0.67"
 serde = "1.0.130"
 hex = "0.4.3"
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
   "solc-full",
   "abigen",
 ] }

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ethereum", "web3", "solidity", "linter"]
 foundry-config = { path = "../config" }
 
 # ethers
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
 
 # parser
 solang-parser = "=0.2.1"

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -10,7 +10,7 @@ foundry-common = { path = "./../common" }
 foundry-config = { path = "./../config" }
 foundry-evm = { path = "./../evm" }
 
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "solc-full",
 ] }
 eyre = "0.6.5"
@@ -34,7 +34,7 @@ parking_lot = "0.12"
 data-encoding = "2.3.3"
 
 [dev-dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "solc-full",
     "solc-tests",
 ] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/foundry-rs/foundry"
 foundry-macros-impl = { path = "./impl" }
 foundry-common = { path = "../common" }
 
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -12,6 +12,6 @@ crossterm = "0.22.1"
 tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 eyre = "0.6.5"
 hex = "0.4.3"
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix" }
 forge = { path = "../forge" }
 revm = { version = "2.3", features = ["std", "k256", "with-serde"] }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,14 +7,14 @@ readme = "README.md"
 repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-core = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-contract = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "abigen",
 ] }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-addressbook = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-providers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
+ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",
@@ -38,7 +38,7 @@ glob = "0.3.0"
 
 [dev-dependencies]
 foundry-common = { path = "./../common" }
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = [
     "solc-full",
 ] }
 


### PR DESCRIPTION
We're currently based off the old fork of foundry, that was depending on the old version of ethers-rs, which supported the solc compiler only up to 0.8.17 (especially on Apple Silicon).

With this PR, I'm moving us to depend on a fork of ethers-rs, that has svm (solidity version manager) patched to the newest release - therefore allowing us to support 0.8.20.

In the near future, we'll rebase ourselves to newer version of foundry, and this dependency would be switched back to original ethers repo.