### PR TITLE
fix: updates compiler dependency to main branch, fixes artifact path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.1.1"
-source = "git+https://github.com/foundry-rs/compilers?branch=main#b1561d807c246c066c7c4b0c72c8eb64c696a43d"
+source = "git+https://github.com/foundry-rs/compilers?rev=b1561d807c246c066c7c4b0c72c8eb64c696a43d#b1561d807c246c066c7c4b0c72c8eb64c696a43d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.1.1"
-source = "git+https://github.com/Deniallugo/compilers.git?branch=main#49eaf03523e4b2853e1329d06f24d40b683d706b"
+source = "git+https://github.com/foundry-rs/compilers?branch=main#b1561d807c246c066c7c4b0c72c8eb64c696a43d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,4 +194,4 @@ revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_f
 revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 
-foundry-compilers = { git  = "https://github.com/Deniallugo/compilers.git", branch = "main", default-features = false }
+foundry-compilers = { git  = "https://github.com/foundry-rs/compilers", branch = "main", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,4 +194,4 @@ revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_f
 revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 
-foundry-compilers = { git  = "https://github.com/foundry-rs/compilers", branch = "main", default-features = false }
+foundry-compilers = { git  = "https://github.com/foundry-rs/compilers", rev = "b1561d807c246c066c7c4b0c72c8eb64c696a43d", default-features = false }

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -349,7 +349,7 @@ impl ZkSolc {
             }
         }
         let mut result = ProjectCompileOutput::default();
-        result.compiled_artifacts = Artifacts(data);
+        result.set_compiled_artifacts(Artifacts(data));
         Ok(result)
     }
 

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -149,6 +149,8 @@ impl TestArgs {
 
         // Set up the project
         let mut project = config.project()?;
+        let zk_out_path = project.paths.root.join("zkout");
+        project.paths.artifacts = zk_out_path;
 
         // install missing dependencies
         if install::install_missing_dependencies(&mut config, self.build_args().silent) &&


### PR DESCRIPTION
# What :computer: 
* Updates compilers-rs dependency to upstream main
* Makes use of set method for artifact
* Fixes artifacts path to zkout

# Why :hand:
* No longer need to make use of forked dependency to set artifacts 
* Keeps artifacts path consistent with zkforge zkbuild 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
