### PR TITLE
fix: persist bytecodes on fork

### DIFF
--- a/crates/common/src/zk_utils/mod.rs
+++ b/crates/common/src/zk_utils/mod.rs
@@ -148,14 +148,31 @@ pub fn decode_hex(s: &str) -> std::result::Result<Vec<u8>, ParseIntError> {
     (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16)).collect()
 }
 
+/// Recorded storage modifications.
+#[derive(Default, Debug, Clone)]
+pub struct StorageModifications {
+    /// Storage key modifications.
+    pub keys: HashMap<StorageKey, StorageValue>,
+    /// Bytecode modifications.
+    pub bytecodes: HashMap<H256, Vec<u8>>,
+}
+
+impl StorageModifications {
+    /// Updates current modifications with the provided modifications.
+    pub fn extend(&mut self, other: StorageModifications) {
+        self.keys.extend(other.keys);
+        self.bytecodes.extend(other.bytecodes);
+    }
+}
+
 /// Keeps track of storage modifications performed during test executions.
 /// This is especially important when forking to re-apply changes.
 pub trait StorageModificationRecorder {
-    /// Merge modified keys into the existing modifications
-    fn record_modified_keys(&mut self, modified_keys: &HashMap<StorageKey, StorageValue>);
+    /// Merge modified keys and bytecodes into the existing modifications
+    fn record_storage_modifications(&mut self, storage_modifications: StorageModifications);
 
     /// Return all modified keys
-    fn get(&self) -> &HashMap<StorageKey, StorageValue>;
+    fn get(&self) -> &StorageModifications;
 }
 
 /// Converts a reference to self into a tracer pointer.

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -2094,8 +2094,7 @@ impl CheatcodeTracer {
                     let key = u256_to_h256(bytecode_key);
                     let value = bytecode_value
                         .into_iter()
-                        .map(|v| u256_to_h256(v).as_bytes().to_owned())
-                        .flatten()
+                        .flat_map(|v| u256_to_h256(v).as_bytes().to_owned())
                         .collect_vec();
                     (key, value)
                 })

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -783,7 +783,7 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                                 .collect(),
                         );
 
-                        let mut db: std::sync::MutexGuard<'_, Box<S>> = era_db.db.lock().unwrap();
+                        let mut db = era_db.db.lock().unwrap();
                         let era_env = self.env.get().unwrap();
                         let mut env = into_revm_env(era_env);
                         db.select_fork(

--- a/crates/era-cheatcodes/tests/src/cheatcodes/Fork.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/Fork.t.sol
@@ -67,7 +67,6 @@ contract ForkTest is Test {
             "ENV for blocks is not set correctly"
         );
     }
-    
 
     function testActiveFork() public {
         uint256 data = vm.createFork("mainnet", FORK_BLOCK + 100);

--- a/crates/era-cheatcodes/tests/src/cheatcodes/Fork.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/Fork.t.sol
@@ -67,6 +67,7 @@ contract ForkTest is Test {
             "ENV for blocks is not set correctly"
         );
     }
+    
 
     function testActiveFork() public {
         uint256 data = vm.createFork("mainnet", FORK_BLOCK + 100);

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
@@ -10,7 +10,7 @@ contract Target {
     }
 }
 
-contract ForkStorageTest is Test {
+contract ForkBytecodeTest is Test {
     uint256 constant FORK_BLOCK = 19579636;
 
     function testCreateSelectForkHasNonDeployedBytecodes() public {

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
@@ -18,27 +18,15 @@ contract ForkStorageTest is Test {
 
         // target should be able to deploy
         Target target = new Target();
-
-        // Contract is still deployed
         require(255 == target.output(), "incorrect output after fork");
-
-        // After fork, bytecode is remembered and contract is deployed
-        Target newTarget = new Target();
-        require(255 == newTarget.output(), "incorrect new target output");
     }
 
     function testSelectForkForkHasNonDeployedBytecodes() public {
-        uint256 forkId = vm.createFork("mainnet", FORK_BLOCK + 100);
+        uint256 forkId = vm.createFork("mainnet", FORK_BLOCK);
         vm.selectFork(forkId);
 
         // target should be able to deploy
         Target target = new Target();
-
-        // Contract is still deployed
         require(255 == target.output(), "incorrect output after fork");
-
-        // After fork, bytecode is remembered and contract is deployed
-        Target newTarget = new Target();
-        require(255 == newTarget.output(), "incorrect new target output");
     }
 }

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console2 as console} from "forge-std/Test.sol";
+import {Constants} from "./Constants.sol";
+
+contract Target {
+    function output() public pure returns (uint256) {
+        return 255;
+    }
+}
+
+contract ForkStorageTest is Test {
+    uint256 constant FORK_BLOCK = 19579636;
+
+    function testCreateSelectForkHasNonDeployedBytecodes() public {
+        vm.createSelectFork("mainnet", FORK_BLOCK);
+
+        // target should be able to deploy
+        Target target = new Target();
+
+        // Contract is still deployed
+        require(255 == target.output(), "incorrect output after fork");
+
+        // After fork, bytecode is remembered and contract is deployed
+        Target newTarget = new Target();
+        require(255 == newTarget.output(), "incorrect new target output");
+    }
+
+    function testSelectForkForkHasNonDeployedBytecodes() public {
+        uint256 forkId = vm.createFork("mainnet", FORK_BLOCK + 100);
+        vm.selectFork(forkId);
+
+        // target should be able to deploy
+        Target target = new Target();
+
+        // Contract is still deployed
+        require(255 == target.output(), "incorrect output after fork");
+
+        // After fork, bytecode is remembered and contract is deployed
+        Target newTarget = new Target();
+        require(255 == newTarget.output(), "incorrect new target output");
+    }
+}

--- a/crates/evm/core/src/era_revm/transactions.rs
+++ b/crates/evm/core/src/era_revm/transactions.rs
@@ -211,8 +211,7 @@ where
                 let key = u256_to_h256(key);
                 let value = value
                     .into_iter()
-                    .map(|word| u256_to_h256(word).as_bytes().to_owned())
-                    .flatten()
+                    .flat_map(|word| u256_to_h256(word).as_bytes().to_owned())
                     .collect_vec();
                 (key, value)
             })
@@ -427,12 +426,12 @@ mod tests {
 
     struct Noop<S, H> {
         _phantom: PhantomData<(S, H)>,
-        modified_storage_keys: HashMap<StorageKey, StorageValue>,
+        storage_modifications: StorageModifications,
     }
 
     impl<S, H> Default for Noop<S, H> {
         fn default() -> Self {
-            Self { _phantom: Default::default(), modified_storage_keys: Default::default() }
+            Self { _phantom: Default::default(), storage_modifications: Default::default() }
         }
     }
 
@@ -440,7 +439,7 @@ mod tests {
         fn clone(&self) -> Self {
             Self {
                 _phantom: self._phantom,
-                modified_storage_keys: self.modified_storage_keys.clone(),
+                storage_modifications: self.storage_modifications.clone(),
             }
         }
     }
@@ -456,8 +455,8 @@ mod tests {
     impl<S, H> StorageModificationRecorder for Noop<S, H> {
         fn record_storage_modifications(&mut self, storage_modifications: StorageModifications) {}
 
-        fn get(&self) -> &HashMap<StorageKey, StorageValue> {
-            &self.modified_storage_keys
+        fn get(&self) -> &StorageModifications {
+            &self.storage_modifications
         }
     }
 }

--- a/crates/evm/core/src/era_revm/transactions.rs
+++ b/crates/evm/core/src/era_revm/transactions.rs
@@ -454,13 +454,7 @@ mod tests {
     }
 
     impl<S, H> StorageModificationRecorder for Noop<S, H> {
-        fn record_storage_modifications(
-            &mut self,
-            _modified_keys: &HashMap<StorageKey, StorageValue>,
-        ) {
-        }
-
-        fn record_modified_contracts(&mut self, modified_keys: &HashMap<H256, Vec<u8>>) {}
+        fn record_storage_modifications(&mut self, storage_modifications: StorageModifications) {}
 
         fn get(&self) -> &HashMap<StorageKey, StorageValue> {
             &self.modified_storage_keys

--- a/crates/evm/core/src/era_revm/transactions.rs
+++ b/crates/evm/core/src/era_revm/transactions.rs
@@ -453,7 +453,7 @@ mod tests {
     }
 
     impl<S, H> StorageModificationRecorder for Noop<S, H> {
-        fn record_storage_modifications(&mut self, storage_modifications: StorageModifications) {}
+        fn record_storage_modifications(&mut self, _storage_modifications: StorageModifications) {}
 
         fn get(&self) -> &StorageModifications {
             &self.storage_modifications

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -113,7 +113,7 @@ impl Executor {
             .expect("failed writing account storage for known codes storage address");
 
         // setup modified keys in inspector to persist cheatcode address setup across forks
-        inspector.modified_storage_keys.insert(
+        inspector.storage_modifications.keys.insert(
             StorageKey::new(
                 AccountTreeId::new(ACCOUNT_CODE_STORAGE_ADDRESS),
                 H256::from_slice(
@@ -122,7 +122,7 @@ impl Executor {
             ),
             H256::from_slice(&empty_contract_code_hash.0),
         );
-        inspector.modified_storage_keys.insert(
+        inspector.storage_modifications.keys.insert(
             StorageKey::new(
                 AccountTreeId::new(zksync_types::H160(CHEATCODE_ADDRESS.0 .0)),
                 H256::from_slice(&empty_contract_code_hash.0),
@@ -350,7 +350,7 @@ impl Executor {
         let result = self.backend.inspect_ref(&mut env, &mut inspector)?;
         // record storage modifications
         if result.result.is_success() {
-            self.inspector.modified_storage_keys = inspector.modified_storage_keys.clone();
+            self.inspector.storage_modifications = inspector.storage_modifications.clone();
         }
         convert_executed_result(env, inspector, result, self.backend.has_snapshot_failure())
     }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -5,7 +5,7 @@ use super::{
 use alloy_primitives::{Address, Bytes, B256, U256};
 use ethers_core::types::Log;
 use ethers_signers::LocalWallet;
-use foundry_common::{AsTracerPointer, StorageModificationRecorder};
+use foundry_common::{AsTracerPointer, StorageModificationRecorder, StorageModifications};
 use foundry_evm_core::{backend::DatabaseExt, debug::DebugArena};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::CallTraceArena;
@@ -16,11 +16,7 @@ use revm::{
     primitives::{BlockEnv, Env},
     EVMData, Inspector,
 };
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
-use zksync_types::{StorageKey, StorageValue};
+use std::{collections::BTreeMap, sync::Arc};
 
 #[derive(Clone, Debug, Default)]
 #[must_use = "builders do nothing unless you call `build` on them"]
@@ -212,7 +208,7 @@ pub struct InspectorStack {
     pub log_collector: Option<LogCollector>,
     pub printer: Option<TracePrinter>,
     pub tracer: Option<Tracer>,
-    pub modified_storage_keys: HashMap<StorageKey, StorageValue>,
+    pub storage_modifications: StorageModifications,
 }
 
 impl InspectorStack {
@@ -595,18 +591,18 @@ impl<DB: DatabaseExt + Send>
     > {
         CheatcodeTracer::new(
             self.cheatcodes.as_ref().map(|c| c.config.clone()).unwrap_or_default(),
-            self.modified_storage_keys.clone(),
+            self.storage_modifications.clone(),
         )
         .into_tracer_pointer()
     }
 }
 
 impl StorageModificationRecorder for &mut InspectorStack {
-    fn record_modified_keys(&mut self, modified_keys: &HashMap<StorageKey, StorageValue>) {
-        self.modified_storage_keys.extend(modified_keys);
+    fn record_storage_modifications(&mut self, storage_modifications: StorageModifications) {
+        self.storage_modifications.extend(storage_modifications);
     }
 
-    fn get(&self) -> &HashMap<StorageKey, StorageValue> {
-        &self.modified_storage_keys
+    fn get(&self) -> &StorageModifications {
+        &self.storage_modifications
     }
 }


### PR DESCRIPTION
# What :computer: 
* persists bytecodes on fork

# Why :hand:
* Required to deploy contract in stages other than `setUp` after a fork.

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
