### PR TITLE
feat(VanityArgs): add `--save-path` option for custom wallet file path specification

### DIFF
--- a/crates/cast/bin/cmd/wallet/vanity.rs
+++ b/crates/cast/bin/cmd/wallet/vanity.rs
@@ -395,4 +395,21 @@ mod tests {
         let addr = format!("{addr:x}");
         assert!(addr.ends_with("00"));
     }
+
+    #[test]
+    fn save_path() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let args: VanityArgs = VanityArgs::parse_from([
+            "foundry-cli",
+            "--starts-with",
+            "00",
+            "--save-path",
+            tmp.path().to_str().unwrap(),
+        ]);
+        args.run().unwrap();
+        assert!(tmp.path().exists());
+        let s = fs::read_to_string(tmp.path()).unwrap();
+        let wallets: Wallets = serde_json::from_str(&s).unwrap();
+        assert!(!wallets.wallets.is_empty());
+    }
 }


### PR DESCRIPTION
# What :computer: 
* Enhanced VanityArgs structure to include an optional save_path parameter with a default value, allowing users to specify a custom path for saving generated vanity addresses or use a default file.
* Added WalletData and Wallets structures to serialize wallet information into JSON format for saving.
* Implemented the logic in VanityArgs::run to generate vanity addresses based on specified prefix/suffix and to handle saving these addresses to a file.

# Why :hand:
* The optional save_path with a default value in VanityArgs makes the tool more flexible, allowing users to either choose a specific file for saving vanity addresses or rely on a default file, enhancing user convenience.
* Introduction of WalletData and Wallets structures for JSON serialization allows for a structured and readable format for storing wallet information, facilitating easier data management and retrieval.
* The updated logic in VanityArgs::run provides a comprehensive solution for generating vanity addresses and managing the storage of these addresses, streamlining the entire process for end-users.

# Evidence :camera:
Evidence showing the functionality of the new features can be provided upon request. This includes screenshots or screen recordings demonstrating:
![image](https://github.com/matter-labs/foundry-zksync/assets/120671243/ff5394ce-637c-4873-800e-06380a65927d)

