### PR TITLE
fix: update revm, fix env update for deployed contracts and era-test-node

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -34,6 +34,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
+              with:
+                  toolchain: nightly-2023-07-23
 
             - name: cargo update
               # Remove first line that always just says "Updating crates.io index"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
+              with:
+                toolchain: nightly-2023-07-23
             - uses: Swatinem/rust-cache@v2
               with:
                 cache-on-failure: true
@@ -53,6 +55,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
               with:
+                  toolchain: nightly-2023-07-23
                   components: rustfmt
             - run: cargo fmt --all --check
 
@@ -63,6 +66,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
+              with:
+                  toolchain: nightly-2023-07-23
             - uses: Swatinem/rust-cache@v2
               with:
                   cache-on-failure: true
@@ -76,6 +81,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
+              with:
+                toolchain: nightly-2023-07-23
             - uses: taiki-e/install-action@cargo-hack
             - uses: Swatinem/rust-cache@v2
               with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era_revm"
 version = "0.0.1-alpha"
-source = "git+https://github.com/matter-labs/era-revm.git?tag=v0.0.1-alpha#ef9b86b6f139224990c5e5c21052f97f57a4135d"
+source = "git+https://github.com/matter-labs/era-revm?rev=dc04c89902ea317f3b0e68b80765b5634a4f42b2#dc04c89902ea317f3b0e68b80765b5634a4f42b2"
 dependencies = [
  "era_test_node",
  "ethabi 18.0.0",
@@ -3201,6 +3201,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
+ "tracing",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
  "zksync_basic_types",
  "zksync_types",
@@ -3210,8 +3211,8 @@ dependencies = [
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/matter-labs/era-test-node.git?rev=e9c8ee02da305cd07f69ba6838107c933b3b1b8f#e9c8ee02da305cd07f69ba6838107c933b3b1b8f"
+version = "0.1.0-alpha.10"
+source = "git+https://github.com/matter-labs/era-test-node.git?rev=a74c39c0d89aec29086524f9a8dd13bf2e4e03f6#a74c39c0d89aec29086524f9a8dd13bf2e4e03f6"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -6644,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "hex",
@@ -6654,7 +6655,7 @@ dependencies = [
  "tracing",
  "vise",
  "zk_evm 1.3.1",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zksync_contracts",
  "zksync_state",
  "zksync_system_constants",
@@ -8002,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "metrics",
@@ -8600,7 +8601,8 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.5.0"
-source = "git+https://github.com/dutterbutter/revm.git?tag=sha3_0.10.6#7b96ba436a76eee078fa9fa95b5ef5ba6dbd24f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f4ca8ae0345104523b4af1a8a7ea97cfa1865cdb7a7c25d23c1a18d9b48598"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -8612,7 +8614,8 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.3.0"
-source = "git+https://github.com/dutterbutter/revm.git?tag=sha3_0.10.6#7b96ba436a76eee078fa9fa95b5ef5ba6dbd24f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f959cafdf64a7f89b014fa73dc2325001cf654b3d9400260b212d19a2ebe3da0"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -8621,7 +8624,8 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.2.0"
-source = "git+https://github.com/dutterbutter/revm.git?tag=sha3_0.10.6#7b96ba436a76eee078fa9fa95b5ef5ba6dbd24f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d360a88223d85709d2e95d4609eb1e19c649c47e28954bfabae5e92bb37e83e"
 dependencies = [
  "c-kzg",
  "k256 0.13.1",
@@ -8631,14 +8635,14 @@ dependencies = [
  "ripemd",
  "secp256k1 0.27.0",
  "sha2 0.10.8",
- "sha3 0.10.8",
  "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
 version = "1.3.0"
-source = "git+https://github.com/dutterbutter/revm.git?tag=sha3_0.10.6#7b96ba436a76eee078fa9fa95b5ef5ba6dbd24f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51187b852d9e458816a2e19c81f1dd6c924077e1a8fccd16e4f044f865f299d7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11309,7 +11313,7 @@ dependencies = [
 [[package]]
 name = "vlog"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "chrono",
  "sentry",
@@ -11958,6 +11962,21 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "1.3.3"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2#fbee20f5bac7d6ca3e22ae69b2077c510a07de4e"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "num 0.4.1",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "zk_evm_abstractions",
+ "zkevm_opcode_defs 1.3.2",
+]
+
+[[package]]
+name = "zk_evm"
+version = "1.3.3"
 source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3#fbee20f5bac7d6ca3e22ae69b2077c510a07de4e"
 dependencies = [
  "anyhow",
@@ -12241,7 +12260,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "serde",
  "serde_json",
@@ -12251,7 +12270,7 @@ dependencies = [
 [[package]]
 name = "zksync_circuit_breaker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12274,7 +12293,7 @@ dependencies = [
 [[package]]
 name = "zksync_commitment_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "zkevm_test_harness 1.4.0",
  "zksync_types",
@@ -12284,7 +12303,7 @@ dependencies = [
 [[package]]
 name = "zksync_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -12303,7 +12322,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "envy",
  "ethabi 18.0.0",
@@ -12317,7 +12336,7 @@ dependencies = [
 [[package]]
 name = "zksync_core"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -12381,7 +12400,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "base64 0.13.1",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12396,7 +12415,7 @@ dependencies = [
 [[package]]
 name = "zksync_dal"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -12405,6 +12424,7 @@ dependencies = [
  "itertools 0.10.5",
  "num 0.3.1",
  "once_cell",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sqlx",
@@ -12412,6 +12432,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "vise",
  "zksync_contracts",
  "zksync_health_check",
@@ -12423,7 +12444,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12443,7 +12464,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "async-trait",
  "hex",
@@ -12462,7 +12483,7 @@ dependencies = [
 [[package]]
 name = "zksync_health_check"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -12475,7 +12496,7 @@ dependencies = [
 [[package]]
 name = "zksync_mempool"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "tracing",
  "zksync_types",
@@ -12484,7 +12505,7 @@ dependencies = [
 [[package]]
 name = "zksync_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "leb128",
  "once_cell",
@@ -12495,12 +12516,13 @@ dependencies = [
  "zksync_crypto",
  "zksync_storage",
  "zksync_types",
+ "zksync_utils",
 ]
 
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -12510,7 +12532,7 @@ dependencies = [
 [[package]]
 name = "zksync_object_store"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12528,7 +12550,7 @@ dependencies = [
 [[package]]
 name = "zksync_prover_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12548,7 +12570,7 @@ dependencies = [
 [[package]]
 name = "zksync_queued_job_processor"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12560,7 +12582,7 @@ dependencies = [
 [[package]]
 name = "zksync_state"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
@@ -12577,7 +12599,7 @@ dependencies = [
 [[package]]
 name = "zksync_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "num_cpus",
  "once_cell",
@@ -12589,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "zksync_system_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -12607,7 +12629,7 @@ dependencies = [
 [[package]]
 name = "zksync_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
@@ -12624,7 +12646,7 @@ dependencies = [
  "serde_with",
  "strum 0.24.1",
  "thiserror",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zkevm_test_harness 1.3.3",
  "zksync_basic_types",
  "zksync_contracts",
@@ -12636,7 +12658,7 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -12651,14 +12673,14 @@ dependencies = [
  "tokio",
  "tracing",
  "vlog",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zksync_basic_types",
 ]
 
 [[package]]
 name = "zksync_verification_key_generator_and_server"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -12678,7 +12700,7 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,8 @@ foundry-debugger = { path = "crates/debugger" }
 ## revm
 # no default features to avoid c-kzg
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
-revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6", default-features = false }
+revm = { version = "3.5.0", default-features = false }
+era_revm = { git="https://github.com/matter-labs/era-revm", rev = "dc04c89902ea317f3b0e68b80765b5634a4f42b2" }
 
 # We use a fork of `ethers` to gain access to a previously private variable.
 # This ensures that all artifact files, freshly compiled and saved in the `output` directory, are publicly accessible.
@@ -194,3 +195,4 @@ ethers-signers = { git = "https://github.com/mm-zk/ethers-rs", tag = "main_publi
 ethers-middleware = { git = "https://github.com/mm-zk/ethers-rs", tag = "main_public_artifact", default-features = false }
 ethers-etherscan = { git = "https://github.com/mm-zk/ethers-rs", tag = "main_public_artifact", default-features = false }
 ethers-solc = { git = "https://github.com/mm-zk/ethers-rs", tag = "main_public_artifact", default-features = false }
+

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 foundry-evm = { path = "../../evm" }
 foundry-utils = { path = "../../utils" }
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
-revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6", default-features = false, features = ["std", "serde", "memory_limit"] }
+revm = { workspace = true, default-features = false, features = ["std", "serde", "memory_limit"] }
 
 alloy-primitives = { workspace = true, features = ["serde"] }
 ethers-core.workspace = true

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -34,7 +34,7 @@ hex = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 jsonpath_lib = { workspace = true, optional = true }
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
-revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6", default-features = false, optional = true }
+revm = { workspace = true, default-features = false, optional = true }
 thiserror = { version = "1", optional = true }
 tracing = { workspace = true, optional = true }
 walkdir = { version = "2", optional = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -23,7 +23,7 @@ ethers-etherscan = { workspace = true, features = ["ethers-solc"] }
 
 # zksync
 zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git", rev = "70327ae5413c517bd4d27502507cdd96ee40cd22"}
-era_revm = { git = "https://github.com/matter-labs/era-revm.git", tag = "v0.0.1-alpha" }
+era_revm = { workspace = true }
 anyhow = {version = "1.0.70"}
 dirs = {version = "5.0.0"}
 ansi_term = "0.12.1"

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -311,7 +311,7 @@ impl ZkSolc {
                     // when output is empty, it has a length of 3, `[]\n`
                     // solc returns true for success if output is empty
                     if output.stderr.len() <= 3 {
-                        continue;
+                        continue
                     }
                     eyre::bail!(
                         "Compilation failed with {:?}. Using compiler: {:?}, with args {:?} {:?}",
@@ -434,8 +434,14 @@ impl ZkSolc {
         write_artifacts: Option<PathBuf>,
     ) -> BTreeMap<String, Vec<ArtifactFile<ConfigurableContractArtifact>>> {
         // Deserialize the compiler output into a serde_json::Value object
-        let compiler_output: ZkSolcCompilerOutput = serde_json::from_slice(&output)
-            .unwrap_or_else(|e| panic!("Could not parse zksolc compiler output: {}", e));
+        let compiler_output: ZkSolcCompilerOutput =
+            serde_json::from_slice(&output).unwrap_or_else(|e| {
+                panic!(
+                    "Could not parse zksolc compiler output: {}\n{}",
+                    e,
+                    std::str::from_utf8(&output).unwrap_or_default()
+                )
+            });
 
         // Handle errors and warnings in the output
         ZkSolc::handle_output_errors(&compiler_output, displayed_warnings);
@@ -903,7 +909,7 @@ fn substitute_remapped_paths(content: String, remappings: &[RelativeRemapping]) 
 
         // Exit the loop if no more replacements were made
         if !made_replacements {
-            break;
+            break
         }
     }
 
@@ -926,7 +932,7 @@ fn remap_source_path(source_path: &mut PathBuf, remappings: &[RelativeRemapping]
 
                 *source_path =
                     PathBuf::from(temp_path.to_str().unwrap().replace("src/src/", "src/"));
-                break;
+                break
             }
         }
     }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -16,7 +16,7 @@ ethers-core.workspace = true
 ethers-solc = { workspace = true, features = ["async", "svm-solc"] }
 ethers-etherscan.workspace = true
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
-revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6", default-features = false, features = ["std", "serde", "memory_limit"] }
+revm = { workspace = true, default-features = false, features = ["std", "serde", "memory_limit"] }
 
 # formats
 Inflector = "0.11"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1799,7 +1799,7 @@ impl Default for Config {
             sender: Config::DEFAULT_SENDER,
             tx_origin: Config::DEFAULT_SENDER,
             initial_balance: U256::from(0xffffffffffffffffffffffffu128),
-            block_number: 1,
+            block_number: 0, // era-test-node starts at block 0
             fork_block_number: None,
             chain_id: None,
             gas_limit: i64::MAX.into(),
@@ -1807,7 +1807,7 @@ impl Default for Config {
             gas_price: None,
             block_base_fee_per_gas: 0,
             block_coinbase: Address::zero(),
-            block_timestamp: 1,
+            block_timestamp: 0, // era-test-node starts at timestamp 0
             block_difficulty: 0,
             block_prevrandao: Default::default(),
             block_gas_limit: None,

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -20,7 +20,7 @@ crossterm = "0.27"
 eyre.workspace = true
 tracing.workspace = true
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
-revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6", default-features = false, features = [
+revm = { workspace = true, default-features = false, features = [
   "std",
   "serde",
   "memory_limit",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -41,7 +41,7 @@ once_cell = "1"
 bytes = "1"
 hashbrown = { version = "0.14", features = ["serde"] }
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
-revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6", default-features = false, features = [
+revm = { workspace = true, default-features = false, features = [
   "std",
   "serde",
   "memory_limit",
@@ -50,7 +50,7 @@ revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6", 
   "optional_no_base_fee",
   "arbitrary",
 ] }
-era_revm = { git = "https://github.com/matter-labs/era-revm.git", tag = "v0.0.1-alpha" }
+era_revm = { workspace = true }
 alloy-primitives = { workspace = true, features = ["serde", "getrandom", "arbitrary", "rlp"] }
 alloy-dyn-abi = { workspace = true, features = ["arbitrary"] }
 

--- a/crates/evm/src/executor/mod.rs
+++ b/crates/evm/src/executor/mod.rs
@@ -168,6 +168,15 @@ impl Executor {
         self
     }
 
+    // Record any changes made to the block's environment during setup,
+    // and also the chainid, which can be set manually.
+    pub fn record_env_changes(&mut self, env: &Env) {
+        // record any changes made to the block's environment during setup
+        self.env.block = env.block.clone();
+        // and also the chainid, which can be set manually
+        self.env.cfg.chain_id = env.cfg.chain_id;
+    }
+
     /// Calls the `setUp()` function on a contract.
     ///
     /// This will commit any state changes to the underlying database.
@@ -185,10 +194,7 @@ impl Executor {
         self.backend.set_test_contract(to).set_caller(from);
         let res = self.call_committing::<(), _, _>(from, to, "setUp()", (), U256::ZERO, None)?;
 
-        // record any changes made to the block's environment during setup
-        self.env.block = res.env.block.clone();
-        // and also the chainid, which can be set manually
-        self.env.cfg.chain_id = res.env.cfg.chain_id;
+        self.record_env_changes(&res.env);
 
         match res.state_changeset.as_ref() {
             Some(changeset) => {
@@ -446,7 +452,12 @@ impl Executor {
         abi: Option<&Abi>,
     ) -> Result<DeployResult, EvmError> {
         let env = self.build_test_env(from, TransactTo::Create(CreateScheme::Create), code, value);
-        self.deploy_with_env(env, abi)
+        let res = self.deploy_with_env(env, abi);
+        if let Ok(DeployResult { env, .. }) = &res {
+            self.record_env_changes(env);
+        }
+
+        res
     }
 
     /// Check if a call to a test contract was successful.

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-07-23"
+components = [ "rustfmt", "clippy" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-07-23"
+components = [ "rustfmt", "clippy" ]

--- a/rust-toolchain.yaml
+++ b/rust-toolchain.yaml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-07-23"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# What :computer: 
* Updates revm to latest revision
* Sets env defaults for `env.block.number` and `env.block.timestamp` to `0` as this is what era-test-node starts with
* Fix env update when deploying contracts
* Show solc output when compilation fails

# Why :hand:
* Required to run `zkforge test`

# Evidence :camera:
![image](https://github.com/matter-labs/foundry-zksync/assets/1564843/f37de46b-5611-4e3b-a448-fe36e78b6769)


<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
