### PR TITLE
fix: resolve CompilerArgs correctly for toml configuration

### DIFF
--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -53,6 +53,7 @@ pub struct CompilerArgs {
         long = "is-system",
         value_name = "SYSTEM_MODE"
     )]
+    #[serde(skip)]
     pub is_system: bool,
 
     /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
@@ -62,6 +63,7 @@ pub struct CompilerArgs {
         long = "force-evmla",
         value_name = "FORCE_EVMLA"
     )]
+    #[serde(skip)]
     pub force_evmla: bool,
 
     /// Try to recompile with -Oz if the bytecode is too large.
@@ -70,6 +72,7 @@ pub struct CompilerArgs {
         long = "fallback-oz",
         value_name = "FALLBACK_OZ"
     )]
+    #[serde(skip)]
     pub fallback_oz: bool,
 
     #[clap(help_heading = "zkSync Compiler options", long = "detect-missing-libraries")]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -411,7 +411,7 @@ pub struct Config {
     pub is_system: bool,
     /// Force evmla for zkSync
     pub force_evmla: bool,
-    // Path to cache missing library dependencies, used for compiling and deploying libraries.
+    /// Path to cache missing library dependencies, used for compiling and deploying libraries.
     pub detect_missing_libraries: bool,
 }
 
@@ -1652,7 +1652,7 @@ impl From<Config> for Figment {
                 .cached(),
             profile.clone(),
         );
-        
+
         // merge environment variables
         figment = figment
             .merge(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -411,6 +411,8 @@ pub struct Config {
     pub is_system: bool,
     /// Force evmla for zkSync
     pub force_evmla: bool,
+    // Path to cache missing library dependencies, used for compiling and deploying libraries.
+    pub detect_missing_libraries: bool,
 }
 
 /// Mapping of fallback standalone sections. See [`FallbackProfileProvider`]
@@ -1650,7 +1652,6 @@ impl From<Config> for Figment {
                 .cached(),
             profile.clone(),
         );
-
         // merge environment variables
         figment = figment
             .merge(
@@ -1923,6 +1924,7 @@ impl Default for Config {
             fallback_oz: false,
             force_evmla: false,
             is_system: false,
+            detect_missing_libraries: false,
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1652,6 +1652,7 @@ impl From<Config> for Figment {
                 .cached(),
             profile.clone(),
         );
+        
         // merge environment variables
         figment = figment
             .merge(

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -125,6 +125,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         fallback_oz: false,
         force_evmla: false,
         is_system: false,
+        detect_missing_libraries: false,
     };
     prj.write_config(input.clone());
     let config = cmd.config();

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -149,10 +149,11 @@ impl TestArgs {
 
         // Set up the project
         let mut project = config.project()?;
+        // load the zkSolc config
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
         let zk_out_path = project.paths.root.join("zkout");
         project.paths.artifacts = zk_out_path;
-        
+
         // install missing dependencies
         if install::install_missing_dependencies(&mut config, self.build_args().silent) &&
             config.auto_detect_remappings

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -150,7 +150,9 @@ impl TestArgs {
         // Set up the project
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
-
+        let zk_out_path = project.paths.root.join("zkout");
+        project.paths.artifacts = zk_out_path;
+        
         // install missing dependencies
         if install::install_missing_dependencies(&mut config, self.build_args().silent) &&
             config.auto_detect_remappings

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -150,8 +150,6 @@ impl TestArgs {
         // Set up the project
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
-        let zk_out_path = project.paths.root.join("zkout");
-        project.paths.artifacts = zk_out_path;
 
         // install missing dependencies
         if install::install_missing_dependencies(&mut config, self.build_args().silent) &&

--- a/crates/zkforge/bin/cmd/zk_build.rs
+++ b/crates/zkforge/bin/cmd/zk_build.rs
@@ -125,6 +125,10 @@ impl ZkBuildArgs {
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
 
+        //set zk out path
+        let zk_out_path = project.paths.root.join("zkout");
+        project.paths.artifacts = zk_out_path;
+
         if install::install_missing_dependencies(&mut config, self.args.silent) &&
             config.auto_detect_remappings
         {

--- a/crates/zkforge/bin/cmd/zk_build.rs
+++ b/crates/zkforge/bin/cmd/zk_build.rs
@@ -125,10 +125,6 @@ impl ZkBuildArgs {
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
 
-        //set zk out path
-        let zk_out_path = project.paths.root.join("zkout");
-        project.paths.artifacts = zk_out_path;
-
         if install::install_missing_dependencies(&mut config, self.args.silent) &&
             config.auto_detect_remappings
         {

--- a/crates/zkforge/tests/cli/config.rs
+++ b/crates/zkforge/tests/cli/config.rs
@@ -125,6 +125,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         fallback_oz: false,
         force_evmla: false,
         is_system: false,
+        detect_missing_libraries: false,
     };
     prj.write_config(input.clone());
     let config = cmd.config();


### PR DESCRIPTION
# What :computer: 
* Fix issue with using foundry.toml for zksolc configuration

# Why :hand:
* There was an issue with deserialization which caused the configurations from the toml to revert to default values

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

Can make use of `foundry.toml` for zksolc configuration like so:

```
[profile.default]
src = 'src'
out = 'out'
libs = ['lib']

[profile.zksync]
src = 'src'
libs = ['lib']
zk_optimizer = true
fallback_oz = true
```
Run with:
`FOUNDRY_PROFILE=zksync zkforge zkbuild`

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
