### PR TITLE
fix: skip contracts with empty bytecode hash to avoid runtime error

### DIFF
--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -469,7 +469,7 @@ impl ZkSolc {
                     // if contract hash is empty, skip
                     if contract.hash.is_none() {
                         println!("{} -> empty contract.hash", contract_name);
-                        continue;
+                        continue
                     }
 
                     println!(

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -466,9 +466,9 @@ impl ZkSolc {
             if key.contains(source) {
                 let contracts_in_file = compiler_output.contracts.get(key).unwrap();
                 for (contract_name, contract) in contracts_in_file {
-                    // if contract is empty, skip
-                    if  contract.hash.is_none() {
-                        println!("{} -> emtpy file", contract_name);
+                    // if contract hash is empty, skip
+                    if contract.hash.is_none() {
+                        println!("{} -> empty contract.hash", contract_name);
                         continue;
                     }
 

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -466,6 +466,12 @@ impl ZkSolc {
             if key.contains(source) {
                 let contracts_in_file = compiler_output.contracts.get(key).unwrap();
                 for (contract_name, contract) in contracts_in_file {
+                    // if contract is empty, skip
+                    if  contract.hash.is_none() {
+                        println!("{} -> emtpy file", contract_name);
+                        continue;
+                    }
+
                     println!(
                         "{} -> Bytecode Hash: {} ",
                         contract_name,


### PR DESCRIPTION
# What :computer: 

Fixed a bug where `zkbuild` would fail once it stumbles on an interface contract


# Evidence :camera:
Before:
```bash
RUST_BACKTRACE=1 zz zkbuild --is-system
```
```

...
Compiler run completed with warnings
ApprovalPaymaster -> Bytecode Hash: 01000137af7c45e8c9b466525248692879a3b6d8615affdddebc81f845b73913
GeneralPaymaster -> Bytecode Hash: 010000c96565b4e27d7d6337adc6ecb745ce8100a89d17db7f0627b8d0d7895c
Greeter -> Bytecode Hash: 010000839de6704080006a8df6674d13a03a3fd7fc9631b1f2c4b20e5282a1a0

Compiler run completed with warnings
MyPaymaster -> Bytecode Hash: 01000163ed132df1d2456f946f4410fc38a0cde1609cb222486f7f804e9a7d5d
NFTWalletMultisig -> Bytecode Hash: 010007ef05fda46bbb8dd9c68c5c0b7e3d56dff4637ba9ae5a785f559df943b1
TwoUserMultisig -> Bytecode Hash: 0100078fb016fc6f0779619a76125b0675c62479226d3c9b58904546f96b1fce
Artgene721 -> Bytecode Hash: 010008c16a9c75a245056bb8c4eba86776aa21b7c610432d285114f9176b838a
The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: crates/common/src/zk_compile.rs:466

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   1: __ZN7rocksdb6ribbon6detail34BandingConfigHelper1MaybeSupportedILNS0_25ConstructionFailureChanceE1ELy128ELb0ELb0ELb1EE11GetNumSlotsEj<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
Run with RUST_BACKTRACE=full to include source snippets.
[1]    1372 abort      RUST_BACKTRACE=1 zkforge zkbuild --is-system
```
After:

```bash
RUST_BACKTRACE=1 zz zkbuild --is-system
```
```
...
Compiler run completed with warnings
ApprovalPaymaster -> Bytecode Hash: 01000137af7c45e8c9b466525248692879a3b6d8615affdddebc81f845b73913
GeneralPaymaster -> Bytecode Hash: 010000c96565b4e27d7d6337adc6ecb745ce8100a89d17db7f0627b8d0d7895c
Greeter -> Bytecode Hash: 010000839de6704080006a8df6674d13a03a3fd7fc9631b1f2c4b20e5282a1a0
...
Compiler run completed with warnings
MyPaymaster -> Bytecode Hash: 01000163ed132df1d2456f946f4410fc38a0cde1609cb222486f7f804e9a7d5d
NFTWalletMultisig -> Bytecode Hash: 010007ef05fda46bbb8dd9c68c5c0b7e3d56dff4637ba9ae5a785f559df943b1
TwoUserMultisig -> Bytecode Hash: 0100078fb016fc6f0779619a76125b0675c62479226d3c9b58904546f96b1fce
IArtgene721 -> emtpy file
IArtgene721Implementation -> emtpy file
Artgene721 -> Bytecode Hash: 010008c16a9c75a245056bb8c4eba86776aa21b7c610432d285114f9176b838a
Artgene721Factory -> Bytecode Hash: 010000d1411650ca7c2f517d321de56e9d72b0746b54b28c1ee6ad3d94d87105
BurnToMintExtension -> Bytecode Hash: 010001378d5685a67b457dc6fee8d4e8e02856a2c38736c898c45e9744aec987
ERC20SaleExtension -> Bytecode Hash: 0100013fbf58e5b37c3ff14eb0720a54c49f6fd53a200d6cbc01e2656a004443
LimitedSupply -> emtpy file
INFTExtension -> emtpy file
INFTURIExtension -> emtpy file
NFTExtension -> Bytecode Hash: 0100002933410a2655258434cf42f7751e945f58bbad7bbc650af7cff7412b8a
SaleControl -> emtpy file
IArtgene721 -> emtpy file
IArtgene721Implementation -> emtpy file
IArtgeneMarketplace -> emtpy file
IArtgenePlatform -> emtpy file
IERC4906 -> emtpy file
IERC721CommunityImplementation -> emtpy file
IERC721Community -> emtpy file
INFTURIExtension -> emtpy file
INFTExtension -> emtpy file
IRenderer -> emtpy file
AAFactory -> Bytecode Hash: 0100004f85b5183dd0f10e036e1405c079e2ca5e32cda128d7655bb29f45173a
Compiled Successfully
```

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
