### PR TITLE
chore: adds latest zksolc compiler

### DIFF
--- a/crates/zkforge/bin/cmd/zksolc_manager.rs
+++ b/crates/zkforge/bin/cmd/zksolc_manager.rs
@@ -60,9 +60,10 @@ pub enum ZkSolcVersion {
     V1313,
     V1314,
     V1315,
+    V1316,
 }
 
-pub const DEFAULT_ZKSOLC_VERSION: &str = "v1.3.15";
+pub const DEFAULT_ZKSOLC_VERSION: &str = "v1.3.16";
 
 /// `parse_version` parses a string representation of a `zksolc` compiler version
 /// and returns the `ZkSolcVersion` enum variant if it matches a supported version.
@@ -87,6 +88,7 @@ fn parse_version(version: &str) -> Result<ZkSolcVersion> {
         "v1.3.13" => Ok(ZkSolcVersion::V1313),
         "v1.3.14" => Ok(ZkSolcVersion::V1314),
         "v1.3.15" => Ok(ZkSolcVersion::V1315),
+        "v1.3.16" => Ok(ZkSolcVersion::V1316),
         _ => Err(Error::msg(
             "ZkSolc compiler version not supported. Proper version format: 'v1.3.x'",
         )),
@@ -111,6 +113,7 @@ impl ZkSolcVersion {
             ZkSolcVersion::V1313 => "v1.3.13",
             ZkSolcVersion::V1314 => "v1.3.14",
             ZkSolcVersion::V1315 => "v1.3.15",
+            ZkSolcVersion::V1316 => "v1.3.16",
         }
     }
 }
@@ -217,7 +220,7 @@ impl ZkSolcManagerOpts {
 ///
 /// ```ignore
 /// use zkforge::zksolc_manager::{ZkSolcManagerBuilder, ZkSolcManagerOpts};
-/// let opts = ZkSolcManagerOpts::new("v1.3.15")
+/// let opts = ZkSolcManagerOpts::new("v1.3.16")
 /// let zk_solc_manager = ZkSolcManagerBuilder::new(opts)
 ///     .build()
 ///     .expect("Failed to build ZkSolcManager");

--- a/crates/zkforge/bin/cmd/zksolc_manager.rs
+++ b/crates/zkforge/bin/cmd/zksolc_manager.rs
@@ -59,7 +59,6 @@ pub enum ZkSolcVersion {
     V1311,
     V1313,
     V1314,
-    V1315,
     V1316,
 }
 
@@ -87,7 +86,6 @@ fn parse_version(version: &str) -> Result<ZkSolcVersion> {
         "v1.3.11" => Ok(ZkSolcVersion::V1311),
         "v1.3.13" => Ok(ZkSolcVersion::V1313),
         "v1.3.14" => Ok(ZkSolcVersion::V1314),
-        "v1.3.15" => Ok(ZkSolcVersion::V1315),
         "v1.3.16" => Ok(ZkSolcVersion::V1316),
         _ => Err(Error::msg(
             "ZkSolc compiler version not supported. Proper version format: 'v1.3.x'",
@@ -112,7 +110,6 @@ impl ZkSolcVersion {
             ZkSolcVersion::V1311 => "v1.3.11",
             ZkSolcVersion::V1313 => "v1.3.13",
             ZkSolcVersion::V1314 => "v1.3.14",
-            ZkSolcVersion::V1315 => "v1.3.15",
             ZkSolcVersion::V1316 => "v1.3.16",
         }
     }


### PR DESCRIPTION
# What :computer: 
* Adds zksolc 1.3.16
* Removes zksolc 1.3.15

# Why :hand:
* Latest version of the compiler
* 1.3.15 has been removed

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended
<img width="1156" alt="Screenshot 2023-10-30 at 10 51 59 AM" src="https://github.com/matter-labs/foundry-zksync/assets/29983536/d387a302-6c58-4684-a5da-82d5e0ac6557">
<img width="800" alt="Screenshot 2023-10-30 at 10 52 10 AM" src="https://github.com/matter-labs/foundry-zksync/assets/29983536/f87e6cc5-b412-486b-9fee-bdcdc66ce29a">

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
