### PR TITLE
feat: merge cheatcodes contract interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,10 +3295,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 name = "era_cheatcodes"
 version = "0.2.0"
 dependencies = [
+ "alloy-sol-types",
  "era_test_node",
  "ethabi 18.0.0",
  "ethers",
  "eyre",
+ "foundry-cheatcodes-spec",
  "foundry-evm-core",
  "hashbrown 0.14.2",
  "hex",

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -385,8 +385,8 @@ impl ZkSolc {
         Ok(result)
     }
 
-    /// Checks if the contract has already been compiled, and if yes then returns the compiled data.
-    /// The contents will not be persisted again.
+    /// Checks if the contract has already been compiled for the given input contract hash. 
+    /// If yes, returns the pre-compiled data.
     fn check_cache(
         &self,
         artifact_paths: &ZkSolcArtifactPaths,

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -385,7 +385,7 @@ impl ZkSolc {
         Ok(result)
     }
 
-    /// Checks if the contract has already been compiled for the given input contract hash. 
+    /// Checks if the contract has already been compiled for the given input contract hash.
     /// If yes, returns the pre-compiled data.
     fn check_cache(
         &self,

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -145,7 +145,7 @@ impl fmt::Display for ZkSolc {
         write!(
             f,
             "ZkSolc (
-                compiler_path: {},   
+                compiler_path: {},
                 output_path: {},
             )",
             self.compiler_path.display(),
@@ -385,8 +385,8 @@ impl ZkSolc {
         Ok(result)
     }
 
-    /// Checks if the contract has already been compiled for the given input contract hash.
-    /// If yes, returns the pre-compiled data.
+    /// Checks if the contract has already been compiled, and if yes then returns the compiled data.
+    /// The contents will not be persisted again.
     fn check_cache(
         &self,
         artifact_paths: &ZkSolcArtifactPaths,

--- a/crates/era-cheatcodes/Cargo.toml
+++ b/crates/era-cheatcodes/Cargo.toml
@@ -20,6 +20,8 @@ multivm.workspace = true
 zksync_web3_decl.workspace = true
 zksync_utils.workspace = true
 foundry-evm-core.workspace = true
+foundry-cheatcodes-spec.workspace = true
+alloy-sol-types = { workspace = true, features = ["json"] }
 
 ethabi = "18.0.0"
 itertools = "0.12.0"
@@ -31,4 +33,3 @@ tracing = { version = "0.1.26", features = ["log"] }
 ethers = { version = "2.0.4", features = ["rustls"] }
 hashbrown = { version = "0.14" }
 maplit = "1.0.2"
-

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -1,12 +1,15 @@
+use crate::utils::{ToH160, ToH256};
+use alloy_sol_types::SolInterface;
 use era_test_node::{fork::ForkStorage, utils::bytecode_to_factory_dep};
-use ethers::{abi::AbiDecode, prelude::abigen, utils::to_checksum};
+use ethers::utils::to_checksum;
+use foundry_cheatcodes_spec::Vm;
 use foundry_evm_core::{backend::DatabaseExt, era_revm::db::RevmDatabaseForEra};
 use itertools::Itertools;
 use multivm::{
     interface::{dyn_tracers::vm_1_3_3::DynTracer, tracer::TracerExecutionStatus},
     vm_refunds_enhancement::{BootloaderState, HistoryMode, SimpleMemory, VmTracer, ZkSyncVmState},
     zk_evm_1_3_3::{
-        tracing::{BeforeExecutionData, VmLocalStateData},
+        tracing::{AfterExecutionData, VmLocalStateData},
         vm_state::PrimitiveValue,
         zkevm_opcode_defs::{
             FatPointer, Opcode, CALL_IMPLICIT_CALLDATA_FAT_PTR_REGISTER,
@@ -15,7 +18,7 @@ use multivm::{
     },
 };
 use std::{cell::RefMut, collections::HashMap, fmt::Debug};
-use zksync_basic_types::{AccountTreeId, Address, H160, H256, U256};
+use zksync_basic_types::{AccountTreeId, H160, H256, U256};
 use zksync_state::{ReadStorage, StoragePtr, StorageView, WriteStorage};
 use zksync_types::{
     block::{pack_block_info, unpack_block_info},
@@ -55,33 +58,6 @@ const INTERNAL_CONTRACT_ADDRESSES: [H160; 20] = [
     H160::zero(),
 ];
 
-abigen!(
-    CheatcodeContract,
-    r#"[
-        function addr(uint256 privateKey)
-        function deal(address who, uint256 newBalance)
-        function etch(address who, bytes calldata code)
-        function getNonce(address account)
-        function load(address account, bytes32 slot)
-        function roll(uint256 blockNumber)
-        function serializeAddress(string objectKey, string valueKey, address value)
-        function serializeBool(string objectKey, string valueKey, bool value)
-        function serializeUint(string objectKey, string valueKey, uint256 value)
-        function setNonce(address account, uint64 nonce)
-        function store(address account, bytes32 slot, bytes32 value)
-        function startPrank(address sender)
-        function startPrank(address sender, address origin)
-        function stopPrank()
-        function toString(address value)
-        function toString(bool value)
-        function toString(uint256 value)
-        function toString(int256 value)
-        function toString(bytes32 value)
-        function toString(bytes value)
-        function warp(uint256 timestamp)
-    ]"#
-);
-
 #[derive(Debug, Default, Clone)]
 pub struct CheatcodeTracer {
     one_time_actions: Vec<FinishCycleOneTimeActions>,
@@ -112,16 +88,35 @@ struct StartPrankOpts {
 impl<S: DatabaseExt + Send, H: HistoryMode> DynTracer<EraDb<S>, SimpleMemory<H>>
     for CheatcodeTracer
 {
-    fn before_execution(
+    fn after_execution(
         &mut self,
         state: VmLocalStateData<'_>,
-        data: BeforeExecutionData,
+        data: multivm::zk_evm_1_3_3::tracing::AfterExecutionData,
         memory: &SimpleMemory<H>,
         storage: StoragePtr<EraDb<S>>,
     ) {
+        if self.return_data.is_some() {
+            if let Opcode::Ret(_call) = data.opcode.variant.opcode {
+                if self.near_calls == 0 {
+                    let ptr = state.vm_local_state.registers
+                        [RET_IMPLICIT_RETURNDATA_PARAMS_REGISTER as usize];
+                    let fat_data_pointer = FatPointer::from_u256(ptr.value);
+                    self.return_ptr = Some(fat_data_pointer);
+                } else {
+                    self.near_calls = self.near_calls.saturating_sub(1);
+                }
+            }
+        }
+
         if let Opcode::NearCall(_call) = data.opcode.variant.opcode {
+            if self.return_data.is_some() {
+                self.near_calls += 1;
+            }
+        }
+
+        if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
             let current = state.vm_local_state.callstack.current;
-            if current.this_address != CHEATCODE_ADDRESS {
+            if current.code_address != CHEATCODE_ADDRESS {
                 return
             }
             if current.code_page.0 == 0 || current.ergs_remaining == 0 {
@@ -142,40 +137,13 @@ impl<S: DatabaseExt + Send, H: HistoryMode> DynTracer<EraDb<S>, SimpleMemory<H>>
             };
 
             // try to dispatch the cheatcode
-            if let Ok(call) = CheatcodeContractCalls::decode(calldata.clone()) {
-                self.dispatch_cheatcode(state, data, memory, storage, call)
+            if let Ok(call) = Vm::VmCalls::abi_decode(&calldata, true) {
+                self.dispatch_cheatcode(state, data, memory, storage, call);
             } else {
                 tracing::error!(
-                    "Failed to decode cheatcode calldata (near call): {}",
+                    "Failed to decode cheatcode calldata (far call): {}",
                     hex::encode(calldata),
                 );
-            }
-        }
-    }
-
-    fn after_execution(
-        &mut self,
-        state: VmLocalStateData<'_>,
-        data: multivm::zk_evm_1_3_3::tracing::AfterExecutionData,
-        _memory: &SimpleMemory<H>,
-        _storage: StoragePtr<EraDb<S>>,
-    ) {
-        if self.return_data.is_some() {
-            if let Opcode::Ret(_call) = data.opcode.variant.opcode {
-                if self.near_calls == 0 {
-                    let ptr = state.vm_local_state.registers
-                        [RET_IMPLICIT_RETURNDATA_PARAMS_REGISTER as usize];
-                    let fat_data_pointer = FatPointer::from_u256(ptr.value);
-                    self.return_ptr = Some(fat_data_pointer);
-                } else {
-                    self.near_calls = self.near_calls.saturating_sub(1);
-                }
-            }
-        }
-
-        if let Opcode::NearCall(_call) = data.opcode.variant.opcode {
-            if self.return_data.is_some() {
-                self.near_calls += 1;
             }
         }
     }
@@ -252,42 +220,43 @@ impl CheatcodeTracer {
     pub fn dispatch_cheatcode<S: DatabaseExt + Send, H: HistoryMode>(
         &mut self,
         _state: VmLocalStateData<'_>,
-        _data: BeforeExecutionData,
+        _data: AfterExecutionData,
         _memory: &SimpleMemory<H>,
         storage: StoragePtr<EraDb<S>>,
-        call: CheatcodeContractCalls,
+        call: Vm::VmCalls,
     ) {
-        use CheatcodeContractCalls::*;
+        use Vm::{VmCalls::*, *};
+
         match call {
-            Addr(AddrCall { private_key }) => {
+            addr(addrCall { privateKey: private_key }) => {
                 tracing::info!("👷 Getting address for private key");
                 let Ok(address) = zksync_types::PackedEthSignature::address_from_private_key(
-                    &u256_to_h256(private_key),
+                    &private_key.to_h256(),
                 ) else {
                     tracing::error!("Failed generating address for private key");
                     return
                 };
                 self.return_data = Some(vec![h256_to_u256(address.into())]);
             }
-            Deal(DealCall { who, new_balance }) => {
-                tracing::info!("👷 Setting balance for {who:?} to {new_balance}");
+            deal(dealCall { account, newBalance: new_balance }) => {
+                tracing::info!("👷 Setting balance for {account:?} to {new_balance}");
                 self.write_storage(
-                    storage_key_for_eth_balance(&who),
-                    u256_to_h256(new_balance),
+                    storage_key_for_eth_balance(&account.to_h160()),
+                    new_balance.to_h256(),
                     &mut storage.borrow_mut(),
                 );
             }
-            Etch(EtchCall { who, code }) => {
-                tracing::info!("👷 Setting address code for {who:?}");
-                let code_key = get_code_key(&who);
-                let (hash, code) = bytecode_to_factory_dep(code.0.into());
+            etch(etchCall { target, newRuntimeBytecode: new_runtime_bytecode }) => {
+                tracing::info!("👷 Setting address code for {target:?}");
+                let code_key = get_code_key(&target.to_h160());
+                let (hash, code) = bytecode_to_factory_dep(new_runtime_bytecode);
                 self.store_factory_dep(hash, code);
                 self.write_storage(code_key, u256_to_h256(hash), &mut storage.borrow_mut());
             }
-            GetNonce(GetNonceCall { account }) => {
+            getNonce_0(getNonce_0Call { account }) => {
                 tracing::info!("👷 Getting nonce for {account:?}");
                 let mut storage = storage.borrow_mut();
-                let nonce_key = get_nonce_key(&account);
+                let nonce_key = get_nonce_key(&account.to_h160());
                 let full_nonce = storage.read_value(&nonce_key);
                 let (account_nonce, _) = decompose_full_nonce(h256_to_u256(full_nonce));
                 tracing::info!(
@@ -299,16 +268,15 @@ impl CheatcodeTracer {
                 tracing::info!("👷 Returndata is {:?}", account_nonce);
                 self.return_data = Some(vec![account_nonce]);
             }
-            Load(LoadCall { account, slot }) => {
-                tracing::info!("👷 Getting storage slot {:?} for account {:?}", slot, account);
-                let key = StorageKey::new(AccountTreeId::new(account), H256(slot));
+            load(loadCall { target, slot }) => {
+                tracing::info!("👷 Getting storage slot {:?} for account {:?}", slot, target);
+                let key = StorageKey::new(AccountTreeId::new(target.to_h160()), H256(*slot));
                 let mut storage = storage.borrow_mut();
                 let value = storage.read_value(&key);
                 self.return_data = Some(vec![h256_to_u256(value)]);
             }
-            Roll(RollCall { block_number }) => {
-                tracing::info!("👷 Setting block number to {}", block_number);
-
+            roll(rollCall { newHeight: new_height }) => {
+                tracing::info!("👷 Setting block number to {}", new_height);
                 let key = StorageKey::new(
                     AccountTreeId::new(zksync_types::SYSTEM_CONTEXT_ADDRESS),
                     zksync_types::CURRENT_VIRTUAL_BLOCK_INFO_POSITION,
@@ -318,11 +286,15 @@ impl CheatcodeTracer {
                     unpack_block_info(h256_to_u256(storage.read_value(&key)));
                 self.write_storage(
                     key,
-                    u256_to_h256(pack_block_info(block_number.as_u64(), block_timestamp)),
+                    u256_to_h256(pack_block_info(new_height.as_limbs()[0], block_timestamp)),
                     &mut storage,
                 );
             }
-            SerializeAddress(SerializeAddressCall { object_key, value_key, value }) => {
+            serializeAddress_0(serializeAddress_0Call {
+                objectKey: object_key,
+                valueKey: value_key,
+                value,
+            }) => {
                 tracing::info!(
                     "👷 Serializing address {:?} with key {:?} to object {:?}",
                     value,
@@ -336,11 +308,14 @@ impl CheatcodeTracer {
                 //write to serialized_objects
                 self.serialized_objects.insert(object_key.clone(), json_value.to_string());
 
-                let address = Address::from(value);
-                let address_with_checksum = to_checksum(&address, None);
+                let address_with_checksum = to_checksum(&value.to_h160(), None);
                 self.add_trimmed_return_data(address_with_checksum.as_bytes());
             }
-            SerializeBool(SerializeBoolCall { object_key, value_key, value }) => {
+            serializeBool_0(serializeBool_0Call {
+                objectKey: object_key,
+                valueKey: value_key,
+                value,
+            }) => {
                 tracing::info!(
                     "👷 Serializing bool {:?} with key {:?} to object {:?}",
                     value,
@@ -356,7 +331,11 @@ impl CheatcodeTracer {
                 let bool_value = value.to_string();
                 self.add_trimmed_return_data(bool_value.as_bytes());
             }
-            SerializeUint(SerializeUintCall { object_key, value_key, value }) => {
+            serializeUint_0(serializeUint_0Call {
+                objectKey: object_key,
+                valueKey: value_key,
+                value,
+            }) => {
                 tracing::info!(
                     "👷 Serializing uint256 {:?} with key {:?} to object {:?}",
                     value,
@@ -372,52 +351,59 @@ impl CheatcodeTracer {
                 let uint_value = value.to_string();
                 self.add_trimmed_return_data(uint_value.as_bytes());
             }
-            SetNonce(SetNonceCall { account, nonce }) => {
-                tracing::info!("👷 Setting nonce for {account:?} to {nonce}");
+            setNonce(setNonceCall { account, newNonce: new_nonce }) => {
+                tracing::info!("👷 Setting nonce for {account:?} to {new_nonce}");
                 let mut storage = storage.borrow_mut();
-                let nonce_key = get_nonce_key(&account);
+                let nonce_key = get_nonce_key(&account.to_h160());
                 let full_nonce = storage.read_value(&nonce_key);
                 let (mut account_nonce, mut deployment_nonce) =
                     decompose_full_nonce(h256_to_u256(full_nonce));
-                if account_nonce.as_u64() >= nonce {
+                if account_nonce.as_u64() >= new_nonce {
                     tracing::error!(
                       "SetNonce cheatcode failed: Account nonce is already set to a higher value ({}, requested {})",
                       account_nonce,
-                      nonce
+                      new_nonce
                   );
                     return
                 }
-                account_nonce = nonce.into();
-                if deployment_nonce.as_u64() >= nonce {
+                account_nonce = new_nonce.into();
+                if deployment_nonce.as_u64() >= new_nonce {
                     tracing::error!(
                       "SetNonce cheatcode failed: Deployment nonce is already set to a higher value ({}, requested {})",
                       deployment_nonce,
-                      nonce
+                      new_nonce
                   );
                     return
                 }
-                deployment_nonce = nonce.into();
+                deployment_nonce = new_nonce.into();
                 let enforced_full_nonce = nonces_to_full_nonce(account_nonce, deployment_nonce);
-                tracing::info!("👷 Nonces for account {:?} have been set to {}", account, nonce);
+                tracing::info!(
+                    "👷 Nonces for account {:?} have been set to {}",
+                    account,
+                    new_nonce
+                );
                 self.write_storage(nonce_key, u256_to_h256(enforced_full_nonce), &mut storage);
             }
-            StartPrank(StartPrankCall { sender }) => {
-                tracing::info!("👷 Starting prank to {sender:?}");
-                self.permanent_actions.start_prank = Some(StartPrankOpts { sender, origin: None });
+            startPrank_0(startPrank_0Call { msgSender: msg_sender }) => {
+                tracing::info!("👷 Starting prank to {msg_sender:?}");
+                self.permanent_actions.start_prank =
+                    Some(StartPrankOpts { sender: msg_sender.to_h160(), origin: None });
             }
-            StartPrankWithOrigin(StartPrankWithOriginCall { sender, origin }) => {
-                tracing::info!("👷 Starting prank to {sender:?} with origin {origin:?}");
+            startPrank_1(startPrank_1Call { msgSender: msg_sender, txOrigin: tx_origin }) => {
+                tracing::info!("👷 Starting prank to {msg_sender:?} with origin {tx_origin:?}");
                 let key = StorageKey::new(
                     AccountTreeId::new(zksync_types::SYSTEM_CONTEXT_ADDRESS),
                     zksync_types::SYSTEM_CONTEXT_TX_ORIGIN_POSITION,
                 );
                 let original_tx_origin = storage.borrow_mut().read_value(&key);
-                self.write_storage(key, origin.into(), &mut storage.borrow_mut());
+                self.write_storage(key, tx_origin.to_h160().into(), &mut storage.borrow_mut());
 
-                self.permanent_actions.start_prank =
-                    Some(StartPrankOpts { sender, origin: Some(original_tx_origin) });
+                self.permanent_actions.start_prank = Some(StartPrankOpts {
+                    sender: msg_sender.to_h160(),
+                    origin: Some(original_tx_origin),
+                });
             }
-            StopPrank(StopPrankCall) => {
+            stopPrank(stopPrankCall {}) => {
                 tracing::info!("👷 Stopping prank");
 
                 if let Some(origin) =
@@ -432,50 +418,49 @@ impl CheatcodeTracer {
 
                 self.permanent_actions.start_prank = None;
             }
-            Store(StoreCall { account, slot, value }) => {
+            store(storeCall { target, slot, value }) => {
                 tracing::info!(
                     "👷 Setting storage slot {:?} for account {:?} to {:?}",
                     slot,
-                    account,
+                    target,
                     value
                 );
                 let mut storage = storage.borrow_mut();
-                let key = StorageKey::new(AccountTreeId::new(account), H256(slot));
-                self.write_storage(key, H256(value), &mut storage);
+                let key = StorageKey::new(AccountTreeId::new(target.to_h160()), H256(*slot));
+                self.write_storage(key, H256(*value), &mut storage);
             }
-            ToString0(ToString0Call { value }) => {
+            toString_0(toString_0Call { value }) => {
                 tracing::info!("Converting address into string");
-                let address = Address::from(value);
-                let address_with_checksum = to_checksum(&address, None);
+                let address_with_checksum = to_checksum(&value.to_h160(), None);
                 self.add_trimmed_return_data(address_with_checksum.as_bytes());
             }
-            ToString1(ToString1Call { value }) => {
-                tracing::info!("Converting bool into string");
-                let bool_value = value.to_string();
-                self.add_trimmed_return_data(bool_value.as_bytes());
-            }
-            ToString2(ToString2Call { value }) => {
-                tracing::info!("Converting uint256 into string");
-                let uint_value = value.to_string();
-                self.add_trimmed_return_data(uint_value.as_bytes());
-            }
-            ToString3(ToString3Call { value }) => {
-                tracing::info!("Converting int256 into string");
-                let int_value = value.to_string();
-                self.add_trimmed_return_data(int_value.as_bytes());
-            }
-            ToString4(ToString4Call { value }) => {
-                tracing::info!("Converting bytes32 into string");
-                let bytes_value = format!("0x{}", hex::encode(value));
-                self.add_trimmed_return_data(bytes_value.as_bytes());
-            }
-            ToString5(ToString5Call { value }) => {
+            toString_1(toString_1Call { value }) => {
                 tracing::info!("Converting bytes into string");
                 let bytes_value = format!("0x{}", hex::encode(value));
                 self.add_trimmed_return_data(bytes_value.as_bytes());
             }
-            Warp(WarpCall { timestamp }) => {
-                tracing::info!("👷 Setting block timestamp {}", timestamp);
+            toString_2(toString_2Call { value }) => {
+                tracing::info!("Converting bytes32 into string");
+                let bytes_value = format!("0x{}", hex::encode(value));
+                self.add_trimmed_return_data(bytes_value.as_bytes());
+            }
+            toString_3(toString_3Call { value }) => {
+                tracing::info!("Converting bool into string");
+                let bool_value = value.to_string();
+                self.add_trimmed_return_data(bool_value.as_bytes());
+            }
+            toString_4(toString_4Call { value }) => {
+                tracing::info!("Converting uint256 into string");
+                let uint_value = value.to_string();
+                self.add_trimmed_return_data(uint_value.as_bytes());
+            }
+            toString_5(toString_5Call { value }) => {
+                tracing::info!("Converting int256 into string");
+                let int_value = value.to_string();
+                self.add_trimmed_return_data(int_value.as_bytes());
+            }
+            warp(warpCall { newTimestamp: new_timestamp }) => {
+                tracing::info!("👷 Setting block timestamp {}", new_timestamp);
 
                 let key = StorageKey::new(
                     AccountTreeId::new(zksync_types::SYSTEM_CONTEXT_ADDRESS),
@@ -485,9 +470,12 @@ impl CheatcodeTracer {
                 let (block_number, _) = unpack_block_info(h256_to_u256(storage.read_value(&key)));
                 self.write_storage(
                     key,
-                    u256_to_h256(pack_block_info(block_number, timestamp.as_u64())),
+                    u256_to_h256(pack_block_info(block_number, new_timestamp.as_limbs()[0])),
                     &mut storage,
                 );
+            }
+            _ => {
+                tracing::error!("👷 Unrecognized cheatcode");
             }
         };
     }

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -91,7 +91,7 @@ impl<S: DatabaseExt + Send, H: HistoryMode> DynTracer<EraDb<S>, SimpleMemory<H>>
     fn after_execution(
         &mut self,
         state: VmLocalStateData<'_>,
-        data: multivm::zk_evm_1_3_3::tracing::AfterExecutionData,
+        data: AfterExecutionData,
         memory: &SimpleMemory<H>,
         storage: StoragePtr<EraDb<S>>,
     ) {

--- a/crates/era-cheatcodes/src/lib.rs
+++ b/crates/era-cheatcodes/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod cheatcodes;
+mod utils;

--- a/crates/era-cheatcodes/src/utils.rs
+++ b/crates/era-cheatcodes/src/utils.rs
@@ -1,0 +1,33 @@
+use revm::primitives::{ruint::Uint, Address};
+use zksync_basic_types::{H160, H256, U256};
+use zksync_utils::u256_to_h256;
+
+pub trait ToU256 {
+    fn to_u256(&self) -> U256;
+}
+
+impl ToU256 for Uint<256, 4> {
+    fn to_u256(&self) -> U256 {
+        U256(self.into_limbs())
+    }
+}
+
+pub trait ToH256 {
+    fn to_h256(&self) -> H256;
+}
+
+impl ToH256 for Uint<256, 4> {
+    fn to_h256(&self) -> H256 {
+        u256_to_h256(self.to_u256())
+    }
+}
+
+pub trait ToH160 {
+    fn to_h160(&self) -> H160;
+}
+
+impl ToH160 for Address {
+    fn to_h160(&self) -> H160 {
+        H160::from_slice(self.as_slice())
+    }
+}


### PR DESCRIPTION
# What :computer: 
* Uses contract interface defined in the cheatcodes spec for era-cheatcodes.

# Why :hand:
* Reduces code duplication
* Prevents diverging interfaces

# Evidence :camera:
![image](https://github.com/matter-labs/foundry-zksync/assets/21188659/df1cc37a-b9e7-4034-ac36-c1d523a8f4fd)
