### PR TITLE
Replace `zksync` crate with `zksync_web3_rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8573,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "zksync-web3-rs"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/zksync-web3-rs.git?rev=7e82c03e658d73622515a643327a7629d759e630#7e82c03e658d73622515a643327a7629d759e630"
+source = "git+https://github.com/lambdaclass/zksync-web3-rs.git?rev=70327ae5413c517bd4d27502507cdd96ee40cd22#70327ae5413c517bd4d27502507cdd96ee40cd22"
 dependencies = [
  "async-trait",
  "clap 4.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,8 +242,8 @@ dependencies = [
  "crc 3.0.1",
  "ctrlc",
  "ethereum-forkid",
- "ethers",
- "ethers-solc",
+ "ethers 1.0.2",
+ "ethers-solc 1.0.2",
  "fdlimit",
  "forge",
  "foundry-common",
@@ -275,7 +275,7 @@ name = "anvil-core"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "ethers-core",
+ "ethers-core 1.0.2",
  "foundry-evm",
  "hash-db",
  "hash256-std-hasher",
@@ -620,6 +620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +912,9 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+dependencies = [
+ "sha2 0.9.9",
+]
 
 [[package]]
 name = "bstr"
@@ -1032,11 +1041,11 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
+ "ethers-contract 1.0.2",
+ "ethers-core 1.0.2",
+ "ethers-etherscan 1.0.2",
+ "ethers-providers 1.0.2",
+ "ethers-signers 1.0.2",
  "eyre",
  "foundry-common",
  "foundry-config",
@@ -1088,8 +1097,8 @@ dependencies = [
  "clap 4.3.2",
  "criterion",
  "dirs 4.0.0",
- "ethers",
- "ethers-solc",
+ "ethers 1.0.2",
+ "ethers-solc 1.0.2",
  "eyre",
  "forge",
  "forge-fmt",
@@ -1105,7 +1114,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "solang-parser",
+ "solang-parser 0.2.1",
  "strum",
  "time 0.3.22",
  "tokio",
@@ -1371,11 +1380,30 @@ checksum = "634c509653de24b439672164bbf56f5f582a2ab0e313d3b0f6af0b7345cf2560"
 dependencies = [
  "bincode",
  "bs58",
- "coins-core",
+ "coins-core 0.7.0",
  "digest 0.10.7",
  "getrandom 0.2.10",
  "hmac 0.12.1",
- "k256",
+ "k256 0.11.6",
+ "lazy_static",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-bip32"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30a84aab436fcb256a2ab3c80663d8aec686e6bae12827bb05fef3e1e439c9f"
+dependencies = [
+ "bincode",
+ "bs58",
+ "coins-core 0.8.3",
+ "digest 0.10.7",
+ "getrandom 0.2.10",
+ "hmac 0.12.1",
+ "k256 0.13.1",
  "lazy_static",
  "serde",
  "sha2 0.10.6",
@@ -1389,11 +1417,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a11892bcac83b4c6e95ab84b5b06c76d9d70ad73548dd07418269c5c7977171"
 dependencies = [
  "bitvec 0.17.4",
- "coins-bip32",
+ "coins-bip32 0.7.0",
  "getrandom 0.2.10",
  "hex",
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f4d04ee18e58356accd644896aeb2094ddeafb6a713e056cef0c0a8e468c15"
+dependencies = [
+ "bitvec 0.17.4",
+ "coins-bip32 0.8.3",
+ "getrandom 0.2.10",
+ "hmac 0.12.1",
+ "once_cell",
+ "pbkdf2 0.12.1",
  "rand 0.8.5",
  "sha2 0.10.6",
  "thiserror",
@@ -1409,6 +1454,26 @@ dependencies = [
  "base64 0.12.3",
  "bech32",
  "blake2 0.10.6",
+ "digest 0.10.7",
+ "generic-array 0.14.7",
+ "hex",
+ "ripemd",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b949a1c63fb7eb591eb7ba438746326aedf0ae843e51ec92ba6bec5bb382c4f"
+dependencies = [
+ "base64 0.21.2",
+ "bech32",
+ "bs58",
  "digest 0.10.7",
  "generic-array 0.14.7",
  "hex",
@@ -1872,6 +1937,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2151,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2235,10 +2323,24 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+dependencies = [
+ "der 0.7.7",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.5",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -2265,16 +2367,35 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array 0.14.7",
- "group",
- "pkcs8",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.2",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.2",
  "subtle",
  "zeroize",
 ]
@@ -2319,7 +2440,25 @@ dependencies = [
  "bs58",
  "bytes",
  "hex",
- "k256",
+ "k256 0.11.6",
+ "log",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "sha3 0.10.6",
+ "zeroize",
+]
+
+[[package]]
+name = "enr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf56acd72bb22d2824e66ae8e9e5ada4d0de17a69c7fd35569dde2ada8ec9116"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "hex",
+ "k256 0.13.1",
  "log",
  "rand 0.8.5",
  "rlp",
@@ -2540,14 +2679,30 @@ name = "ethers"
 version = "1.0.2"
 source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
+ "ethers-addressbook 1.0.2",
+ "ethers-contract 1.0.2",
+ "ethers-core 1.0.2",
+ "ethers-etherscan 1.0.2",
+ "ethers-middleware 1.0.2",
+ "ethers-providers 1.0.2",
+ "ethers-signers 1.0.2",
+ "ethers-solc 1.0.2",
+]
+
+[[package]]
+name = "ethers"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a58ce802c65cf3d0756dee5a61094a92cde53c1583b246e9ee5b37226c7fc15"
+dependencies = [
+ "ethers-addressbook 2.0.7",
+ "ethers-contract 2.0.7",
+ "ethers-core 2.0.7",
+ "ethers-etherscan 2.0.7",
+ "ethers-middleware 2.0.7",
+ "ethers-providers 2.0.7",
+ "ethers-signers 2.0.7",
+ "ethers-solc 2.0.7",
 ]
 
 [[package]]
@@ -2555,7 +2710,19 @@ name = "ethers-addressbook"
 version = "1.0.2"
 source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
- "ethers-core",
+ "ethers-core 1.0.2",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b856b7b8ff5c961093cb8efe151fbcce724b451941ce20781de11a531ccd578"
+dependencies = [
+ "ethers-core 2.0.7",
  "once_cell",
  "serde",
  "serde_json",
@@ -2566,10 +2733,29 @@ name = "ethers-contract"
 version = "1.0.2"
 source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
+ "ethers-contract-abigen 1.0.2",
+ "ethers-contract-derive 1.0.2",
+ "ethers-core 1.0.2",
+ "ethers-providers 1.0.2",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e066a0d9cfc70c454672bf16bb433b0243427420076dc5b2f49c448fb5a10628"
+dependencies = [
+ "ethers-contract-abigen 2.0.7",
+ "ethers-contract-derive 2.0.7",
+ "ethers-core 2.0.7",
+ "ethers-providers 2.0.7",
  "futures-util",
  "hex",
  "once_cell",
@@ -2587,12 +2773,12 @@ dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
  "dunce",
- "ethers-core",
- "ethers-etherscan",
+ "ethers-core 1.0.2",
+ "ethers-etherscan 1.0.2",
  "eyre",
  "getrandom 0.2.10",
  "hex",
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "regex",
@@ -2607,17 +2793,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-contract-abigen"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c113e3e86b6bc16d98484b2c3bb2d01d6fed9f489fe2e592e5cc87c3024d616b"
+dependencies = [
+ "Inflector",
+ "dunce",
+ "ethers-core 2.0.7",
+ "ethers-etherscan 2.0.7",
+ "eyre",
+ "hex",
+ "prettyplease 0.2.9",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn 2.0.18",
+ "toml 0.7.4",
+ "walkdir",
+]
+
+[[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
 source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-core",
+ "ethers-contract-abigen 1.0.2",
+ "ethers-core 1.0.2",
  "hex",
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "serde_json",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3fb5adee25701c79ec58fcf2c63594cd8829bc9ad6037ff862d5a111101ed2"
+dependencies = [
+ "Inflector",
+ "ethers-contract-abigen 2.0.7",
+ "ethers-core 2.0.7",
+ "hex",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "serde_json",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2630,12 +2856,12 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "convert_case 0.6.0",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "ethabi 18.0.0",
  "generic-array 0.14.7",
  "hex",
- "k256",
- "num_enum",
+ "k256 0.11.6",
+ "num_enum 0.5.11",
  "once_cell",
  "open-fastrlp",
  "proc-macro2 1.0.60",
@@ -2652,17 +2878,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-core"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da5fa198af0d3be20c19192df2bd9590b92ce09a8421e793bec8851270f1b05"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bytes",
+ "cargo_metadata",
+ "chrono",
+ "elliptic-curve 0.13.5",
+ "ethabi 18.0.0",
+ "generic-array 0.14.7",
+ "hex",
+ "k256 0.13.1",
+ "num_enum 0.6.1",
+ "once_cell",
+ "open-fastrlp",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "serde_json",
+ "strum",
+ "syn 2.0.18",
+ "tempfile",
+ "thiserror",
+ "tiny-keccak 2.0.2",
+ "unicode-xid 0.2.4",
+]
+
+[[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
 source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
- "ethers-core",
- "ethers-solc",
+ "ethers-core 1.0.2",
+ "ethers-solc 1.0.2",
  "getrandom 0.2.10",
  "reqwest",
  "semver",
  "serde",
  "serde-aux",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ebb401ba97c6f5af278c2c9936c4546cad75dec464b439ae6df249906f4caa"
+dependencies = [
+ "ethers-core 2.0.7",
+ "ethers-solc 2.0.7",
+ "reqwest",
+ "semver",
+ "serde",
  "serde_json",
  "thiserror",
  "tracing",
@@ -2675,11 +2947,38 @@ source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#97792
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
+ "ethers-contract 1.0.2",
+ "ethers-core 1.0.2",
+ "ethers-etherscan 1.0.2",
+ "ethers-providers 1.0.2",
+ "ethers-signers 1.0.2",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740f4a773c19dd6d6a68c8c2e0996c096488d38997d524e21dc612c55da3bd24"
+dependencies = [
+ "async-trait",
+ "auto_impl 1.1.0",
+ "ethers-contract 2.0.7",
+ "ethers-core 2.0.7",
+ "ethers-etherscan 2.0.7",
+ "ethers-providers 2.0.7",
+ "ethers-signers 2.0.7",
+ "futures-channel",
  "futures-locks",
  "futures-util",
  "instant",
@@ -2702,8 +3001,8 @@ dependencies = [
  "auto_impl 1.1.0",
  "base64 0.21.2",
  "bytes",
- "enr",
- "ethers-core",
+ "enr 0.7.0",
+ "ethers-core 1.0.2",
  "futures-channel",
  "futures-core",
  "futures-timer",
@@ -2733,17 +3032,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-providers"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b498fd2a6c019d023e43e83488cd1fb0721f299055975aa6bac8dbf1e95f2c"
+dependencies = [
+ "async-trait",
+ "auto_impl 1.1.0",
+ "base64 0.21.2",
+ "bytes",
+ "enr 0.8.1",
+ "ethers-core 2.0.7",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "hex",
+ "http",
+ "instant",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.19.0",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
 name = "ethers-signers"
 version = "1.0.2"
 source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#9779264a752897103e58b266ac2f4dd9a2e735ca"
 dependencies = [
  "async-trait",
- "coins-bip32",
- "coins-bip39",
+ "coins-bip32 0.7.0",
+ "coins-bip39 0.7.0",
  "coins-ledger",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "eth-keystore",
- "ethers-core",
+ "ethers-core 1.0.2",
  "futures-executor",
  "futures-util",
  "hex",
@@ -2753,10 +3088,29 @@ dependencies = [
  "rusoto_kms",
  "semver",
  "sha2 0.10.6",
- "spki",
+ "spki 0.6.0",
  "thiserror",
  "tracing",
  "trezor-client",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c4b7e15f212fa7cc2e1251868320221d4ff77a3d48068e69f47ce1c491df2d"
+dependencies = [
+ "async-trait",
+ "coins-bip32 0.8.3",
+ "coins-bip39 0.8.6",
+ "elliptic-curve 0.13.5",
+ "eth-keystore",
+ "ethers-core 2.0.7",
+ "hex",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2766,7 +3120,7 @@ source = "git+https://github.com/mm-zk/ethers-rs?branch=foundry_zksync_fix#97792
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
- "ethers-core",
+ "ethers-core 1.0.2",
  "fs_extra",
  "futures-util",
  "getrandom 0.2.10",
@@ -2784,10 +3138,41 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "solang-parser",
+ "solang-parser 0.2.1",
  "svm-rs",
  "svm-rs-builds",
  "tempfile",
+ "thiserror",
+ "tiny-keccak 2.0.2",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a81c89f121595cf8959e746045bb8b25a6a38d72588561e1a3b7992fc213f674"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dunce",
+ "ethers-core 2.0.7",
+ "glob",
+ "hex",
+ "home",
+ "md-5 0.10.5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "solang-parser 0.3.0",
+ "svm-rs",
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
@@ -2876,6 +3261,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -3016,7 +3411,7 @@ version = "0.2.0"
 dependencies = [
  "comfy-table",
  "data-encoding",
- "ethers",
+ "ethers 1.0.2",
  "eyre",
  "foundry-common",
  "foundry-config",
@@ -3047,8 +3442,8 @@ dependencies = [
  "auto_impl 1.1.0",
  "clap 3.2.25",
  "derive_more",
- "ethers-core",
- "ethers-solc",
+ "ethers-core 1.0.2",
+ "ethers-solc 1.0.2",
  "eyre",
  "forge-fmt",
  "foundry-common",
@@ -3059,7 +3454,7 @@ dependencies = [
  "mdbook",
  "once_cell",
  "rayon",
- "solang-parser",
+ "solang-parser 0.2.1",
  "thiserror",
  "tokio",
  "toml 0.5.11",
@@ -3071,12 +3466,12 @@ dependencies = [
 name = "forge-fmt"
 version = "0.2.0"
 dependencies = [
- "ethers-core",
+ "ethers-core 1.0.2",
  "foundry-config",
  "itertools",
  "pretty_assertions",
  "semver",
- "solang-parser",
+ "solang-parser 0.2.1",
  "thiserror",
  "toml 0.5.11",
 ]
@@ -3095,8 +3490,8 @@ name = "foundry-binder"
 version = "0.1.0"
 dependencies = [
  "curl",
- "ethers-contract",
- "ethers-solc",
+ "ethers-contract 1.0.2",
+ "ethers-solc 1.0.2",
  "eyre",
  "foundry-config",
  "git2",
@@ -3131,7 +3526,7 @@ dependencies = [
  "dunce",
  "error-chain",
  "ethabi 18.0.0",
- "ethers",
+ "ethers 1.0.2",
  "eyre",
  "forge",
  "forge-doc",
@@ -3163,7 +3558,7 @@ dependencies = [
  "serial_test",
  "sha2 0.10.6",
  "similar",
- "solang-parser",
+ "solang-parser 0.2.1",
  "strsim 0.10.0",
  "strum",
  "svm-rs",
@@ -3184,6 +3579,7 @@ dependencies = [
  "which",
  "yansi",
  "zksync",
+ "zksync-web3-rs",
  "zksync_eth_signer",
  "zksync_types",
  "zksync_utils",
@@ -3194,8 +3590,8 @@ name = "foundry-cli-test-utils"
 version = "0.1.0"
 dependencies = [
  "atty",
- "ethers",
- "ethers-solc",
+ "ethers 1.0.2",
+ "ethers-solc 1.0.2",
  "eyre",
  "foundry-common",
  "foundry-config",
@@ -3216,11 +3612,11 @@ dependencies = [
  "clap 4.3.2",
  "comfy-table",
  "dunce",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-solc",
+ "ethers-core 1.0.2",
+ "ethers-etherscan 1.0.2",
+ "ethers-middleware 1.0.2",
+ "ethers-providers 1.0.2",
+ "ethers-solc 1.0.2",
  "eyre",
  "foundry-config",
  "once_cell",
@@ -3243,9 +3639,9 @@ version = "0.2.0"
 dependencies = [
  "Inflector",
  "dirs-next",
- "ethers-core",
- "ethers-etherscan",
- "ethers-solc",
+ "ethers-core 1.0.2",
+ "ethers-etherscan 1.0.2",
+ "ethers-solc 1.0.2",
  "eyre",
  "figment",
  "globset",
@@ -3273,7 +3669,7 @@ version = "0.2.0"
 dependencies = [
  "auto_impl 1.1.0",
  "bytes",
- "ethers",
+ "ethers 1.0.2",
  "eyre",
  "foundry-common",
  "foundry-config",
@@ -3304,7 +3700,7 @@ dependencies = [
 name = "foundry-macros"
 version = "0.1.0"
 dependencies = [
- "ethers-core",
+ "ethers-core 1.0.2",
  "foundry-common",
  "foundry-macros-impl",
 ]
@@ -3322,13 +3718,13 @@ dependencies = [
 name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
- "ethers",
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-solc",
+ "ethers 1.0.2",
+ "ethers-addressbook 1.0.2",
+ "ethers-contract 1.0.2",
+ "ethers-core 1.0.2",
+ "ethers-etherscan 1.0.2",
+ "ethers-providers 1.0.2",
+ "ethers-solc 1.0.2",
  "eyre",
  "forge-fmt",
  "foundry-common",
@@ -3566,6 +3962,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3903,7 +4300,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -4221,7 +4629,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4605,7 +5013,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tokio-util 0.7.8",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4708,10 +5116,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if 1.0.0",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.6",
  "sha3 0.10.6",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa 0.16.7",
+ "elliptic-curve 0.13.5",
+ "once_cell",
+ "sha2 0.10.6",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -5452,7 +5874,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -5465,6 +5896,18 @@ dependencies = [
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5953,6 +6396,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "pear"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6173,8 +6626,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.7",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -6258,6 +6721,16 @@ checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2 1.0.60",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+dependencies = [
+ "proc-macro2 1.0.60",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -6855,7 +7328,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -6890,7 +7363,7 @@ dependencies = [
  "bytes",
  "hashbrown 0.13.2",
  "hex",
- "num_enum",
+ "num_enum 0.5.11",
  "primitive-types 0.12.1",
  "revm_precompiles",
  "rlp",
@@ -6906,7 +7379,7 @@ checksum = "0353d456ef3e989dc9190f42c6020f09bc2025930c37895826029304413204b5"
 dependencies = [
  "bytes",
  "hashbrown 0.13.2",
- "k256",
+ "k256 0.11.6",
  "num 0.4.0",
  "once_cell",
  "primitive-types 0.12.1",
@@ -6923,9 +7396,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac 0.12.1",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -6970,6 +7453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
+ "rlp-derive",
  "rustc-hex",
 ]
 
@@ -7363,10 +7847,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.7",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -7862,6 +8360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7927,6 +8435,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solang-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a94494913728908efa7a25a2dd2e4f037e714897985c24273c40596638ed909"
+dependencies = [
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "phf 0.11.1",
+ "thiserror",
+ "unicode-xid 0.2.4",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7939,7 +8461,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.7",
 ]
 
 [[package]]
@@ -8499,7 +9031,22 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tungstenite 0.18.0",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.21.1",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tungstenite 0.19.0",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -8907,6 +9454,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.21.1",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+ "webpki",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8923,7 +9491,7 @@ name = "ui"
 version = "0.2.0"
 dependencies = [
  "crossterm 0.22.1",
- "ethers",
+ "ethers 1.0.2",
  "eyre",
  "forge",
  "hex",
@@ -9431,6 +9999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9771,7 +10348,7 @@ dependencies = [
  "bitflags 2.3.1",
  "blake2 0.10.6",
  "ethereum-types 0.12.1",
- "k256",
+ "k256 0.11.6",
  "lazy_static",
  "sha2 0.10.6",
  "sha3 0.10.6",
@@ -9818,6 +10395,25 @@ dependencies = [
  "zksync_types",
  "zksync_utils",
  "zksync_web3_decl",
+]
+
+[[package]]
+name = "zksync-web3-rs"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "clap 4.3.2",
+ "env_logger",
+ "ethers 2.0.7",
+ "ethers-contract 2.0.7",
+ "eyre",
+ "hex",
+ "log",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,17 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addchain"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,56 +29,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
-dependencies = [
- "aes-soft",
- "aesni",
- "cipher 0.2.5",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
-]
-
-[[package]]
-name = "aes-ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7729c3cde54d67063be556aeac75a81330d802f0259500ca40cb52967f975763"
-dependencies = [
- "aes-soft",
- "aesni",
- "cipher 0.2.5",
- "ctr 0.6.0",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher 0.2.5",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher 0.2.5",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -326,40 +272,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
-name = "arr_macro"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a105bfda48707cf19220129e78fca01e9639433ffaef4163546ed8fb04120a5"
-dependencies = [
- "arr_macro_impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "arr_macro_impl"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0609c78bd572f4edc74310dfb63a01f5609d53fa8b4dd7c4d98aef3b3e8d72d1"
-dependencies = [
- "proc-macro-hack",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
-name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "arrayvec"
@@ -389,15 +305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-lock"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-priority-channel"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,30 +319,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -445,8 +330,8 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -491,8 +376,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -503,18 +388,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -672,50 +548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bellman_ce"
-version = "0.3.2"
-source = "git+https://github.com/matter-labs/bellman?branch=dev#bbac0559fdc440b2331eca1c347a30559a3dd969"
-dependencies = [
- "arrayvec 0.7.2",
- "bit-vec",
- "blake2s_const",
- "blake2s_simd",
- "byteorder",
- "cfg-if 1.0.0",
- "crossbeam 0.7.3",
- "futures",
- "hex",
- "lazy_static",
- "num_cpus",
- "pairing_ce",
- "rand 0.4.6",
- "serde",
- "smallvec",
- "tiny-keccak 1.5.0",
-]
-
-[[package]]
-name = "bigdecimal"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc403c26e6b03005522e6e8053384c4e881dfe5b2bf041c0c2c49be33d64a539"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,9 +570,6 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -790,17 +619,6 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
@@ -809,42 +627,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2-rfc_bellman_edition"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc60350286c7c3db13b98e91dbe5c8b6830a6821bc20af5b0c310ce94d74915"
-dependencies = [
- "arrayvec 0.4.12",
- "byteorder",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
-]
-
-[[package]]
-name = "blake2s_const"
-version = "0.6.0"
-source = "git+https://github.com/matter-labs/bellman?branch=dev#bbac0559fdc440b2331eca1c347a30559a3dd969"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
-]
-
-[[package]]
-name = "blake2s_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -880,16 +666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-modes"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
-dependencies = [
- "block-padding 0.2.1",
- "cipher 0.2.5",
 ]
 
 [[package]]
@@ -1132,7 +908,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "rustc-serialize",
  "serde",
  "time 0.1.45",
  "wasm-bindgen",
@@ -1168,44 +943,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "circuit_testing"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-circuit_testing.git?branch=main#abd44b507840f836da6e084aaacb2ba8a7cb1df6"
-dependencies = [
- "bellman_ce",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -1220,10 +963,10 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "terminal_size",
- "textwrap 0.16.0",
+ "textwrap",
  "unicase",
 ]
 
@@ -1249,7 +992,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_lex 0.5.0",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "terminal_size",
  "unicase",
  "unicode-width",
@@ -1280,10 +1023,10 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1293,9 +1036,9 @@ version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -1336,40 +1079,6 @@ dependencies = [
  "error-code",
  "str-buf",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "codegen"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/solidity_plonk_verifier.git?branch=dev#cad8d38f631691a6b456eb4eb7b410fd129ca006"
-dependencies = [
- "ethereum-types 0.12.1",
- "franklin-crypto",
- "handlebars",
- "hex",
- "paste",
- "rescue_poseidon",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "codegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff61280aed771c3070e7dcc9e050c66f1eb1e3b96431ba66f9f74641d02fc41d"
-dependencies = [
- "indexmap",
 ]
 
 [[package]]
@@ -1453,7 +1162,7 @@ dependencies = [
  "base58check",
  "base64 0.12.3",
  "bech32",
- "blake2 0.10.6",
+ "blake2",
  "digest 0.10.7",
  "generic-array 0.14.7",
  "hex",
@@ -1714,62 +1423,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.4",
- "crossbeam-epoch 0.8.2",
- "crossbeam-queue 0.2.3",
- "crossbeam-utils 0.7.2",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel 0.5.8",
- "crossbeam-deque 0.8.3",
- "crossbeam-epoch 0.9.14",
- "crossbeam-queue 0.3.8",
- "crossbeam-utils 0.8.15",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.15",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
-dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1779,23 +1439,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.14",
- "crossbeam-utils 0.8.15",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg 1.1.0",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "lazy_static",
- "maybe-uninit",
- "memoffset 0.5.6",
- "scopeguard",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1804,43 +1449,11 @@ version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.15",
+ "crossbeam-utils",
  "memoffset 0.8.0",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.15",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.1.0",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -1960,26 +1573,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array 0.14.7",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array 0.14.7",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
@@ -1989,34 +1582,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cs_derive"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.2#4205618b2c3ef82c8e498a318a95f3f3a64496e2"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "serde",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.28",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
-dependencies = [
- "cipher 0.2.5",
 ]
 
 [[package]]
@@ -2025,7 +1597,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -2067,41 +1639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,16 +1668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid 1.3.3",
-]
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,25 +1688,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -2482,8 +1998,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -2498,15 +2014,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "envy"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2555,20 +2062,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
- "aes 0.8.2",
- "ctr 0.9.2",
+ "aes",
+ "ctr",
  "digest 0.10.7",
  "hex",
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
- "scrypt 0.10.0",
+ "scrypt",
  "serde",
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.6",
  "thiserror",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2613,7 +2120,7 @@ dependencies = [
  "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde 0.3.2",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2628,7 +2135,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde 0.4.0",
  "scale-info",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2779,8 +2286,8 @@ dependencies = [
  "getrandom 0.2.10",
  "hex",
  "prettyplease 0.1.25",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "regex",
  "reqwest",
  "serde",
@@ -2805,8 +2312,8 @@ dependencies = [
  "eyre",
  "hex",
  "prettyplease 0.2.9",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "regex",
  "reqwest",
  "serde",
@@ -2824,8 +2331,8 @@ dependencies = [
  "ethers-contract-abigen 1.0.2",
  "ethers-core 1.0.2",
  "hex",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "serde_json",
  "syn 1.0.109",
 ]
@@ -2840,8 +2347,8 @@ dependencies = [
  "ethers-contract-abigen 2.0.7",
  "ethers-core 2.0.7",
  "hex",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "serde_json",
  "syn 2.0.18",
 ]
@@ -2864,7 +2371,7 @@ dependencies = [
  "num_enum 0.5.11",
  "once_cell",
  "open-fastrlp",
- "proc-macro2 1.0.60",
+ "proc-macro2",
  "rand 0.8.5",
  "rlp",
  "rlp-derive",
@@ -2873,8 +2380,8 @@ dependencies = [
  "strum",
  "syn 1.0.109",
  "thiserror",
- "tiny-keccak 2.0.2",
- "unicode-xid 0.2.4",
+ "tiny-keccak",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2903,8 +2410,8 @@ dependencies = [
  "syn 2.0.18",
  "tempfile",
  "thiserror",
- "tiny-keccak 2.0.2",
- "unicode-xid 0.2.4",
+ "tiny-keccak",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3142,7 +2649,7 @@ dependencies = [
  "svm-rs-builds",
  "tempfile",
  "thiserror",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
  "tokio",
  "tracing",
  "walkdir",
@@ -3173,7 +2680,7 @@ dependencies = [
  "solang-parser 0.3.0",
  "svm-rs",
  "thiserror",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
  "tokio",
  "tracing",
  "walkdir",
@@ -3230,8 +2737,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0f9d074ab623d1b388c12544bfeed759c7df36dc5c300cda053df9ba1232075"
 dependencies = [
  "bytes",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3276,34 +2783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff_ce"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b538e4231443a5b9c507caee3356f016d832cf7393d2d90f03ea3180d4e3fbc"
-dependencies = [
- "byteorder",
- "ff_derive_ce",
- "hex",
- "rand 0.4.6",
- "serde",
-]
-
-[[package]]
-name = "ff_derive_ce"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96fbccd88dbb1fac4ee4a07c2fcc4ca719a74ffbd9d2b9d41d8c8eb073d8b20"
-dependencies = [
- "num-bigint 0.4.3",
- "num-integer",
- "num-traits",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "serde",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "figment"
 version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,18 +2808,6 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "findshlibs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3558,7 +3025,7 @@ dependencies = [
  "sha2 0.10.6",
  "similar",
  "solang-parser 0.2.1",
- "strsim 0.10.0",
+ "strsim",
  "strum",
  "svm-rs",
  "tempfile",
@@ -3577,11 +3044,7 @@ dependencies = [
  "web3",
  "which",
  "yansi",
- "zksync",
  "zksync-web3-rs",
- "zksync_eth_signer",
- "zksync_types",
- "zksync_utils",
 ]
 
 [[package]]
@@ -3708,8 +3171,8 @@ dependencies = [
 name = "foundry-macros-impl"
 version = "0.0.0"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3743,36 +3206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "franklin-crypto"
-version = "0.0.5"
-source = "git+https://github.com/matter-labs/franklin-crypto?branch=dev#5922873d25ecec827cd60420ca8cd84a188bb965"
-dependencies = [
- "arr_macro",
- "bellman_ce",
- "bit-vec",
- "blake2 0.9.2",
- "blake2-rfc_bellman_edition",
- "blake2s_simd",
- "byteorder",
- "digest 0.9.0",
- "hex",
- "indexmap",
- "itertools",
- "lazy_static",
- "num-bigint 0.4.3",
- "num-derive 0.2.5",
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "serde",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "smallvec",
- "splitmut",
- "tiny-keccak 1.5.0",
-]
-
-[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,12 +3229,6 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -3865,7 +3292,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -3890,8 +3316,8 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -3995,8 +3421,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4249,26 +3675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-net"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9902a044653b26b99f7e3693a42f171312d9be8b26b5697bd1e43ad1f8a35e10"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,19 +3684,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -4424,15 +3817,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -4484,21 +3868,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.1",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -4521,17 +3895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,8 +3903,8 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4628,7 +3991,6 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
- "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4642,18 +4004,6 @@ dependencies = [
  "rustls 0.21.1",
  "tokio",
  "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -4691,12 +4041,6 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4805,8 +4149,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4822,7 +4166,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown 0.12.3",
 ]
 
@@ -4835,7 +4179,7 @@ dependencies = [
  "console",
  "instant",
  "number_prefix",
- "portable-atomic 1.3.3",
+ "portable-atomic",
  "unicode-width",
 ]
 
@@ -4975,140 +4319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-proc-macros",
- "jsonrpsee-types",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
-dependencies = [
- "anyhow",
- "futures-channel",
- "futures-timer",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "pin-project",
- "rustls-native-certs",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls 0.23.4",
- "tokio-util 0.7.8",
- "tracing",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
-dependencies = [
- "anyhow",
- "async-lock",
- "async-trait",
- "beef",
- "futures-channel",
- "futures-timer",
- "futures-util",
- "hyper",
- "jsonrpsee-types",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls 0.23.2",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-crate",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77310456f43c6c89bcba1f6b2fc2a28300da7c341f320f5128f8c83cc63232d"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
-dependencies = [
- "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
-]
-
-[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5152,7 +4362,7 @@ checksum = "711adba9940a039f4374fc5724c0a5eaca84a2d558cce62256bfe26f0dbef05e"
 dependencies = [
  "hash-db",
  "hash256-std-hasher",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -5203,8 +4413,8 @@ dependencies = [
  "regex-syntax 0.6.29",
  "string_cache",
  "term",
- "tiny-keccak 2.0.2",
- "unicode-xid 0.2.4",
+ "tiny-keccak",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5295,7 +4505,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
 ]
 
@@ -5332,12 +4542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5357,12 +4561,6 @@ name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md-5"
@@ -5429,20 +4627,11 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -5451,7 +4640,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -5463,28 +4652,6 @@ dependencies = [
  "hash-db",
  "hashbrown 0.12.3",
  "parity-util-mem",
-]
-
-[[package]]
-name = "metrics"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
-dependencies = [
- "ahash 0.7.6",
- "metrics-macros",
- "portable-atomic 0.3.20",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
-dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5505,8 +4672,8 @@ version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4901771e1d44ddb37964565c654a3223ba41a594d02b8da471cc4464912b5cfa"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -5585,12 +4752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5629,7 +4790,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
@@ -5648,12 +4809,6 @@ dependencies = [
  "pin-utils",
  "static_assertions",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -5678,7 +4833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
 dependencies = [
  "bitflags 1.3.2",
- "crossbeam-channel 0.5.8",
+ "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -5710,42 +4865,16 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint 0.3.3",
- "num-complex 0.3.1",
- "num-integer",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits",
-]
-
-[[package]]
-name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.3",
- "num-complex 0.4.3",
+ "num-bigint",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg 1.1.0",
- "num-integer",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -5754,20 +4883,9 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
- "serde",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -5780,34 +4898,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -5817,22 +4913,9 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg 1.1.0",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -5841,8 +4924,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg 1.1.0",
- "num-bigint 0.4.3",
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -5853,7 +4936,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libm",
 ]
 
@@ -5892,8 +4975,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -5904,8 +4987,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -5977,8 +5060,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
 dependencies = [
  "bytes",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6013,8 +5096,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -6037,68 +5120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
-dependencies = [
- "async-trait",
- "crossbeam-channel 0.5.8",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry",
- "reqwest",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http",
- "opentelemetry",
- "opentelemetry-http",
- "prost",
- "prost-build",
- "reqwest",
- "thiserror",
- "tokio",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6111,17 +5132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "os_info"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
-dependencies = [
- "log",
- "serde",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6150,43 +5160,6 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
-name = "pairing_ce"
-version = "0.28.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db007b21259660d025918e653508f03050bf23fb96a88601f9936329faadc597"
-dependencies = [
- "byteorder",
- "cfg-if 1.0.0",
- "ff_ce",
- "rand 0.4.6",
- "serde",
-]
-
-[[package]]
-name = "parity-crypto"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b92ea9ddac0d6e1db7c49991e7d397d34a9fd814b4c93cda53788e8eef94e35"
-dependencies = [
- "aes 0.6.0",
- "aes-ctr",
- "block-modes",
- "digest 0.9.0",
- "ethereum-types 0.12.1",
- "hmac 0.10.1",
- "lazy_static",
- "pbkdf2 0.7.5",
- "ripemd160",
- "rustc-hex",
- "scrypt 0.5.0",
- "secp256k1 0.20.3",
- "sha2 0.9.9",
- "subtle",
- "tiny-keccak 2.0.2",
- "zeroize",
-]
 
 [[package]]
 name = "parity-scale-codec"
@@ -6223,8 +5196,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6235,8 +5208,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6274,7 +5247,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -6329,16 +5302,6 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54986aa4bfc9b98c6a5f40184223658d187159d7b3c6af33f2b2aa25ae1db0fa"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
@@ -6349,38 +5312,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
-
-[[package]]
 name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pbkdf2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
-dependencies = [
- "crypto-mac 0.10.1",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
-dependencies = [
- "base64ct",
- "crypto-mac 0.10.1",
- "hmac 0.10.1",
- "password-hash 0.1.4",
- "sha2 0.9.9",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -6390,7 +5325,7 @@ checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
- "password-hash 0.4.2",
+ "password-hash",
  "sha2 0.10.6",
 ]
 
@@ -6421,9 +5356,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9661a3a53f93f09f2ea882018e4d7c88f6ff2956d809a276060476fd8c879d3c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2",
  "proc-macro2-diagnostics",
- "quote 1.0.28",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -6461,8 +5396,8 @@ checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -6564,8 +5499,8 @@ checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
 dependencies = [
  "phf_generator 0.11.1",
  "phf_shared 0.11.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6602,8 +5537,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -6675,15 +5610,6 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
-dependencies = [
- "portable-atomic 1.3.3",
-]
-
-[[package]]
-name = "portable-atomic"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
@@ -6718,7 +5644,7 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2",
  "syn 1.0.109",
 ]
 
@@ -6728,7 +5654,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2",
  "syn 2.0.18",
 ]
 
@@ -6776,8 +5702,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -6788,24 +5714,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -6823,8 +5734,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "606c4ba35817e2922a308af55ad51bab3645b59eae5c570d4a6cf07e36bd493b"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
  "version_check",
  "yansi",
@@ -6854,64 +5765,11 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand_xorshift",
  "regex-syntax 0.6.29",
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -6939,20 +5797,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -6985,38 +5834,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift 0.1.1",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -7025,7 +5842,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
@@ -7037,16 +5854,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7071,21 +5878,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -7104,73 +5896,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7198,19 +5928,10 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
- "crossbeam-channel 0.5.8",
- "crossbeam-deque 0.8.3",
- "crossbeam-utils 0.8.15",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7332,26 +6053,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rescue_poseidon"
-version = "0.4.1"
-source = "git+https://github.com/matter-labs/rescue-poseidon#f611a3353e48cf42153e44d89ed90da9bc5934e8"
-dependencies = [
- "addchain",
- "arrayvec 0.7.2",
- "blake2 0.10.6",
- "byteorder",
- "franklin-crypto",
- "num-bigint 0.3.3",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.4.6",
- "serde",
- "sha3 0.9.1",
- "smallvec",
-]
-
-[[package]]
 name = "revm"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7379,7 +6080,7 @@ dependencies = [
  "bytes",
  "hashbrown 0.13.2",
  "k256 0.11.6",
- "num 0.4.0",
+ "num",
  "once_cell",
  "primitive-types 0.12.1",
  "ripemd",
@@ -7435,17 +6136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd160"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7462,8 +6152,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7588,22 +6278,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
@@ -7732,20 +6410,11 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "salsa20"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
-dependencies = [
- "cipher 0.2.5",
-]
-
-[[package]]
-name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -7776,8 +6445,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7804,29 +6473,13 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da492dab03f925d977776a0b7233d7b934d6dc2b94faead48928e2e9bacedb9"
-dependencies = [
- "base64 0.13.1",
- "hmac 0.10.1",
- "pbkdf2 0.6.0",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "salsa20 0.7.2",
- "sha2 0.9.9",
- "subtle",
-]
-
-[[package]]
-name = "scrypt"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
- "salsa20 0.10.2",
+ "salsa20",
  "sha2 0.10.6",
 ]
 
@@ -7866,16 +6519,6 @@ dependencies = [
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
-dependencies = [
- "rand 0.6.5",
- "secp256k1-sys 0.4.2",
 ]
 
 [[package]]
@@ -7959,114 +6602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
-name = "sentry"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de31c6e03322af2175d3c850c5b5e11efcadc01948cd1fb7b5ad0a7c7b6c7ff2"
-dependencies = [
- "httpdate",
- "native-tls",
- "reqwest",
- "sentry-backtrace",
- "sentry-contexts",
- "sentry-core",
- "sentry-debug-images",
- "sentry-panic",
- "sentry-tracing",
- "tokio",
- "ureq",
-]
-
-[[package]]
-name = "sentry-backtrace"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264e3ad27da3d1ad81b499dbcceae0a50e0e6ffc4b65b93f47d5180d46827644"
-dependencies = [
- "backtrace 0.3.67",
- "once_cell",
- "regex",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-contexts"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7144590f7950647e4df5bd95f234c3aa29124729c54bd2457e1224d701d1a91c"
-dependencies = [
- "hostname",
- "libc",
- "os_info",
- "rustc_version",
- "sentry-core",
- "uname",
-]
-
-[[package]]
-name = "sentry-core"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35614ecf115f55d93583baa02a85cb63acb6567cf91b17690d1147bac1739ca4"
-dependencies = [
- "once_cell",
- "rand 0.8.5",
- "sentry-types",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "sentry-debug-images"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c4288a1b255e6ff55f111d2e14a48d369da76e86fae15a00ee26a371d82ad4"
-dependencies = [
- "findshlibs",
- "once_cell",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-panic"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a941028a24baf0a5a994d8a39670cecc72a61971bb0155f771537447a46211a"
-dependencies = [
- "sentry-backtrace",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-tracing"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec56ebafd7cfc1175bccdf277be582ccc3308b8c353dca5831261a967a6e28c"
-dependencies = [
- "sentry-backtrace",
- "sentry-core",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c56f616602a3b282bf4b4e8e5b4d10bcf9412a987df91c592b95a1f6ef1ee43"
-dependencies = [
- "debugid",
- "getrandom 0.2.10",
- "hex",
- "serde",
- "serde_json",
- "thiserror",
- "time 0.3.22",
- "url",
- "uuid 1.3.3",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8091,8 +6626,8 @@ version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -8140,28 +6675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "serial_test"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8182,8 +6695,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8386,7 +6899,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -8430,7 +6943,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "phf 0.11.1",
- "unicode-xid 0.2.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8444,7 +6957,7 @@ dependencies = [
  "lalrpop-util",
  "phf 0.11.1",
  "thiserror",
- "unicode-xid 0.2.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8472,12 +6985,6 @@ dependencies = [
  "base64ct",
  "der 0.7.6",
 ]
-
-[[package]]
-name = "splitmut"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85070f382340e8b23a75808e83573ddf65f9ad9143df9573ca37c1ed2ee956a"
 
 [[package]]
 name = "static_assertions"
@@ -8513,45 +7020,15 @@ checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -8568,9 +7045,9 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "heck",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -8629,23 +7106,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -8655,35 +7121,9 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sync_vm"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.2#4205618b2c3ef82c8e498a318a95f3f3a64496e2"
-dependencies = [
- "arrayvec 0.7.2",
- "cs_derive",
- "derivative",
- "franklin-crypto",
- "hex",
- "itertools",
- "num-bigint 0.4.3",
- "num-derive 0.3.3",
- "num-integer",
- "num-traits",
- "once_cell",
- "rand 0.4.6",
- "rescue_poseidon",
- "serde",
- "sha2 0.10.6",
- "sha3 0.10.6",
- "smallvec",
- "zk_evm",
- "zkevm_opcode_defs",
 ]
 
 [[package]]
@@ -8698,10 +7138,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
- "unicode-xid 0.2.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8716,7 +7156,7 @@ version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
@@ -8779,26 +7219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-log"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
-dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8823,8 +7243,8 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -8880,15 +7300,6 @@ dependencies = [
 
 [[package]]
 name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
-name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
@@ -8927,7 +7338,7 @@ version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "bytes",
  "libc",
  "mio 0.8.8",
@@ -8941,23 +7352,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -9071,7 +7472,6 @@ checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -9134,49 +7534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "prost-derive",
- "tokio",
- "tokio-stream",
- "tokio-util 0.6.10",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2 1.0.60",
- "prost-build",
- "quote 1.0.28",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "topological-sort"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9190,13 +7547,9 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
- "slab",
  "tokio",
- "tokio-util 0.7.8",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9253,8 +7606,8 @@ version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
 ]
 
@@ -9300,30 +7653,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-opentelemetry"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9333,16 +7662,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.22",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -9511,15 +7836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9584,12 +7900,6 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -9601,19 +7911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "ureq"
-version = "2.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
-dependencies = [
- "base64 0.13.1",
- "log",
- "native-tls",
- "once_cell",
- "url",
-]
-
-[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9622,7 +7919,6 @@ dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -9648,16 +7944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
-dependencies = [
- "getrandom 0.2.10",
- "serde",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9668,12 +7954,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
@@ -9697,22 +7977,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vlog"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "chrono",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "sentry",
- "serde_json",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
-]
 
 [[package]]
 name = "wait-timeout"
@@ -9810,8 +8074,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
@@ -9834,7 +8098,7 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
- "quote 1.0.28",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -9844,8 +8108,8 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2",
+ "quote",
  "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -9958,7 +8222,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -10292,108 +8556,18 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes 0.8.2",
+ "aes",
  "byteorder",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils 0.8.15",
+ "crossbeam-utils",
  "flate2",
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha1",
  "time 0.3.22",
  "zstd",
-]
-
-[[package]]
-name = "zk_evm"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.2#4262966337708702b5a6cdad902a757acc968dbb"
-dependencies = [
- "lazy_static",
- "num 0.4.0",
- "serde",
- "serde_json",
- "static_assertions",
- "zkevm_opcode_defs",
-]
-
-[[package]]
-name = "zkevm-assembly"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2#8a339104582d175627feba2bc4f176304b67b943"
-dependencies = [
- "env_logger",
- "hex",
- "lazy_static",
- "log",
- "nom",
- "num-bigint 0.4.3",
- "num-traits",
- "regex",
- "sha3 0.10.6",
- "smallvec",
- "structopt",
- "thiserror",
- "zkevm_opcode_defs",
-]
-
-[[package]]
-name = "zkevm_opcode_defs"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkevm_opcode_defs.git?branch=v1.3.2#2f69c6975a272e8c31d2d82c136a4ea81df25115"
-dependencies = [
- "bitflags 2.3.1",
- "blake2 0.10.6",
- "ethereum-types 0.12.1",
- "k256 0.11.6",
- "lazy_static",
- "sha2 0.10.6",
- "sha3 0.10.6",
-]
-
-[[package]]
-name = "zkevm_test_harness"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.2#22f29e09715133f4158ad0d71c48547daf283090"
-dependencies = [
- "bincode",
- "circuit_testing",
- "codegen 0.2.0",
- "crossbeam 0.8.2",
- "derivative",
- "env_logger",
- "hex",
- "num-bigint 0.4.3",
- "num-integer",
- "num-traits",
- "rayon",
- "serde",
- "serde_json",
- "smallvec",
- "structopt",
- "sync_vm",
- "test-log",
- "tracing",
- "zk_evm",
- "zkevm-assembly",
-]
-
-[[package]]
-name = "zksync"
-version = "0.4.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "num 0.3.1",
- "serde_json",
- "thiserror",
- "tokio",
- "zksync_eth_client",
- "zksync_eth_signer",
- "zksync_types",
- "zksync_utils",
- "zksync_web3_decl",
 ]
 
 [[package]]
@@ -10413,182 +8587,6 @@ dependencies = [
  "sha2 0.9.9",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "zksync_basic_types"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "serde",
- "web3",
-]
-
-[[package]]
-name = "zksync_config"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "bigdecimal",
- "envy",
- "num 0.3.1",
- "once_cell",
- "serde",
- "serde_json",
- "url",
- "zksync_basic_types",
- "zksync_contracts",
- "zksync_utils",
-]
-
-[[package]]
-name = "zksync_contracts"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "ethabi 16.0.0",
- "hex",
- "once_cell",
- "serde",
- "serde_json",
- "zksync_utils",
-]
-
-[[package]]
-name = "zksync_crypto"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "base64 0.13.1",
- "blake2 0.10.6",
- "hex",
- "once_cell",
- "rand 0.4.6",
- "serde",
- "sha2 0.9.9",
- "thiserror",
- "zksync_basic_types",
-]
-
-[[package]]
-name = "zksync_eth_client"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "anyhow",
- "async-trait",
- "hex",
- "jsonrpc-core",
- "metrics",
- "parity-crypto",
- "serde",
- "thiserror",
- "tokio",
- "vlog",
- "zksync_config",
- "zksync_contracts",
- "zksync_eth_signer",
- "zksync_types",
-]
-
-[[package]]
-name = "zksync_eth_signer"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "async-trait",
- "hex",
- "jsonrpc-core",
- "parity-crypto",
- "reqwest",
- "rlp",
- "secp256k1 0.21.3",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "zksync_types",
-]
-
-[[package]]
-name = "zksync_mini_merkle_tree"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "once_cell",
- "rayon",
- "zksync_basic_types",
- "zksync_crypto",
-]
-
-[[package]]
-name = "zksync_types"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "bigdecimal",
- "blake2 0.10.6",
- "chrono",
- "codegen 0.1.0",
- "ethbloom 0.11.1",
- "hex",
- "metrics",
- "num 0.3.1",
- "once_cell",
- "parity-crypto",
- "rayon",
- "rlp",
- "serde",
- "serde_json",
- "serde_with",
- "strum",
- "thiserror",
- "tiny-keccak 1.5.0",
- "zk_evm",
- "zkevm-assembly",
- "zkevm_test_harness",
- "zksync_basic_types",
- "zksync_config",
- "zksync_contracts",
- "zksync_mini_merkle_tree",
- "zksync_utils",
-]
-
-[[package]]
-name = "zksync_utils"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "anyhow",
- "bigdecimal",
- "envy",
- "futures",
- "hex",
- "itertools",
- "num 0.3.1",
- "reqwest",
- "serde",
- "thiserror",
- "tokio",
- "vlog",
- "zk_evm",
- "zksync_basic_types",
-]
-
-[[package]]
-name = "zksync_web3_decl"
-version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#fa74321e085c66aa7da0286a46956a4dfa247e98"
-dependencies = [
- "bigdecimal",
- "chrono",
- "itertools",
- "jsonrpsee",
- "rlp",
- "serde",
- "serde_json",
- "thiserror",
- "zksync_types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8573,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "zksync-web3-rs"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/zksync-web3-rs.git"
+source = "git+https://github.com/lambdaclass/zksync-web3-rs.git?rev=7e82c03e658d73622515a643327a7629d759e630#7e82c03e658d73622515a643327a7629d759e630"
 dependencies = [
  "async-trait",
  "clap 4.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,7 +2804,7 @@ dependencies = [
  "ethers-etherscan 2.0.7",
  "eyre",
  "hex",
- "prettyplease 0.2.6",
+ "prettyplease 0.2.9",
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "regex",
@@ -6724,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2 1.0.60",
  "syn 2.0.18",
@@ -10399,7 +10399,7 @@ dependencies = [
 [[package]]
 name = "zksync-web3-rs"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/zksync-web3-rs/?branch=main#37c6321447a49b564d8511497e2032544300450e"
+source = "git+https://github.com/lambdaclass/zksync-web3-rs.git"
 dependencies = [
  "async-trait",
  "clap 4.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -2335,7 +2335,7 @@ version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.6",
  "digest 0.10.7",
  "elliptic-curve 0.13.5",
  "rfc6979 0.4.0",
@@ -2804,7 +2804,7 @@ dependencies = [
  "ethers-etherscan 2.0.7",
  "eyre",
  "hex",
- "prettyplease 0.2.9",
+ "prettyplease 0.2.6",
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "regex",
@@ -2931,7 +2931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84ebb401ba97c6f5af278c2c9936c4546cad75dec464b439ae6df249906f4caa"
 dependencies = [
  "ethers-core 2.0.7",
- "ethers-solc 2.0.7",
  "reqwest",
  "semver",
  "serde",
@@ -6636,7 +6635,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.6",
  "spki 0.7.2",
 ]
 
@@ -6725,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
 dependencies = [
  "proc-macro2 1.0.60",
  "syn 2.0.18",
@@ -7862,7 +7861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.7",
+ "der 0.7.6",
  "generic-array 0.14.7",
  "pkcs8 0.10.2",
  "subtle",
@@ -8471,7 +8470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.7",
+ "der 0.7.6",
 ]
 
 [[package]]
@@ -10400,13 +10399,13 @@ dependencies = [
 [[package]]
 name = "zksync-web3-rs"
 version = "0.1.0"
+source = "git+https://github.com/lambdaclass/zksync-web3-rs/?branch=main#37c6321447a49b564d8511497e2032544300450e"
 dependencies = [
  "async-trait",
  "clap 4.3.2",
  "env_logger",
  "ethers 2.0.7",
  "ethers-contract 2.0.7",
- "eyre",
  "hex",
  "log",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,52 +8,42 @@ repository = "https://github.com/foundry-rs/foundry"
 version = "0.2.0"
 
 [build-dependencies]
-vergen = { version = "7.0", default-features = false, features = [
-  "build",
-  "rustc",
-  "git",
-] }
+vergen = {version = "7.0", default-features = false, features = ["build", "rustc", "git"]}
 
 [dependencies]
 # foundry internal
-cast = { path = "../cast" }
+cast = {path = "../cast"}
 error-chain = "0.5"
-forge = { path = "../forge" }
-forge-doc = { path = "../doc" }
-forge-fmt = { path = "../fmt" }
-foundry-common = { path = "../common" }
-foundry-config = { path = "../config" }
-foundry-utils = { path = "../utils" }
-ui = { path = "../ui" }
+forge = {path = "../forge"}
+forge-doc = {path = "../doc"}
+forge-fmt = {path = "../fmt"}
+foundry-common = {path = "../common"}
+foundry-config = {path = "../config"}
+foundry-utils = {path = "../utils"}
+ui = {path = "../ui"}
 web3 = "0.18"
 
 # eth
-ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix", default-features = false, features = [
-  "rustls",
-] }
+ethers = {git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = ["rustls"]}
 solang-parser = "=0.2.1"
 
 # cli
 atty = "0.2.14"
-clap = { version = "4.0", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = {version = "4.0", features = ["derive", "env", "unicode", "wrap_help"]}
 clap_complete = "4.0"
 clap_complete_fig = "4.0"
 comfy-table = "6.0.0"
 console = "0.15.0"
-dialoguer = { version = "0.10.2", default-features = false }
+dialoguer = {version = "0.10.2", default-features = false}
 dotenvy = "0.15"
-reqwest = { version = "0.11.8", default-features = false, features = [
+reqwest = {version = "0.11.8", default-features = false, features = [
   "json",
   "rustls",
   "rustls-native-certs",
-] }
+]}
 tracing = "0.1"
 tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3", features = [
-  "registry",
-  "env-filter",
-  "fmt",
-] }
+tracing-subscriber = {version = "0.3", features = ["registry", "env-filter", "fmt"]}
 watchexec = "2.0"
 yansi = "0.5.1"
 
@@ -61,7 +51,7 @@ yansi = "0.5.1"
 async-trait = "0.1.53"
 futures = "0.3.17"
 rayon = "1.6.1"
-tokio = { version = "1", features = ["macros"] }
+tokio = {version = "1", features = ["macros"]}
 
 # disk / paths
 dunce = "1.0.2"
@@ -83,45 +73,43 @@ once_cell = "1.13"
 parking_lot = "0.12"
 pkg-config = "0.3.26"
 proptest = "1.0.0"
-regex = { version = "1.5.4", default-features = false }
+regex = {version = "1.5.4", default-features = false}
 ring = "0.16.20"
 rpassword = "7.0.0"
 rustc-hex = "2.1.0"
 semver = "1.0.5"
-serde = { version = "1.0.133", features = ["derive"] }
+serde = {version = "1.0.133", features = ["derive"]}
 serde_json = "1.0.67"
 sha2 = "0.10.6"
-similar = { version = "2.1.0", features = ["inline"] }
+similar = {version = "2.1.0", features = ["inline"]}
 strsim = "0.10.0"
-strum = { version = "0.24", features = ["derive"] }
+strum = {version = "0.24", features = ["derive"]}
 thiserror = "1.0.30"
 which = "4.2.5"
 
 #zksync
-zksync = { git = "https://github.com/matter-labs/zksync-era.git" }
-zksync_eth_signer = { git = "https://github.com/matter-labs/zksync-era.git" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git" }
-zksync-web3-rs = { git = "https://github.com/lambdaclass/zksync-web3-rs/", branch = "main" }
+zksync = {git = "https://github.com/matter-labs/zksync-era.git"}
+zksync_eth_signer = {git = "https://github.com/matter-labs/zksync-era.git"}
+zksync_types = {git = "https://github.com/matter-labs/zksync-era.git"}
+zksync_utils = {git = "https://github.com/matter-labs/zksync-era.git"}
+zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git"}
 
 ansi_term = "0.12.1"
-anyhow = { version = "1.0.70" }
-dirs = { version = "5.0.0" }
+anyhow = {version = "1.0.70"}
+dirs = {version = "5.0.0"}
 url = "2.3.1"
 
 ethabi = "18.0.0"
 uint = "0.9.0"
 
 [dev-dependencies]
-anvil = { path = "../anvil" }
+anvil = {path = "../anvil"}
 criterion = "0.4.0"
-foundry-cli-test-utils = { path = "./test-utils" }
-foundry-utils = { path = "./../utils", features = ["test"] }
+foundry-cli-test-utils = {path = "./test-utils"}
+foundry-utils = {path = "./../utils", features = ["test"]}
 pretty_assertions = "1.0.0"
 serial_test = "0.9.0"
-svm = { package = "svm-rs", version = "0.2.16", default-features = false, features = [
-  "rustls",
-] }
+svm = {package = "svm-rs", version = "0.2.16", default-features = false, features = ["rustls"]}
 toml = "0.5"
 
 [features]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -102,7 +102,7 @@ zksync = { git = "https://github.com/matter-labs/zksync-era.git" }
 zksync_eth_signer = { git = "https://github.com/matter-labs/zksync-era.git" }
 zksync_types = { git = "https://github.com/matter-labs/zksync-era.git" }
 zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git" }
-zksync-web3-rs = { path = "../../zksync-web3-rs" }
+zksync-web3-rs = { git = "https://github.com/lambdaclass/zksync-web3-rs/", branch = "main" }
 
 ansi_term = "0.12.1"
 anyhow = { version = "1.0.70" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -88,10 +88,6 @@ thiserror = "1.0.30"
 which = "4.2.5"
 
 #zksync
-zksync = {git = "https://github.com/matter-labs/zksync-era.git"}
-zksync_eth_signer = {git = "https://github.com/matter-labs/zksync-era.git"}
-zksync_types = {git = "https://github.com/matter-labs/zksync-era.git"}
-zksync_utils = {git = "https://github.com/matter-labs/zksync-era.git"}
 zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git"}
 
 ansi_term = "0.12.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -88,7 +88,7 @@ thiserror = "1.0.30"
 which = "4.2.5"
 
 #zksync
-zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git", rev = "7e82c03e658d73622515a643327a7629d759e630"}
+zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git", rev = "70327ae5413c517bd4d27502507cdd96ee40cd22"}
 
 ansi_term = "0.12.1"
 anyhow = {version = "1.0.70"}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -88,7 +88,7 @@ thiserror = "1.0.30"
 which = "4.2.5"
 
 #zksync
-zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git"}
+zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git", rev = "7e82c03e658d73622515a643327a7629d759e630"}
 
 ansi_term = "0.12.1"
 anyhow = {version = "1.0.70"}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,42 +8,52 @@ repository = "https://github.com/foundry-rs/foundry"
 version = "0.2.0"
 
 [build-dependencies]
-vergen = {version = "7.0", default-features = false, features = ["build", "rustc", "git"]}
+vergen = { version = "7.0", default-features = false, features = [
+  "build",
+  "rustc",
+  "git",
+] }
 
 [dependencies]
 # foundry internal
-cast = {path = "../cast"}
+cast = { path = "../cast" }
 error-chain = "0.5"
-forge = {path = "../forge"}
-forge-doc = {path = "../doc"}
-forge-fmt = {path = "../fmt"}
-foundry-common = {path = "../common"}
-foundry-config = {path = "../config"}
-foundry-utils = {path = "../utils"}
-ui = {path = "../ui"}
+forge = { path = "../forge" }
+forge-doc = { path = "../doc" }
+forge-fmt = { path = "../fmt" }
+foundry-common = { path = "../common" }
+foundry-config = { path = "../config" }
+foundry-utils = { path = "../utils" }
+ui = { path = "../ui" }
 web3 = "0.18"
 
 # eth
-ethers = {git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix",default-features = false, features = ["rustls"]}
+ethers = { git = "https://github.com/mm-zk/ethers-rs", branch = "foundry_zksync_fix", default-features = false, features = [
+  "rustls",
+] }
 solang-parser = "=0.2.1"
 
 # cli
 atty = "0.2.14"
-clap = {version = "4.0", features = ["derive", "env", "unicode", "wrap_help"]}
+clap = { version = "4.0", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete = "4.0"
 clap_complete_fig = "4.0"
 comfy-table = "6.0.0"
 console = "0.15.0"
-dialoguer = {version = "0.10.2", default-features = false}
+dialoguer = { version = "0.10.2", default-features = false }
 dotenvy = "0.15"
-reqwest = {version = "0.11.8", default-features = false, features = [
+reqwest = { version = "0.11.8", default-features = false, features = [
   "json",
   "rustls",
   "rustls-native-certs",
-]}
+] }
 tracing = "0.1"
 tracing-error = "0.2.0"
-tracing-subscriber = {version = "0.3", features = ["registry", "env-filter", "fmt"]}
+tracing-subscriber = { version = "0.3", features = [
+  "registry",
+  "env-filter",
+  "fmt",
+] }
 watchexec = "2.0"
 yansi = "0.5.1"
 
@@ -51,7 +61,7 @@ yansi = "0.5.1"
 async-trait = "0.1.53"
 futures = "0.3.17"
 rayon = "1.6.1"
-tokio = {version = "1", features = ["macros"]}
+tokio = { version = "1", features = ["macros"] }
 
 # disk / paths
 dunce = "1.0.2"
@@ -73,42 +83,45 @@ once_cell = "1.13"
 parking_lot = "0.12"
 pkg-config = "0.3.26"
 proptest = "1.0.0"
-regex = {version = "1.5.4", default-features = false}
+regex = { version = "1.5.4", default-features = false }
 ring = "0.16.20"
 rpassword = "7.0.0"
 rustc-hex = "2.1.0"
 semver = "1.0.5"
-serde = {version = "1.0.133", features = ["derive"]}
+serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.67"
 sha2 = "0.10.6"
-similar = {version = "2.1.0", features = ["inline"]}
+similar = { version = "2.1.0", features = ["inline"] }
 strsim = "0.10.0"
-strum = {version = "0.24", features = ["derive"]}
+strum = { version = "0.24", features = ["derive"] }
 thiserror = "1.0.30"
 which = "4.2.5"
 
 #zksync
-zksync = {git = "https://github.com/matter-labs/zksync-era.git"}
-zksync_eth_signer = {git = "https://github.com/matter-labs/zksync-era.git"}
-zksync_types = {git = "https://github.com/matter-labs/zksync-era.git"}
-zksync_utils = {git = "https://github.com/matter-labs/zksync-era.git"}
+zksync = { git = "https://github.com/matter-labs/zksync-era.git" }
+zksync_eth_signer = { git = "https://github.com/matter-labs/zksync-era.git" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git" }
+zksync-web3-rs = { path = "../../zksync-web3-rs" }
 
 ansi_term = "0.12.1"
-anyhow = {version = "1.0.70"}
-dirs = {version = "5.0.0"}
+anyhow = { version = "1.0.70" }
+dirs = { version = "5.0.0" }
 url = "2.3.1"
 
 ethabi = "18.0.0"
 uint = "0.9.0"
 
 [dev-dependencies]
-anvil = {path = "../anvil"}
+anvil = { path = "../anvil" }
 criterion = "0.4.0"
-foundry-cli-test-utils = {path = "./test-utils"}
-foundry-utils = {path = "./../utils", features = ["test"]}
+foundry-cli-test-utils = { path = "./test-utils" }
+foundry-utils = { path = "./../utils", features = ["test"] }
 pretty_assertions = "1.0.0"
 serial_test = "0.9.0"
-svm = {package = "svm-rs", version = "0.2.16", default-features = false, features = ["rustls"]}
+svm = { package = "svm-rs", version = "0.2.16", default-features = false, features = [
+  "rustls",
+] }
 toml = "0.5"
 
 [features]

--- a/cli/src/cmd/cast/zk_deposit.rs
+++ b/cli/src/cmd/cast/zk_deposit.rs
@@ -133,7 +133,7 @@ impl ZkDepositTxArgs {
         let private_key = &self.wallet.private_key.as_ref().unwrap();
         let l1_url = get_rpc_url(&self.l1_url)?;
         let l2_url = get_url_with_port(&self.l2_url).expect("Invalid L2_RPC_URL");
-        let chain = get_chain(self.chain)?;
+        let chain: Chain = get_chain(self.chain)?;
         // let token_address: Address = match self.token {
         //     Some(token_addy) => token_addy,
         //     None => Address::zero(),
@@ -141,7 +141,7 @@ impl ZkDepositTxArgs {
 
         let l1_provider = Provider::try_from(l1_url)?;
         let l2_provider = Provider::try_from(l2_url)?;
-        let wallet = LocalWallet::from_str(private_key).unwrap().with_chain_id(chain.id());
+        let wallet = LocalWallet::from_str(private_key)?.with_chain_id(chain);
         let zk_wallet =
             ZKSWallet::new(wallet, None, Some(l2_provider.clone()), Some(l1_provider.clone()))
                 .unwrap();

--- a/cli/src/cmd/cast/zk_deposit.rs
+++ b/cli/src/cmd/cast/zk_deposit.rs
@@ -13,19 +13,27 @@
 ///     - `parse_decimal_u256`: Converts a string to a `U256` number.
 ///
 use crate::{
-    cmd::cast::zk_utils::zk_utils::{
-        get_chain, get_private_key, get_rpc_url, get_signer, get_url_with_port,
-    },
-    opts::{cast::parse_name_or_address, TransactionOpts, Wallet},
+    cmd::cast::zk_utils::zk_utils::{get_chain, get_rpc_url, get_url_with_port},
+    opts::{TransactionOpts, Wallet},
 };
 use clap::Parser;
-use ethers::types::NameOrAddress;
 use foundry_config::Chain;
-use zksync::{
-    self,
-    types::{Address, H160, U256},
-    wallet,
-};
+use std::str::FromStr;
+use zksync_web3_rs::providers::Provider;
+use zksync_web3_rs::signers::{LocalWallet, Signer};
+use zksync_web3_rs::types::{Address, NameOrAddress, H160, U256};
+use zksync_web3_rs::DepositRequest;
+use zksync_web3_rs::ZKSWallet;
+
+// FIXME this function belongs in the `crate::opts::cast` module. I moved it here because the rest
+// of the code is using the ethers types while we are using the `zksync_web3_rs` re-exports.
+pub fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {
+    Ok(if s.starts_with("0x") {
+        NameOrAddress::Address(s.parse()?)
+    } else {
+        NameOrAddress::Name(s.into())
+    })
+}
 
 /// Struct to represent the command line arguments for the `cast zk-deposit` command.
 ///
@@ -62,6 +70,14 @@ pub struct ZkDepositTxArgs {
     )]
     operator_tip: Option<U256>,
 
+    /// Layer 2 gas limit.
+    #[clap(help = "Layer 2 gas limit", value_name = "L2_GAS_LIMIT")]
+    l2_gas_limit: Option<U256>,
+
+    /// Set the gas per pubdata byte (Optional).
+    #[clap(help = "Set the gas per pubdata byte (Optional)", value_name = "GAS_PER_PUBDATA_BYTE")]
+    gas_per_pubdata_byte: Option<U256>,
+
     /// The zkSync RPC Layer 2 endpoint.
     /// Can be provided via the env var L2_RPC_URL
     /// or --l2-url from the command line.
@@ -85,8 +101,13 @@ pub struct ZkDepositTxArgs {
     tx: TransactionOpts,
 
     /// Ethereum-specific options, such as the network and wallet.
-    /// We use the options directly, as we want to have a separate URL 
-    #[clap(env = "L1_RPC_URL", long = "l1-rpc-url", help = "The L1 RPC endpoint.", value_name = "L1_URL")]
+    /// We use the options directly, as we want to have a separate URL
+    #[clap(
+        env = "L1_RPC_URL",
+        long = "l1-rpc-url",
+        help = "The L1 RPC endpoint.",
+        value_name = "L1_URL"
+    )]
     pub l1_url: Option<String>,
 
     #[clap(long, env = "CHAIN", value_name = "CHAIN_NAME")]
@@ -94,7 +115,6 @@ pub struct ZkDepositTxArgs {
 
     #[clap(flatten)]
     pub wallet: Wallet,
-
 }
 
 impl ZkDepositTxArgs {
@@ -110,37 +130,33 @@ impl ZkDepositTxArgs {
     /// - Ok: If the deposit transaction is successfully completed.
     /// - Err: If an error occurred during the execution of the deposit transaction.
     pub async fn run(self) -> eyre::Result<()> {
-        let private_key = get_private_key(&self.wallet.private_key)?;
+        let private_key = &self.wallet.private_key.as_ref().unwrap();
         let l1_url = get_rpc_url(&self.l1_url)?;
         let l2_url = get_url_with_port(&self.l2_url).expect("Invalid L2_RPC_URL");
         let chain = get_chain(self.chain)?;
-        let signer = get_signer(private_key, &chain);
-        let wallet = wallet::Wallet::with_http_client(&l2_url, signer);
-        let to_address = self.get_to_address();
-        let token_address: Address = match self.token {
-            Some(token_addy) => token_addy,
-            None => Address::zero(),
-        };
+        // let token_address: Address = match self.token {
+        //     Some(token_addy) => token_addy,
+        //     None => Address::zero(),
+        // };
 
-        match wallet {
-            Ok(w) => {
-                println!("Bridging assets....");
-                let eth_provider = w.ethereum(l1_url).await.map_err(|e| e)?;
-                let tx_hash = eth_provider
-                    .deposit(
-                        token_address,
-                        self.amount,
-                        to_address,
-                        self.operator_tip,
-                        self.bridge_address,
-                        None,
-                    )
-                    .await?;
+        let l1_provider = Provider::try_from(l1_url)?;
+        let l2_provider = Provider::try_from(l2_url)?;
+        let wallet = LocalWallet::from_str(private_key).unwrap().with_chain_id(chain.id());
+        let zk_wallet =
+            ZKSWallet::new(wallet, None, Some(l2_provider.clone()), Some(l1_provider.clone()))
+                .unwrap();
 
-                println!("Transaction Hash: {:#?}", tx_hash);
-            }
-            Err(e) => eyre::bail!("Failed to download the file: {}", e),
-        }
+        let deposit_request = DepositRequest::new(self.amount.into())
+            .to(self.get_to_address())
+            .operator_tip(self.operator_tip.unwrap_or(0.into()))
+            .gas_price(self.tx.gas_price)
+            .gas_limit(self.tx.gas_limit)
+            .gas_per_pubdata_byte(self.gas_per_pubdata_byte)
+            .l2_gas_limit(self.l2_gas_limit);
+
+        println!("Bridging assets....");
+        let l1_receipt = zk_wallet.deposit(&deposit_request).await.unwrap();
+        println!("Transaction Hash: {:#?}", l1_receipt.transaction_hash);
 
         Ok(())
     }
@@ -156,7 +172,7 @@ impl ZkDepositTxArgs {
     fn get_to_address(&self) -> H160 {
         let to = self.to.as_address().expect("Please enter TO address.");
         let deployed_contract = to.as_bytes();
-        zksync_utils::be_bytes_to_safe_address(&deployed_contract).unwrap()
+        Address::from_slice(deployed_contract)
     }
 }
 
@@ -178,5 +194,83 @@ fn parse_decimal_u256(s: &str) -> Result<U256, String> {
     match U256::from_dec_str(s) {
         Ok(value) => Ok(value),
         Err(e) => Err(format!("Failed to parse decimal number: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod zk_deposit_tests {
+    use std::env;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_deposit_to_signer_account() {
+        let amount = U256::from(1);
+        let private_key = "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110";
+        let l1_url = env::var("L1_RPC_URL").ok();
+        let l2_url = env::var("L2_RPC_URL").unwrap();
+
+        let zk_wallet = {
+            let l1_provider = Provider::try_from(l1_url.unwrap()).unwrap();
+            let l2_provider = Provider::try_from(l2_url.clone()).unwrap();
+
+            let wallet = LocalWallet::from_str(private_key).unwrap();
+            let zk_wallet =
+                ZKSWallet::new(wallet, None, Some(l2_provider), Some(l1_provider)).unwrap();
+
+            zk_wallet
+        };
+
+        let l1_balance_before = zk_wallet.eth_balance().await.unwrap();
+        let l2_balance_before = zk_wallet.era_balance().await.unwrap();
+
+        let zk_deposit_tx_args = {
+            let to = parse_name_or_address("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049").unwrap();
+            let bridge_address = None;
+            let operator_tip = None;
+            let token = None; // => Ether.
+            let tx = TransactionOpts {
+                gas_limit: None,
+                gas_price: None,
+                priority_gas_price: None,
+                value: None,
+                nonce: None,
+                legacy: false,
+            };
+            let l1_url = env::var("L1_RPC_URL").ok();
+            let chain = Some(Chain::Id(env::var("CHAIN").unwrap().parse().unwrap()));
+            let wallet: Wallet = Wallet::parse_from(["foundry-cli", "--private-key", private_key]);
+
+            ZkDepositTxArgs {
+                to,
+                amount,
+                bridge_address,
+                operator_tip,
+                l2_url,
+                token,
+                tx,
+                l1_url,
+                chain,
+                wallet,
+                l2_gas_limit: None,
+                gas_per_pubdata_byte: None,
+            }
+        };
+
+        zk_deposit_tx_args.run().await.unwrap();
+
+        let l1_balance_after = zk_wallet.eth_balance().await.unwrap();
+        let l2_balance_after = zk_wallet.era_balance().await.unwrap();
+        println!("L1 balance after: {}", l1_balance_after);
+        println!("L2 balance after: {}", l2_balance_after);
+
+        assert!(
+            l1_balance_after <= l1_balance_before - amount,
+            "Balance on L1 should be decreased"
+        );
+        assert!(
+            l2_balance_after >= l2_balance_before + amount,
+            "Balance on L2 should be increased"
+        );
     }
 }

--- a/cli/src/cmd/cast/zk_send.rs
+++ b/cli/src/cmd/cast/zk_send.rs
@@ -36,24 +36,14 @@
 ///
 /// The `print_receipt` method extracts relevant information from the transaction receipt and prints it to the console.
 /// This includes the transaction hash, gas used, effective gas price, block number, and deployed contract address, if applicable.
-use crate::cmd::cast::zk_utils::zk_utils::{
-    decode_hex, get_chain, get_private_key, get_rpc_url, get_signer,
-};
+use crate::cmd::cast::zk_utils::zk_utils::{get_rpc_url};
 use crate::opts::{cast::parse_name_or_address, EthereumOpts, TransactionOpts};
-use cast::TxBuilder;
 use clap::Parser;
 use ethers::types::NameOrAddress;
-use eyre::Context;
-use foundry_common::try_get_http_provider;
-use foundry_config::Config;
-use zksync::{
-    self,
-    signer::Signer,
-    types::{Address, TransactionReceipt, H160, U256},
-    wallet,
-};
-use zksync_eth_signer::PrivateKeySigner;
-use zksync_types::CONTRACT_DEPLOYER_ADDRESS;
+use std::str::FromStr;
+use zksync_web3_rs::{ZKSWallet,providers::{Provider,Middleware}, signers::LocalWallet, types::{Address, TransactionReceipt, H160, U256}, zks_utils::CONTRACT_DEPLOYER_ADDR, zks_provider::ZKSProvider};
+
+use super::zk_utils::zk_utils::get_private_key;
 
 /// CLI arguments for the `cast zk-send` subcommand.
 ///
@@ -137,92 +127,42 @@ impl ZkSendTxArgs {
     /// - Ok: If the transaction or withdraw operation is successful.
     /// - Err: If any error occurs during the operation.
     pub async fn run(self) -> eyre::Result<()> {
-        let config = Config::load();
-
         let private_key = get_private_key(&self.eth.wallet.private_key)?;
-
         let rpc_url = get_rpc_url(&self.eth.rpc_url)?;
-
-        let chain = get_chain(self.eth.chain)?;
-
-        let signer: Signer<PrivateKeySigner> = get_signer(private_key, &chain);
-        let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
+        let provider = Provider::try_from(rpc_url)?;
         let to_address = self.get_to_address();
-        let sender = self.eth.sender().await;
+        let wallet = LocalWallet::from_str(&format!("{private_key:?}"))?;
+        let zk_wallet = ZKSWallet::new(wallet, None, Some(provider), None);
 
-        let wallet = wallet::Wallet::with_http_client(&rpc_url, signer);
-
+        // TODO Support different tokens than ETH.
         if self.withdraw {
-            let token_address: Address = match &self.token {
-                Some(token_addy) => {
-                    let decoded = match decode_hex(token_addy) {
-                        Ok(addy) => addy,
-                        Err(e) => {
-                            eyre::bail!("Error parsing token address: {e}, try removing the '0x'")
-                        }
-                    };
-                    Address::from_slice(decoded.as_slice())
-                }
-                None => Address::zero(),
-            };
-
             let amount = self
                 .amount
                 .expect("Amount was not provided. Use --amount flag (ex. --amount 1000000000 )");
 
-            match wallet {
-                Ok(w) => {
+            match zk_wallet {
+                Ok(wallet) => {
                     println!("Bridging assets....");
-                    // Build Withdraw //
-                    let tx = w
-                        .start_withdraw()
-                        .to(to_address)
-                        .amount(amount)
-                        .token(token_address)
-                        .send()
-                        .await
-                        .unwrap();
-
-                    let rcpt = match tx.wait_for_commit().await {
-                        Ok(rcpt) => rcpt,
-                        Err(e) => eyre::bail!("Transaction Error: {}", e),
-                    };
-
-                    self.print_receipt(&rcpt);
+                    let tx_rcpt = wallet.withdraw(amount, to_address).await?;
+                    self.print_receipt(&tx_rcpt);
                 }
                 Err(e) => eyre::bail!("error wallet: {e:?}"),
             };
         } else {
-            match wallet {
-                Ok(w) => {
+            match zk_wallet {
+                Ok(wallet) => {
                     println!("Sending transaction....");
-
-                    // Here we are constructing the parameters for the transaction
                     let sig = self.sig.as_ref().expect("Error: Function Signature is empty");
-                    let params =
-                        if !sig.is_empty() { Some((&sig[..], self.args.clone())) } else { None };
+                    let params = (!sig.is_empty()).then_some((&sig[..], self.args.clone()));
 
-                    // Creating a new transaction builder
-                    let mut builder =
-                        TxBuilder::new(&provider, sender, self.to.clone(), chain, true).await?;
-
-                    builder.args(params).await?;
-
-                    let (tx, _func) = builder.build();
-                    let encoded_function_call = tx.data().unwrap().to_vec();
-
-                    let tx = w
-                        .start_execute_contract()
-                        .contract_address(to_address)
-                        .calldata(encoded_function_call)
-                        .send()
-                        .await
-                        .wrap_err("Failed to execute transaction")?;
-
-                    let rcpt = match tx.wait_for_commit().await {
-                        Ok(rcpt) => rcpt,
-                        Err(e) => eyre::bail!("Transaction Error: {}", e),
-                    };
+                    let (_, tx_hash) = wallet.get_era_provider()?.send_eip712(
+                        &wallet.l2_wallet,
+                        to_address,
+                        sig,
+                        params.map(|(_, values)| values),
+                        None
+                    ).await?;
+                    let rcpt = wallet.get_era_provider()?.get_transaction_receipt(tx_hash).await?.ok_or(eyre::eyre!("Error retrieving transaction receipt"))?;
 
                     self.print_receipt(&rcpt);
                 }
@@ -255,7 +195,7 @@ impl ZkSendTxArgs {
 
         // This will display a deployed contract address if one was deployed via zksend
         for log in &rcpt.logs {
-            if log.address == CONTRACT_DEPLOYER_ADDRESS {
+            if log.address == Address::from_str(CONTRACT_DEPLOYER_ADDR).unwrap() {
                 let deployed_address = log.topics.get(3).unwrap();
                 let deployed_address = Address::from(*deployed_address);
                 println!("Deployed contract address: {:#?}", deployed_address);
@@ -264,7 +204,7 @@ impl ZkSendTxArgs {
         }
     }
 
-    /// Gets the recipient address of the transaction.
+    // Gets the recipient address of the transaction.
     ///
     /// If the `to` field is `None`, it will panic with the message "Enter TO: Address".
     ///
@@ -274,7 +214,7 @@ impl ZkSendTxArgs {
     fn get_to_address(&self) -> H160 {
         let to = self.to.as_ref().expect("Enter TO: Address");
         let deployed_contract = to.as_address().expect("Invalid address").as_bytes();
-        zksync_utils::be_bytes_to_safe_address(&deployed_contract).unwrap()
+        Address::from_slice(deployed_contract)
     }
 }
 

--- a/cli/src/cmd/cast/zk_send.rs
+++ b/cli/src/cmd/cast/zk_send.rs
@@ -36,14 +36,14 @@
 ///
 /// The `print_receipt` method extracts relevant information from the transaction receipt and prints it to the console.
 /// This includes the transaction hash, gas used, effective gas price, block number, and deployed contract address, if applicable.
-use crate::cmd::cast::zk_utils::zk_utils::{get_rpc_url};
 use crate::opts::{cast::parse_name_or_address, EthereumOpts, TransactionOpts};
 use clap::Parser;
 use ethers::types::NameOrAddress;
+use zksync_web3_rs::signers::Signer;
 use std::str::FromStr;
 use zksync_web3_rs::{ZKSWallet,providers::{Provider,Middleware}, signers::LocalWallet, types::{Address, TransactionReceipt, H160, U256}, zks_utils::CONTRACT_DEPLOYER_ADDR, zks_provider::ZKSProvider};
 
-use super::zk_utils::zk_utils::get_private_key;
+use super::zk_utils::zk_utils::{get_private_key, get_chain, get_rpc_url};
 
 /// CLI arguments for the `cast zk-send` subcommand.
 ///
@@ -129,9 +129,10 @@ impl ZkSendTxArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let private_key = get_private_key(&self.eth.wallet.private_key)?;
         let rpc_url = get_rpc_url(&self.eth.rpc_url)?;
+        let chain = get_chain(self.eth.chain)?;
         let provider = Provider::try_from(rpc_url)?;
         let to_address = self.get_to_address();
-        let wallet = LocalWallet::from_str(&format!("{private_key:?}"))?;
+        let wallet = LocalWallet::from_str(&format!("{private_key:?}"))?.with_chain_id(chain);
         let zk_wallet = ZKSWallet::new(wallet, None, Some(provider), None);
 
         // TODO Support different tokens than ETH.

--- a/cli/src/cmd/cast/zk_utils.rs
+++ b/cli/src/cmd/cast/zk_utils.rs
@@ -29,9 +29,7 @@ pub mod zk_utils {
     use foundry_config::Chain;
     use std::num::ParseIntError;
     use url::Url;
-    use zksync::{signer::Signer, types::H256};
-    use zksync_eth_signer::PrivateKeySigner;
-    use zksync_types::{L2ChainId, PackedEthSignature};
+    use zksync_web3_rs::types::H256;
     /// Gets the RPC URL for Ethereum.
     ///
     /// If the `eth.rpc_url` is `None`, an error is returned.
@@ -112,28 +110,6 @@ pub mod zk_utils {
                 "Chain was not provided. Use --chain flag (ex. --chain 270 ) \nor environment variable 'CHAIN= ' (ex.'CHAIN=270')",
             )),
         }
-    }
-
-    /// Creates a signer from the private key and the chain.
-    ///
-    /// This function creates a `Signer` instance for signing transactions on the zkSync network.
-    /// It uses the private key to create an `pk_signer` and derives the associated address.
-    /// The `Signer` is then initialized with the `pk_signer`, the derived address, and the L2ChainId
-    /// derived from the `Chain` instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `private_key` - A `H256` that represents the private key.
-    /// * `chain` - A reference to `Chain` that represents the chain.
-    ///
-    /// # Returns
-    ///
-    /// A `Signer<PrivateKeySigner>` instance.
-    pub fn get_signer(private_key: H256, chain: &Chain) -> Signer<PrivateKeySigner> {
-        let pk_signer = PrivateKeySigner::new(private_key);
-        let signer_addy = PackedEthSignature::address_from_private_key(&private_key)
-            .expect("Can't get an address from the private key");
-        Signer::new(pk_signer, signer_addy, L2ChainId(chain.id().try_into().unwrap()))
     }
 
     /// Decodes a hexadecimal string into a byte vector.

--- a/cli/src/cmd/forge/zk_create.rs
+++ b/cli/src/cmd/forge/zk_create.rs
@@ -195,8 +195,9 @@ impl ZkCreateArgs {
         let wallet = LocalWallet::from_str(&format!("{private_key:?}"))?;
         let zk_wallet = ZKSWallet::new(wallet, None, Some(provider), None)?;
 
-        let rcpt =
-            zk_wallet._deploy(contract, bytecode.to_vec(), None, Some(self.constructor_args)).await?;
+        let rcpt = zk_wallet
+            .deploy(contract, bytecode.to_vec(), None, Some(self.constructor_args))
+            .await?;
 
         let deployed_address = rcpt.contract_address.expect("Error retrieving deployed address");
         let gas_used = rcpt.gas_used.expect("Error retrieving gas used");

--- a/cli/src/cmd/forge/zk_create.rs
+++ b/cli/src/cmd/forge/zk_create.rs
@@ -58,7 +58,7 @@ use ethers::{
 use eyre::Context;
 use serde_json::Value;
 use std::{fs, path::PathBuf, str::FromStr};
-use zksync_web3_rs::{providers::Provider, signers::LocalWallet, ZKSWallet};
+use zksync_web3_rs::{providers::Provider, signers::{LocalWallet, Signer}, ZKSWallet};
 
 /// CLI arguments for `forge zk-create`.
 /// Struct `ZkCreateArgs` encapsulates the arguments necessary for creating a new zkSync contract.
@@ -192,7 +192,7 @@ impl ZkCreateArgs {
         let constructor_args = self.get_constructor_args(&contract);
 
         let provider = Provider::try_from(rpc_url)?;
-        let wallet = LocalWallet::from_str(&format!("{private_key:?}"))?;
+        let wallet = LocalWallet::from_str(&format!("{private_key:?}"))?.with_chain_id(chain);
         let zk_wallet = ZKSWallet::new(wallet, None, Some(provider), None)?;
 
         let rcpt = zk_wallet

--- a/cli/src/cmd/forge/zk_create.rs
+++ b/cli/src/cmd/forge/zk_create.rs
@@ -206,6 +206,7 @@ impl ZkCreateArgs {
 
         println!("+-------------------------------------------------+");
         println!("Contract successfully deployed to address: {:#?}", deployed_address);
+        println!("Transaction Hash: {:#?}", rcpt.transaction_hash);
         println!("Gas used: {:#?}", gas_used);
         println!("Effective gas price: {:#?}", gas_price);
         println!("Block Number: {:#?}", block_number);

--- a/cli/src/cmd/forge/zk_create.rs
+++ b/cli/src/cmd/forge/zk_create.rs
@@ -43,7 +43,7 @@
 /// - `zksync`
 use crate::{
     cmd::{
-        cast::zk_utils::zk_utils::{get_chain, get_private_key, get_rpc_url, get_signer},
+        cast::zk_utils::zk_utils::{get_chain, get_private_key, get_rpc_url},
         forge::build::CoreBuildArgs,
         read_constructor_args_file,
     },

--- a/cli/src/cmd/forge/zksolc_manager.rs
+++ b/cli/src/cmd/forge/zksolc_manager.rs
@@ -199,9 +199,9 @@ impl ZkSolcManagerOpts {
 /// ```
 #[derive(Debug, Clone)]
 pub struct ZkSolcManagerBuilder {
-    compilers_path: Option<PathBuf>,
+    _compilers_path: Option<PathBuf>,
     version: String,
-    compiler: Option<String>,
+    _compiler: Option<String>,
     download_url: Url,
 }
 
@@ -226,9 +226,9 @@ impl ZkSolcManagerBuilder {
     /// Returns a new `ZkSolcManagerBuilder` instance.
     pub fn new(opts: ZkSolcManagerOpts) -> Self {
         Self {
-            compilers_path: None,
+            _compilers_path: None,
             version: opts.version,
-            compiler: None,
+            _compiler: None,
             download_url: Url::parse(ZKSOLC_DOWNLOAD_BASE_URL).unwrap(),
         }
     }

--- a/cli/src/cmd/forge/zksolc_manager.rs
+++ b/cli/src/cmd/forge/zksolc_manager.rs
@@ -197,7 +197,7 @@ impl ZkSolcManagerOpts {
 ///     .build()
 ///     .expect("Failed to build ZkSolcManager");
 /// ```
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub struct ZkSolcManagerBuilder {
     compilers_path: Option<PathBuf>,
     version: String,
@@ -331,7 +331,7 @@ impl ZkSolcManagerBuilder {
 /// The `ZkSolcManager` structure provides a high-level interface to manage the `zksolc` compiler,
 /// simplifying the process of handling different versions and ensuring the availability of the compiler
 /// for contract compilation.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub struct ZkSolcManager {
     compilers_path: PathBuf,
     version: ZkSolcVersion,

--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -69,7 +69,7 @@ impl GasReport {
                 (!self.ignore.contains(&contract_name) && self.report_for.is_empty()) ||
                 (self.report_for.contains(&contract_name));
             if report_contract {
-                let mut contract_report =
+                let contract_report =
                     self.contracts.entry(name.to_string()).or_insert_with(Default::default);
 
                 match &trace.data {


### PR DESCRIPTION
## Motivation
`zksync` is a big crate with a lot of functionality that is irrelevant for foundry. That's why we are replacing the crate with the zksync SDK, which provides the same functionality that is needed for foundry but is much more lightweight.

Functionality that has been affected:
- zk_deposit
- zk_send
- zk_create

TODO items to be fully compatible with zksync functionality:
- Deposit and withdrawal of ERC20 tokens (work in progress),
