### PR TITLE
fix: resolve issue with setting zksolc configuration values in .toml and update readme / docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Please note that `foundry-zksync` is still in its **alpha** stage. Some features
 While `foundry-zksync` is **in-development**, there are some limitations to be aware of:
 
 - **Cheat Codes Support**: Not all cheat codes are fully supported. [View the list of supported cheat codes](./SUPPORTED_CHEATCODES.md).
-- **Script Command**: The `script` command is currently a work in progress.
 - **Compile Time**: Some users may experience slower compile times.
 - **Compiling Libraries**: Compiling non-inlinable libraries requires deployment and adding to configuration like so:
     ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ While `foundry-zksync` is **in-development**, there are some limitations to be a
 - **Cheat Codes Support**: Not all cheat codes are fully supported. [View the list of supported cheat codes](./SUPPORTED_CHEATCODES.md).
 - **Script Command**: The `script` command is currently a work in progress.
 - **Compile Time**: Some users may experience slower compile times.
-- **Compiling Libraries**: Compiling non-inlinable libraries requires deployment. [Learn more](https://era.zksync.io/docs/tools/hardhat/compiling-libraries.html).
+- **Compiling Libraries**: Compiling non-inlinable libraries requires deployment and adding to configuration like so:
+    ```
+    libraries = [
+        "src/MyLibrary.sol:MyLibrary:0xfD88CeE74f7D78697775aBDAE53f9Da1559728E4"
+    ]
+    ```
+[Learn more](https://era.zksync.io/docs/tools/hardhat/compiling-libraries.html).
 - **Create2 Address Derivation**: There are differences in Create2 Address derivation compared to Ethereum. [Read the details](https://era.zksync.io/docs/reference/architecture/differences-with-ethereum.html#create-create2).
 
 For the most effective use of our library, we recommend familiarizing yourself with these features and limitations. 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Foundry consists of:
 
 Need help getting started with Foundry? Read the 📖 [Foundry Book](https://book.getfoundry.sh/) (WIP)!
 
-Foundry-zkSync adds:
+### Foundry-zkSync adds:
 
-- **zkForge:** zkSync testing framework (like Truffle, Hardhat and DappTools).
+- **zkForge:** zkSync testing framework (like Hardhat and DappTools).
 - **zkCast:** Swiss army knife for interacting with zkEVM smart contracts, sending transactions and getting chain data.
 
 Need help getting started with **Foundry-zkSync**? Read the 📖 [Usage Guides](./docs/dev/zksync/) (WIP)!
@@ -28,14 +28,32 @@ Please note that `foundry-zksync` is still in its **alpha** stage. Some features
 
 ## 📊 Features & Limitations
 
-| ✅ Features                                                                                     | 🚫 Limitations                                                         |
-|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| Compile smart contracts with the [zksolc compiler](https://github.com/matter-labs/zksolc-bin). | Can't find `test/` directory |
-| Deploy smart contracts to zkSync Era mainnet, testnet, or local test node.                     | `script` command lacks `zksolc` support.                               |
-| Bridge assets L1 <-> L2.                                                                       | Cheat codes are not supported.                                         |
-| Call deployed contracts on zkSync Era testnet or local test node.                              | Lacks advanced testing methods (e.g., variant testing).                |
-| Send transactions to deployed contracts on zkSync Era testnet or local test node.              |                                                                        |
-| Simple 'PASS / FAIL' testing.                                                                  |                                                                        |
+### Features
+
+`Foundry-zksync` offers a set of features designed to work with zkSync Era, providing a comprehensive toolkit for smart contract deployment and interaction:
+
+- **Smart Contract Deployment**: Easily deploy smart contracts to zkSync Era mainnet, testnet, or a local test node.
+- **Asset Bridging**: Bridge assets between L1 and L2, facilitating seamless transactions across layers.
+- **Contract Interaction**: Call and send transactions to deployed contracts on zkSync Era testnet or local test node.
+- **Solidity Testing**: Write tests in Solidity, similar to DappTools, for a familiar testing environment.
+- **Fuzz Testing**: Benefit from fuzz testing, complete with shrinking of inputs and printing of counter-examples.
+- **Remote RPC Forking**: Utilize remote RPC forking mode, leveraging Rust's asynchronous infrastructure like tokio.
+- **Flexible Debug Logging**: Choose your debugging style:
+  - DappTools-style: Utilize DsTest's emitted logs for debugging.
+  - Hardhat-style: Leverage the popular console.sol contract.
+- **Configurable Compiler Options**: Tailor compiler settings to your needs, including LLVM optimization modes.
+
+# Limitations
+
+While `foundry-zksync` is **in-development**, there are some limitations to be aware of:
+
+- **Cheat Codes Support**: Not all cheat codes are fully supported. [View the list of supported cheat codes](./SUPPORTED_CHEATCODES.md).
+- **Script Command**: The `script` command is currently a work in progress.
+- **Compile Time**: Some users may experience slower compile times.
+- **Compiling Libraries**: Compiling non-inlinable libraries requires deployment. [Learn more](https://era.zksync.io/docs/tools/hardhat/compiling-libraries.html).
+- **Create2 Address Derivation**: There are differences in Create2 Address derivation compared to Ethereum. [Read the details](https://era.zksync.io/docs/reference/architecture/differences-with-ethereum.html#create-create2).
+
+For the most effective use of our library, we recommend familiarizing yourself with these features and limitations. 
 
 ## 📝 Prerequisites
 
@@ -77,13 +95,13 @@ cargo build --release
 
 Run:
 ``` 
-zkforge init --template https://github.com/dutterbutter/hello-foundry-zksync
+zkforge init hello_foundry
 ```
 
 Let's check out what zkforge generated for us:
 
 ```
-$ cd hello-foundry-zksync
+$ cd hello_foundry
 $ tree . -d -L 1
 .
 ├── abis
@@ -101,14 +119,6 @@ We can build the project with zkforge zkbuild:
 ```
 $ zkforge zkbuild
 Compiling smart contracts...
-Child -> Bytecode Hash: 010000410c1f3728a3887d9bc854d978ce441ccef394319cb26c58e0ba90df46
-Counter -> Bytecode Hash: 0100003bc44686be52940f3f2bd8a0feef17700663cba9edb978886c08123811
-Greeter -> Bytecode Hash: 0100008f03cbc9c98bb0a883736bf9c1d8801b74928ed78148ddbd5445defddf
-StepChild -> Bytecode Hash: 010000239f712c49b5804a34b1f995e034d853e2c6d2edcb60646f1bf9f057f2
-Compiler run completed with warnings
-TwoUserMultisig -> Bytecode Hash: 01000757a0867b6d7aba75853f126e7780bd893ae384a4718a2a03a6b53a5ee1
-AAFactory -> Bytecode Hash: 0100007b76ee1ed575d19043b0b995632ac07ae996aefbbc8238f490f492c793
-SimpleFactory -> Bytecode Hash: 0100021b7653e052f7f8218197d79e28de792ff243a30711fb63251644d47524
 Compiled Successfully
 ```
 
@@ -116,28 +126,17 @@ Compiled Successfully
 
 You can run the tests using `zkforge test`. 
 
->❗Known issue of not being able to find tests in the `/tests/` directory. 
-
 The command and its expected output are shown below:
 
 ```bash
 $ zkforge test
 
-Running 2 tests for Counter.sol:ContractBTest
-[PASS] test_CannotSubtract43() (gas: 9223372034707517612)
-[PASS] test_NumberIs42() (gas: 9223372034707517612)
-Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 43.08ms
+Running 2 tests for Counter.t.sol:CounterTest
+[PASS] testFuzz_SetNumber(uint256) (runs: 256, μ: 9223372034707527035, ~: 9223372034707527076)
+[PASS] test_Increment() (gas: 9223372034707527339)
+Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 5.15s
 
-Running 1 test for Counter.sol:OwnerUpOnlyTest
-[PASS] test_IncrementAsOwner() (gas: 9223372034707517612)
-Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 43.46ms
-
-Running 2 tests for Counter.sol:CounterTest
-[PASS] test_Increment() (gas: 9223372034707517612)
-[PASS] test_Increment_twice() (gas: 9223372034707517612)
-Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 47.81ms
-
-Ran 3 test suites: 5 tests passed, 0 failed, 0 skipped (5 total tests)
+Ran 1 test suites: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 ```
 
 ## Configuration
@@ -154,11 +153,21 @@ You can select another profile using the `FOUNDRY_PROFILE` environment variable.
 
 To see your current configuration, run `zkforge config`. To see only basic options (as set with `zkforge init`), run `zkforge config --basic`. This can be used to create a new `foundry.toml` file with `zkforge config --basic > foundry.toml`.
 
-By default `zkforge config` shows the currently selected foundry profile and its values. It also accepts the same arguments as `zkforge build`.
+By default `zkforge config` shows the currently selected foundry profile and its values. It also accepts the same arguments as `zkforge build`. An example `foundry.toml` for zkSync with zksolc configurations may look like:
 
-### DappTools Compatibility
+```
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
 
-You can re-use your `.dapprc` environment variables by running `source .dapprc` before using a Foundry tool.
+[profile.zksync]
+src = 'src'
+libs = ['lib']
+fallback_oz = true
+is_system = true
+mode = "2"
+```
 
 ### Additional Configuration
 
@@ -185,27 +194,6 @@ Make sure that:
 
 If you get errors like `(code: -32601, message: Method not found, data: None)` - you are probably using a `send` method instead of `zksend`.
 
-### 'Could not get solc: Unknown version provided', 'checksum not found'
-
-These errors might show up on the Mac with ARM chip (M1, M2) due to the fact that most recent solc compilers are not auto-downloaded there.
-
-There are 2 workarounds:
-
- - Use an older compiler by adding `--use 0.8.19` flag to the `zk-build` command.
- - Download the compiler manually and then use the `--offline` mode. (Download the compiler into ~/.svm/VERSION/solc-VERSION -- for example ~/.svm/0.8.20/solc-0.8.20).
-
-You can get the latest compiler version for MacOs AARCH here: https://github.com/ethers-rs/solc-builds/tree/master/macosx/aarch64
-
-You might have to remove the `zkout` directory (that holds the compilation artifacts) and in some rare scenarios also cleanup the installed solc versions (by removing `~/.svm/` directory)
-
-### `solc` versions >0.8.19 are not supported, found 0.8.20
-
-This means that our zksync compiler doesn't support that version of solidity yet.
-
-In such case, please remove the artifacts (by removing `zkout` directory) and re-run with the older version of solidity (`--use 0.8.19`) for example.
-
-You might also have to remove the `~/.svm/0.8.20/solc-0.8.20` file.
-
 ## Acknowledgements
 
 -   Foundry is a clean-room rewrite of the testing framework [DappTools](https://github.com/dapphub/dapptools). None of this would have been possible without the DappHub team's work over the years.
@@ -213,6 +201,9 @@ You might also have to remove the `~/.svm/0.8.20/solc-0.8.20` file.
 -   [Rohit Narurkar](https://twitter.com/rohitnarurkar): Created the Rust Solidity version manager [svm-rs](https://github.com/roynalnaruto/svm-rs) which we use to auto-detect and manage multiple Solidity versions.
 -   [Brock Elmore](https://twitter.com/brockjelmore): For extending the VM's cheatcodes and implementing [structured call tracing](https://github.com/foundry-rs/foundry/pull/192), a critical feature for debugging smart contract calls.
 -   All the other [contributors](https://github.com/foundry-rs/foundry/graphs/contributors) to the [ethers-rs](https://github.com/gakonst/ethers-rs) & [foundry](https://github.com/foundry-rs/foundry) repositories and chatrooms.
+
+### foundry-zksync Acknowledgments
+- [Moonsong Labs](https://moonsonglabs.com/): Implemented [era-cheatcodes], and resolved a number of different challenges to enable zkSync support. 
 
 [foundry-book]: https://book.getfoundry.sh
 [foundry-gha]: https://github.com/foundry-rs/foundry-toolchain

--- a/SUPPORTED_CHEATCODES.md
+++ b/SUPPORTED_CHEATCODES.md
@@ -1,0 +1,49 @@
+# 🔧 Supported Cheatcodes for Foundry-zksync 🔧
+
+> ⚠️ **WORK IN PROGRESS**: This list is non-comprehensive and being updated. If there is an cheatcode that requires additional support, please start by [creating a GitHub Issue](https://github.com/matter-labs/foundry-zksync/issues/new/choose).
+
+## Key
+
+The `status` options are:
+
++ `SUPPORTED` - Basic support is completed
++ `NOT IMPLEMENTED` - Currently not supported/implemented
+
+## Supported Cheatcodes Table
+
+| Cheatcode | Status | Link |
+| --- | --- | --- |
+| `vm.setNonce` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/set-nonce) |
+| `vm.getNonce` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/get-nonce) |
+| `vm.deal` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/deal) |
+| `vm.etch` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/etch) |
+| `vm.warp(u256)` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/warp) |
+| `vm.roll` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/roll) |
+| `vm.startPrank` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/start-prank) |
+| `vm.stopPrank` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/stop-prank) |
+| `vm.addr` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/addr) |
+| `vm.toString` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/to-string) |
+| `vm.readCallers` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/read-callers) |
+| `vm.expectRevert` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/expect-revert) |
+| `vm.recordLogs` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/record-logs) |
+| `vm.getRecordedLogs` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/get-recorded-logs) |
+| `vm.snapshot` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/snapshot) |
+| `vm.revertTo` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/revert-to) |
+| `vm.expectEmit` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/expect-emit) |
+| `vm.expectCall` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/expect-call) |
+| `vm.createFork` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/create-fork) |
+| `vm.selectFork` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/select-fork) |
+| `vm.createSelectFork` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/create-select-fork) |
+| `vm.rpcUrl` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/rpc-url) |
+| `vm.activeFork` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/active-fork) |
+| `vm.writeFile` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/write-file) |
+| `vm.writeJson` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/write-json) |
+| `vm.serializeUint` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/serialize-uint) |
+| `vm.serializeAddress` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/serialize-address) |
+| `vm.serializeBool` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/serialize-bool) |
+| `vm.store` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/store) |
+| `vm.load` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/load) |
+| `vm.ffi` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/ffi) |
+| `vm.tryFfi` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/try-ffi) |
+| `vm.startBroadcast` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/start-broadcast) |
+| `vm.stopBroadcast` | SUPPORTED | [Link](https://book.getfoundry.sh/cheatcodes/stop-broadcast) |

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -53,6 +53,7 @@ pub struct CompilerArgs {
         long = "is-system",
         value_name = "SYSTEM_MODE"
     )]
+    #[serde(skip)]
     pub is_system: bool,
 
     /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
@@ -62,6 +63,7 @@ pub struct CompilerArgs {
         long = "force-evmla",
         value_name = "FORCE_EVMLA"
     )]
+    #[serde(skip)]
     pub force_evmla: bool,
 
     /// Try to recompile with -Oz if the bytecode is too large.
@@ -70,6 +72,7 @@ pub struct CompilerArgs {
         long = "fallback-oz",
         value_name = "FALLBACK_OZ"
     )]
+    #[serde(skip)]
     pub fallback_oz: bool,
 
     #[clap(help_heading = "zkSync Compiler options", long = "detect-missing-libraries")]

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -53,8 +53,8 @@ pub struct CompilerArgs {
         long = "is-system",
         value_name = "SYSTEM_MODE"
     )]
-    #[serde(skip)]
-    pub is_system: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_system: Option<bool>,
 
     /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
     #[clap(
@@ -63,8 +63,8 @@ pub struct CompilerArgs {
         long = "force-evmla",
         value_name = "FORCE_EVMLA"
     )]
-    #[serde(skip)]
-    pub force_evmla: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_evmla: Option<bool>,
 
     /// Try to recompile with -Oz if the bytecode is too large.
     #[clap(
@@ -72,9 +72,10 @@ pub struct CompilerArgs {
         long = "fallback-oz",
         value_name = "FALLBACK_OZ"
     )]
-    #[serde(skip)]
-    pub fallback_oz: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_oz: Option<bool>,
 
+    /// Path to cache missing library dependencies, used for compiling and deploying libraries.
     #[clap(help_heading = "zkSync Compiler options", long = "detect-missing-libraries")]
     pub detect_missing_libraries: bool,
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -411,7 +411,7 @@ pub struct Config {
     pub is_system: bool,
     /// Force evmla for zkSync
     pub force_evmla: bool,
-    // Path to cache missing library dependencies, used for compiling and deploying libraries.
+    /// Path to cache missing library dependencies, used for compiling and deploying libraries.
     pub detect_missing_libraries: bool,
 }
 
@@ -1652,7 +1652,7 @@ impl From<Config> for Figment {
                 .cached(),
             profile.clone(),
         );
-        
+
         // merge environment variables
         figment = figment
             .merge(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -411,6 +411,8 @@ pub struct Config {
     pub is_system: bool,
     /// Force evmla for zkSync
     pub force_evmla: bool,
+    // Path to cache missing library dependencies, used for compiling and deploying libraries.
+    pub detect_missing_libraries: bool,
 }
 
 /// Mapping of fallback standalone sections. See [`FallbackProfileProvider`]
@@ -1650,7 +1652,6 @@ impl From<Config> for Figment {
                 .cached(),
             profile.clone(),
         );
-
         // merge environment variables
         figment = figment
             .merge(
@@ -1923,6 +1924,7 @@ impl Default for Config {
             fallback_oz: false,
             force_evmla: false,
             is_system: false,
+            detect_missing_libraries: false,
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1652,6 +1652,7 @@ impl From<Config> for Figment {
                 .cached(),
             profile.clone(),
         );
+        
         // merge environment variables
         figment = figment
             .merge(

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -125,6 +125,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         fallback_oz: false,
         force_evmla: false,
         is_system: false,
+        detect_missing_libraries: false,
     };
     prj.write_config(input.clone());
     let config = cmd.config();

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -149,10 +149,11 @@ impl TestArgs {
 
         // Set up the project
         let mut project = config.project()?;
+        // load the zkSolc config
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
         let zk_out_path = project.paths.root.join("zkout");
         project.paths.artifacts = zk_out_path;
-        
+
         // install missing dependencies
         if install::install_missing_dependencies(&mut config, self.build_args().silent) &&
             config.auto_detect_remappings

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -150,7 +150,9 @@ impl TestArgs {
         // Set up the project
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
-
+        let zk_out_path = project.paths.root.join("zkout");
+        project.paths.artifacts = zk_out_path;
+        
         // install missing dependencies
         if install::install_missing_dependencies(&mut config, self.build_args().silent) &&
             config.auto_detect_remappings

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -150,8 +150,6 @@ impl TestArgs {
         // Set up the project
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
-        let zk_out_path = project.paths.root.join("zkout");
-        project.paths.artifacts = zk_out_path;
 
         // install missing dependencies
         if install::install_missing_dependencies(&mut config, self.build_args().silent) &&

--- a/crates/zkforge/bin/cmd/zk_build.rs
+++ b/crates/zkforge/bin/cmd/zk_build.rs
@@ -125,6 +125,10 @@ impl ZkBuildArgs {
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
 
+        //set zk out path
+        let zk_out_path = project.paths.root.join("zkout");
+        project.paths.artifacts = zk_out_path;
+
         if install::install_missing_dependencies(&mut config, self.args.silent) &&
             config.auto_detect_remappings
         {

--- a/crates/zkforge/bin/cmd/zk_build.rs
+++ b/crates/zkforge/bin/cmd/zk_build.rs
@@ -125,10 +125,6 @@ impl ZkBuildArgs {
         let mut project = config.project()?;
         let mut zksolc_cfg = config.zk_solc_config().map_err(|e| eyre::eyre!(e))?;
 
-        //set zk out path
-        let zk_out_path = project.paths.root.join("zkout");
-        project.paths.artifacts = zk_out_path;
-
         if install::install_missing_dependencies(&mut config, self.args.silent) &&
             config.auto_detect_remappings
         {

--- a/crates/zkforge/tests/cli/config.rs
+++ b/crates/zkforge/tests/cli/config.rs
@@ -125,6 +125,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         fallback_oz: false,
         force_evmla: false,
         is_system: false,
+        detect_missing_libraries: false,
     };
     prj.write_config(input.clone());
     let config = cmd.config();

--- a/docs/dev/zksync/zkcast-usage.md
+++ b/docs/dev/zksync/zkcast-usage.md
@@ -139,5 +139,3 @@ Welcome to the zkcast usage guide! This document will provide you with detailed 
   zkcast call 0x97b985951fd3e0c1d996421cc783d46c12d00082 "greet()(string)" --rpc-url http://localhost:3050
   ```
   **Output:** `Killer combo!`
-
-This guide provides a comprehensive overview of the commands available in zkcast for various blockchain interactions, bridging assets

--- a/docs/dev/zksync/zkforge-usage.md
+++ b/docs/dev/zksync/zkforge-usage.md
@@ -12,12 +12,22 @@
 zkforge zk-build [OPTIONS]
 ```
 
-**Options:**
+**zkSync Compiler Options:**
 
-- `--use-zksolc`: Specify zksolc compiler version (default if left blank).
-- `--is-system`: Enables system contract compilation mode.
-- `--force-evmla`: Forces the EVM legacy assembly pipeline.
-- `-h, --help`: Prints help.
+- `--use-zksolc <ZK_SOLC_VERSION>`: Specify the solc version or a path to a local solc for building. Valid values are in the format `x.y.z`, `zksolc:x.y.z`, or `path/to/zksolc`. Default is `v1.3.21`.
+
+- `--is-system <SYSTEM_MODE>`: Enable system contract compilation mode. Possible values are `true` or `false`.
+
+- `--force-evmla <FORCE_EVMLA>`: Forcibly switch to the EVM legacy assembly pipeline. Possible values are `true` or `false`.
+
+- `--fallback-oz <FALLBACK_OZ>`: Attempt to recompile with `-Oz` if the bytecode is too large. Possible values are `true` or `false`.
+
+- `--detect-missing-libraries`: Detects and reports missing libraries in the project.
+
+- `-O, --optimization <LEVEL>`: Set the LLVM optimization parameter `-O[0 | 1 | 2 | 3 | s | z]`. Use `3` for the best performance and `z` for minimal size.
+
+- `--zk-optimizer`: Enables specific optimizations for zkSync.
+
 
 **Note:** The `--is-system` flag is essential for contracts like factory contracts. These should be in `src/is-system/`. Create the folder if it doesn't exist.
 
@@ -25,7 +35,7 @@ zkforge zk-build [OPTIONS]
 
 **Example Usage:**
 
-Compile with default compiler options (v1.3.11).
+Compile with default compiler options (v1.3.21).
 
 ```sh
 zkforge zk-build
@@ -33,10 +43,10 @@ zkforge zk-build
 
 **Compiler Settings:**
 
-Set `zksolc` compiler version using `--use` flag.
+Set `zksolc` compiler version using `--use-zksolc` flag.
 
 ```bash
-zkforge zkb --use 0.8.19
+zkforge zkb --use-zksolc 1.3.21
 ```
 
 **Example Output:**
@@ -51,10 +61,6 @@ zkforge zkb --use 0.8.19
 Example terminal output:
 
 ![Terminal Output](https://user-images.githubusercontent.com/76663878/236305625-8c7519e2-0c5e-492f-a4bc-3b019a95e34f.png)
-
-**Important:** Until `forge remappings` are implemented, use relative import paths:
-
-![Import Paths](https://github.com/matter-labs/foundry-zksync/assets/76663878/490b34f4-e286-42a7-8570-d4b228ec10c7)
 
 `SimpleFactory.sol` and `AAFactory.sol` should be in `src/is-system/`.
 

--- a/docs/dev/zksync/zksync-aa-usage.md
+++ b/docs/dev/zksync/zksync-aa-usage.md
@@ -15,7 +15,6 @@ First, compile `AAFactory.sol` using the `--is-system` flag because it interacts
 
 **Expected Output:**
 ```sh
-AAFactory -> Bytecode Hash: "010000791703a54dbe2502b00ee470989c267d0f6c0d12a9009a947715683744" 
 Compiled Successfully
 ```
 


### PR DESCRIPTION
# What :computer: 
* Resolves an issue where zksolc config options were not being correctly set from .toml file
* Updates readme / docs to reflect current state of project

# Why :hand:
* Making use of .toml file is easy way to configure project for zksync usage
* Reflects current supported features and limitations and acknowledges the tremendous work provided by @matter-labs/external-moonsonglabs-team 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

Can now make use of .toml configuration like so:

```
[profile.default]
src = 'src'
out = 'out'
libs = ['lib']

[profile.zksync]
src = 'src'
libs = ['lib']
fallback_oz = true
```

And use it accordingly:
`FOUNDRY_PROFILE=zksync zkforge zkbuild`

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
