### PR TITLE
fix: addresses compilation paths issue and correctly compiles all project files

### DIFF
--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -578,7 +578,7 @@ impl ZkSolc {
                 for (contract_name, contract) in contracts_in_file {
                     // if contract hash is empty, skip
                     if contract.hash.is_none() {
-                        println!("{} -> empty contract.hash", contract_name);
+                        trace!("{} -> empty contract.hash", contract_name);
                         continue
                     }
 
@@ -944,8 +944,8 @@ impl ZkSolc {
     /// The versioned sources can then be used for further processing or analysis.
     fn get_versioned_sources(&mut self) -> Result<BTreeMap<Solc, SolidityVersionSources>> {
         // Step 1: Retrieve Project Sources
-        let sources = self.project.sources().wrap_err("Could not get project sources")?;
-
+        let sources = self.project.paths.read_input_files()?;
+        
         // Step 2: Resolve Graph of Sources and Versions
         let graph = Graph::resolve_sources(&self.project.paths, sources)
             .wrap_err("Could not resolve sources")?;

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -40,11 +40,9 @@ use foundry_compilers::{
         output_selection::FileOutputSelection, CompactBytecode, CompactDeployedBytecode, Source,
         StandardJsonCompilerInput,
     },
-    remappings::RelativeRemapping,
     ArtifactFile, Artifacts, ConfigurableContractArtifact, Graph, Project, ProjectCompileOutput,
     Solc,
 };
-use regex::Regex;
 use semver::Version;
 use serde::Deserialize;
 use serde_json::Value;
@@ -80,7 +78,6 @@ pub struct ZkSolcOpts {
     pub compiler_path: PathBuf,
     pub is_system: bool,
     pub force_evmla: bool,
-    pub remappings: Vec<RelativeRemapping>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -162,7 +159,6 @@ pub struct ZkSolc {
     is_system: bool,
     force_evmla: bool,
     standard_json: Option<StandardJsonCompilerInput>,
-    remappings: Vec<RelativeRemapping>,
 }
 
 impl fmt::Display for ZkSolc {
@@ -193,13 +189,11 @@ pub fn compile_smart_contracts(
     is_legacy: bool,
     zksolc_manager: ZkSolcManager,
     project: Project,
-    remappings: Vec<RelativeRemapping>,
 ) -> eyre::Result<()> {
     let zksolc_opts = ZkSolcOpts {
         compiler_path: zksolc_manager.get_full_compiler_path(),
         is_system,
         force_evmla: is_legacy,
-        remappings,
     };
 
     let mut zksolc = ZkSolc::new(zksolc_opts, project);
@@ -223,7 +217,6 @@ impl ZkSolc {
             is_system: opts.is_system,
             force_evmla: opts.force_evmla,
             standard_json: None,
-            remappings: opts.remappings,
         }
     }
 
@@ -833,7 +826,7 @@ impl ZkSolc {
             .insert("*".to_string(), file_output_selection.clone());
 
         // Step 4: Generate Standard JSON Input
-        let mut standard_json = self
+        let standard_json = self
             .project
             .standard_json_input(contract_path)
             .wrap_err("Could not get standard json input")

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -309,17 +309,18 @@ impl ZkSolc {
 
         // Step 2: Compile Contracts for Each Source
         for (_solc, version) in sources {
+            info!("\nCompiling {} files...", version.1.len());
             //configure project solc for each solc version
             for (contract_path, _) in version.1 {
                 // Check if the contract_path is in 'sources' directory or its subdirectories
-                let is_in_sources_dir = contract_path
-                    .ancestors()
-                    .any(|ancestor| ancestor.starts_with(&self.project.paths.sources));
+                // let is_in_sources_dir = contract_path
+                //     .ancestors()
+                //     .any(|ancestor| ancestor.starts_with(&self.project.paths.sources));
 
-                // Skip this file if it's not in the 'sources' directory or its subdirectories
-                if !is_in_sources_dir {
-                    continue
-                }
+                // // Skip this file if it's not in the 'sources' directory or its subdirectories
+                // if !is_in_sources_dir {
+                //     continue
+                // }
 
                 // Step 3: Parse JSON Input for each Source
                 self.prepare_compiler_input(&contract_path).wrap_err(format!(

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -206,7 +206,7 @@ pub fn compile_smart_contracts(
 
     match zksolc.compile() {
         Ok(_) => {
-            println!("Compiled Successfully");
+            info!("Compiled Successfully");
             Ok(())
         }
         Err(err) => {

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -206,7 +206,7 @@ pub fn compile_smart_contracts(
 
     match zksolc.compile() {
         Ok(_) => {
-            info!("Compiled Successfully");
+            println!("Compiled Successfully");
             Ok(())
         }
         Err(err) => {
@@ -312,13 +312,22 @@ impl ZkSolc {
             info!("\nCompiling {} files...", version.1.len());
             //configure project solc for each solc version
             for (contract_path, _) in version.1 {
+
                 // Check if the contract_path is in 'sources' directory or its subdirectories
                 // let is_in_sources_dir = contract_path
                 //     .ancestors()
                 //     .any(|ancestor| ancestor.starts_with(&self.project.paths.sources));
 
-                // // Skip this file if it's not in the 'sources' directory or its subdirectories
-                // if !is_in_sources_dir {
+                // let is_in_tests_dir = contract_path
+                //     .ancestors()
+                //     .any(|ancestor| ancestor.starts_with(&self.project.paths.tests));
+
+                // let is_in_scripts_dir = contract_path
+                //     .ancestors()
+                //     .any(|ancestor| ancestor.starts_with(&self.project.paths.scripts));
+
+                // // // Skip this file if it's not in the 'sources' directory or its subdirectories
+                // if !is_in_sources_dir && !is_in_tests_dir && !is_in_scripts_dir {
                 //     continue
                 // }
 
@@ -946,7 +955,7 @@ impl ZkSolc {
     fn get_versioned_sources(&mut self) -> Result<BTreeMap<Solc, SolidityVersionSources>> {
         // Step 1: Retrieve Project Sources
         let sources = self.project.paths.read_input_files()?;
-        
+
         // Step 2: Resolve Graph of Sources and Versions
         let graph = Graph::resolve_sources(&self.project.paths, sources)
             .wrap_err("Could not resolve sources")?;

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -173,7 +173,6 @@ impl TestArgs {
             compiler_path: zksolc_manager.get_full_compiler_path(),
             is_system: false,
             force_evmla: false,
-            remappings: config.remappings.clone(),
         };
 
         let mut zksolc = ZkSolc::new(zksolc_opts, project);

--- a/crates/zkforge/bin/cmd/zk_build.rs
+++ b/crates/zkforge/bin/cmd/zk_build.rs
@@ -169,7 +169,6 @@ impl ZkBuildArgs {
         }
 
         let zksolc_manager = setup_zksolc_manager(self.use_zksolc.clone())?;
-        let remappings = config.remappings;
 
         // TODO: add filter support
 
@@ -178,7 +177,6 @@ impl ZkBuildArgs {
             self.force_evmla,
             zksolc_manager,
             project,
-            remappings,
         )
     }
     /// Returns the `Project` for the current workspace


### PR DESCRIPTION
# What :computer: 
* Fixes compilation paths issue 
* Compiles all project files in src / tests / scripts. Previously we were only compiling contracts in `/src`. 

# Why :hand:
* Can successfully compile nested contracts in `/lib` and no longer rely on hacky regex 
* Contracts in scripts and tests were not being correctly compiled 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
The one caveat, is now that we are compiling all contract files, in larger projects with 200+ contracts it takes a while to compile. This can be remedied when a long-term refactor of `zk_compile.rs` is done. 