### PR TITLE
fix: persist bytecodes on fork

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@nightly
               with:
-                  toolchain: nightly-2023-09-21
+                  toolchain: nightly-2023-09-30
 
             - name: cargo update
               # Remove first line that always just says "Updating crates.io index"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         - name: Install Rust
           uses: actions-rust-lang/setup-rust-toolchain@v1
           with:
-            toolchain: nightly-2023-07-23
+            toolchain: nightly-2023-09-30
   
         - name: Test Cheatcodes
           run: cd crates/era-cheatcodes/tests && ./test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
               with:
-                toolchain: nightly-2023-09-21
+                toolchain: nightly-2023-09-30
             - uses: Swatinem/rust-cache@v2
               with:
                 cache-on-failure: true
@@ -55,7 +55,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
               with:
-                  toolchain: nightly-2023-09-21
+                  toolchain: nightly-2023-09-30
                   components: rustfmt
             - run: cargo fmt --all --check
 
@@ -67,7 +67,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
               with:
-                  toolchain: nightly-2023-09-21
+                  toolchain: nightly-2023-09-30
             - uses: Swatinem/rust-cache@v2
               with:
                   cache-on-failure: true
@@ -82,7 +82,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@nightly
               with:
-                toolchain: nightly-2023-09-21
+                toolchain: nightly-2023-09-30
             - uses: taiki-e/install-action@cargo-hack
             - uses: Swatinem/rust-cache@v2
               with:
@@ -104,7 +104,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2023-09-21
+          toolchain: nightly-2023-09-30
 
       - name: Run smoke-test
         env:

--- a/crates/common/src/zk_utils/mod.rs
+++ b/crates/common/src/zk_utils/mod.rs
@@ -148,14 +148,31 @@ pub fn decode_hex(s: &str) -> std::result::Result<Vec<u8>, ParseIntError> {
     (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16)).collect()
 }
 
+/// Recorded storage modifications.
+#[derive(Default, Debug, Clone)]
+pub struct StorageModifications {
+    /// Storage key modifications.
+    pub keys: HashMap<StorageKey, StorageValue>,
+    /// Bytecode modifications.
+    pub bytecodes: HashMap<H256, Vec<u8>>,
+}
+
+impl StorageModifications {
+    /// Updates current modifications with the provided modifications.
+    pub fn extend(&mut self, other: StorageModifications) {
+        self.keys.extend(other.keys);
+        self.bytecodes.extend(other.bytecodes);
+    }
+}
+
 /// Keeps track of storage modifications performed during test executions.
 /// This is especially important when forking to re-apply changes.
 pub trait StorageModificationRecorder {
-    /// Merge modified keys into the existing modifications
-    fn record_modified_keys(&mut self, modified_keys: &HashMap<StorageKey, StorageValue>);
+    /// Merge modified keys and bytecodes into the existing modifications
+    fn record_storage_modifications(&mut self, storage_modifications: StorageModifications);
 
     /// Return all modified keys
-    fn get(&self) -> &HashMap<StorageKey, StorageValue>;
+    fn get(&self) -> &StorageModifications;
 }
 
 /// Converts a reference to self into a tracer pointer.

--- a/crates/common/src/zk_utils/mod.rs
+++ b/crates/common/src/zk_utils/mod.rs
@@ -172,7 +172,7 @@ pub trait StorageModificationRecorder {
     fn record_storage_modifications(&mut self, storage_modifications: StorageModifications);
 
     /// Return all modified keys
-    fn get(&self) -> &StorageModifications;
+    fn get_storage_modifications(&self) -> &StorageModifications;
 }
 
 /// Converts a reference to self into a tracer pointer.

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -681,13 +681,15 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                     let era_db = &storage.borrow_mut().storage_handle;
                     let mut db = era_db.db.lock().unwrap();
                     let era_env = self.env.get().unwrap();
-                    let fork_id = db.create_fork(create_fork_request(
-                        era_env,
-                        self.config.clone(),
-                        block_number,
-                        &url_or_alias,
-                    ));
-                    self.return_data = Some(fork_id.unwrap().to_return_data());
+                    let fork_id = db
+                        .create_fork(create_fork_request(
+                            era_env,
+                            self.config.clone(),
+                            block_number,
+                            &url_or_alias,
+                        ))
+                        .unwrap();
+                    self.return_data = Some(fork_id.to_return_data());
                 }
                 FinishCycleOneTimeActions::RollFork { block_number, fork_id } => {
                     let modified_storage =
@@ -745,7 +747,6 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                                 .clone()
                                 .into_iter()
                                 .filter(|(key, _)| {
-                                    println!("STOR {}", hex::encode(u256_to_h256(*key)));
                                     !state
                                         .decommittment_processor
                                         .known_bytecodes
@@ -1612,8 +1613,8 @@ impl CheatcodeTracer {
                     tracing::error!("Failed to write file");
                 }
             }
-            _ => {
-                tracing::error!("👷 Unrecognized cheatcode");
+            code => {
+                tracing::error!("👷 Unrecognized cheatcode {:?}", code);
             }
         };
     }

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -7,7 +7,7 @@ use era_test_node::utils::bytecode_to_factory_dep;
 use ethers::{signers::Signer, types::TransactionRequest, utils::to_checksum};
 use foundry_cheatcodes::{BroadcastableTransaction, CheatsConfig};
 use foundry_cheatcodes_spec::Vm;
-use foundry_common::conversion_utils::h160_to_address;
+use foundry_common::{conversion_utils::h160_to_address, StorageModifications};
 use foundry_evm_core::{
     backend::DatabaseExt,
     era_revm::{db::RevmDatabaseForEra, storage_view::StorageView, transactions::storage_to_state},
@@ -53,10 +53,9 @@ use zksync_types::{
     block::{pack_block_info, unpack_block_info},
     get_code_key, get_nonce_key,
     utils::{decompose_full_nonce, nonces_to_full_nonce, storage_key_for_eth_balance},
-    LogQuery, StorageKey, StorageValue, Timestamp, ACCOUNT_CODE_STORAGE_ADDRESS,
-    MSG_VALUE_SIMULATOR_ADDRESS,
+    LogQuery, StorageKey, Timestamp, ACCOUNT_CODE_STORAGE_ADDRESS, MSG_VALUE_SIMULATOR_ADDRESS,
 };
-use zksync_utils::{h256_to_u256, u256_to_h256};
+use zksync_utils::{bytecode::CompressedBytecodeInfo, h256_to_u256, u256_to_h256};
 
 type EraDb<DB> = StorageView<RevmDatabaseForEra<DB>>;
 type PcOrImm = <EncodingModeProduction as VmEncodingMode<8>>::PcOrImm;
@@ -115,7 +114,7 @@ enum FoundryTestState {
 
 #[derive(Debug, Default, Clone)]
 pub struct CheatcodeTracer {
-    modified_storage_keys: HashMap<StorageKey, StorageValue>,
+    storage_modifications: StorageModifications,
     one_time_actions: Vec<FinishCycleOneTimeActions>,
     next_return_action: Option<NextReturnAction>,
     permanent_actions: FinishCyclePermanentActions,
@@ -633,15 +632,28 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                     let mut storage = storage.borrow_mut();
                     let modified_storage =
                         self.get_modified_storage(storage.modified_storage_keys());
+                    let modified_bytecodes = self.get_modified_bytecodes(
+                        bootloader_state.get_last_tx_compressed_bytecodes(),
+                    );
 
                     storage.clean_cache();
                     let fork_id = {
-                        let era_db = &storage.storage_handle;
-                        let bytecodes = bootloader_state
-                            .get_last_tx_compressed_bytecodes()
-                            .iter()
-                            .map(|b| bytecode_to_factory_dep(b.original.clone()))
-                            .collect();
+                        let era_db: &RevmDatabaseForEra<S> = &storage.storage_handle;
+                        let bytecodes = into_revm_bytecodes(modified_bytecodes.clone());
+                        state.decommittment_processor.populate(
+                            bytecodes
+                                .clone()
+                                .into_iter()
+                                .filter(|(key, _)| {
+                                    !state
+                                        .decommittment_processor
+                                        .known_bytecodes
+                                        .inner()
+                                        .contains_key(&key)
+                                })
+                                .collect(),
+                            Timestamp(state.local_state.timestamp),
+                        );
 
                         let mut journaled_state = JournaledState::new(SpecId::LATEST, vec![]);
                         journaled_state.state =
@@ -678,31 +690,36 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                     self.return_data = Some(fork_id.unwrap().to_return_data());
                 }
                 FinishCycleOneTimeActions::RollFork { block_number, fork_id } => {
-                    let mut modified_storage = self
-                        .modified_storage_keys
-                        .clone()
-                        .into_iter()
-                        .filter(|(key, _)| key.address() != &zksync_types::SYSTEM_CONTEXT_ADDRESS)
-                        .collect::<HashMap<_, _>>();
-                    modified_storage.extend(
-                        storage.borrow().modified_storage_keys.iter().filter(|(key, _)| {
-                            key.address() != &zksync_types::SYSTEM_CONTEXT_ADDRESS
-                        }),
+                    let modified_storage =
+                        self.get_modified_storage(storage.borrow_mut().modified_storage_keys());
+                    let modified_bytecodes = self.get_modified_bytecodes(
+                        bootloader_state.get_last_tx_compressed_bytecodes(),
                     );
+
                     let mut storage = storage.borrow_mut();
 
                     storage.clean_cache();
                     {
                         let era_db = &storage.storage_handle;
-                        let bytecodes = bootloader_state
-                            .get_last_tx_compressed_bytecodes()
-                            .iter()
-                            .map(|b| bytecode_to_factory_dep(b.original.clone()))
-                            .collect();
+                        let bytecodes = into_revm_bytecodes(modified_bytecodes.clone());
+                        state.decommittment_processor.populate(
+                            bytecodes
+                                .clone()
+                                .into_iter()
+                                .filter(|(key, _)| {
+                                    !state
+                                        .decommittment_processor
+                                        .known_bytecodes
+                                        .inner()
+                                        .contains_key(&key)
+                                })
+                                .collect(),
+                            Timestamp(state.local_state.timestamp),
+                        );
 
                         let mut journaled_state = JournaledState::new(SpecId::LATEST, vec![]);
-                        let state = storage_to_state(era_db, &modified_storage, bytecodes);
-                        *journaled_state.state() = state;
+                        journaled_state.state =
+                            storage_to_state(era_db, &modified_storage, bytecodes);
 
                         let mut db = era_db.db.lock().unwrap();
                         let era_env = self.env.get().unwrap();
@@ -716,14 +733,27 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                     let mut storage = storage.borrow_mut();
                     let modified_storage =
                         self.get_modified_storage(storage.modified_storage_keys());
+                    let modified_bytecodes = self.get_modified_bytecodes(
+                        bootloader_state.get_last_tx_compressed_bytecodes(),
+                    );
                     {
                         storage.clean_cache();
                         let era_db = &storage.storage_handle;
-                        let bytecodes = bootloader_state
-                            .get_last_tx_compressed_bytecodes()
-                            .iter()
-                            .map(|b| bytecode_to_factory_dep(b.original.clone()))
-                            .collect();
+                        let bytecodes = into_revm_bytecodes(modified_bytecodes.clone());
+                        state.decommittment_processor.populate(
+                            bytecodes
+                                .clone()
+                                .into_iter()
+                                .filter(|(key, _)| {
+                                    !state
+                                        .decommittment_processor
+                                        .known_bytecodes
+                                        .inner()
+                                        .contains_key(&key)
+                                })
+                                .collect(),
+                            Timestamp(state.local_state.timestamp),
+                        );
 
                         let mut journaled_state = JournaledState::new(SpecId::LATEST, vec![]);
                         journaled_state.state =
@@ -881,13 +911,9 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
 impl CheatcodeTracer {
     pub fn new(
         cheatcodes_config: Arc<CheatsConfig>,
-        modified_keys: HashMap<StorageKey, StorageValue>,
+        storage_modifications: StorageModifications,
     ) -> Self {
-        Self {
-            config: cheatcodes_config,
-            modified_storage_keys: modified_keys,
-            ..Default::default()
-        }
+        Self { config: cheatcodes_config, storage_modifications, ..Default::default() }
     }
 
     /// Resets the test state to [TestStatus::NotStarted]
@@ -1967,7 +1993,8 @@ impl CheatcodeTracer {
         storage: &HashMap<StorageKey, H256>,
     ) -> HashMap<StorageKey, H256> {
         let mut modified_storage = self
-            .modified_storage_keys
+            .storage_modifications
+            .keys
             .clone()
             .into_iter()
             .filter(|(key, _)| key.address() != &zksync_types::SYSTEM_CONTEXT_ADDRESS)
@@ -1978,6 +2005,31 @@ impl CheatcodeTracer {
                 .filter(|(key, _)| key.address() != &zksync_types::SYSTEM_CONTEXT_ADDRESS),
         );
         modified_storage
+    }
+
+    /// Merge current modified bytecodes with the entire storage modifications made so far in the
+    /// test
+    fn get_modified_bytecodes(
+        &self,
+        bootloader_bytecodes: Vec<CompressedBytecodeInfo>,
+    ) -> HashMap<H256, Vec<u8>> {
+        let mut modified_bytecodes = self.storage_modifications.bytecodes.clone();
+        modified_bytecodes.extend(
+            bootloader_bytecodes
+                .iter()
+                .map(|b| {
+                    let (bytecode_key, bytecode_value) =
+                        bytecode_to_factory_dep(b.original.clone());
+                    let key = u256_to_h256(bytecode_key);
+                    let value = bytecode_value
+                        .into_iter()
+                        .flat_map(|v| u256_to_h256(v).as_bytes().to_owned())
+                        .collect_vec();
+                    (key, value)
+                })
+                .collect::<HashMap<_, _>>(),
+        );
+        modified_bytecodes
     }
 }
 
@@ -1996,6 +2048,17 @@ where
 
         abi_encoded_data.chunks(32).map(U256::from_big_endian).collect_vec()
     }
+}
+
+fn into_revm_bytecodes(zk_bytecodes: HashMap<H256, Vec<u8>>) -> HashMap<U256, Vec<U256>> {
+    zk_bytecodes
+        .into_iter()
+        .map(|(key, value)| {
+            let key = h256_to_u256(key);
+            let value = value.chunks(32).map(U256::from).collect_vec();
+            (key, value)
+        })
+        .collect()
 }
 
 fn into_revm_env(env: &EraEnv) -> Env {

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -649,7 +649,7 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                                         .decommittment_processor
                                         .known_bytecodes
                                         .inner()
-                                        .contains_key(&key)
+                                        .contains_key(key)
                                 })
                                 .collect(),
                             Timestamp(state.local_state.timestamp),
@@ -711,7 +711,7 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                                         .decommittment_processor
                                         .known_bytecodes
                                         .inner()
-                                        .contains_key(&key)
+                                        .contains_key(key)
                                 })
                                 .collect(),
                             Timestamp(state.local_state.timestamp),
@@ -745,11 +745,12 @@ impl<S: DatabaseExt + Send, H: HistoryMode> VmTracer<EraDb<S>, H> for CheatcodeT
                                 .clone()
                                 .into_iter()
                                 .filter(|(key, _)| {
+                                    println!("STOR {}", hex::encode(u256_to_h256(*key)));
                                     !state
                                         .decommittment_processor
                                         .known_bytecodes
                                         .inner()
-                                        .contains_key(&key)
+                                        .contains_key(key)
                                 })
                                 .collect(),
                             Timestamp(state.local_state.timestamp),

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console2 as console} from "forge-std/Test.sol";
+import {Constants} from "./Constants.sol";
+
+contract Target {
+    function output() public pure returns (uint256) {
+        return 255;
+    }
+}
+
+contract ForkBytecodeTest is Test {
+    uint256 constant FORK_BLOCK = 19579636;
+
+    function testCreateSelectForkHasNonDeployedBytecodes() public {
+        console.log("run");
+        vm.createSelectFork("mainnet", FORK_BLOCK);
+
+        // target should be able to deploy
+        Target target = new Target();
+        require(255 == target.output(), "incorrect output after fork");
+    }
+
+    function testSelectForkForkHasNonDeployedBytecodes() public {
+        uint256 forkId = vm.createFork("mainnet", FORK_BLOCK);
+        vm.selectFork(forkId);
+
+        // target should be able to deploy
+        Target target = new Target();
+        require(255 == target.output(), "incorrect output after fork");
+    }
+}

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console2 as console} from "forge-std/Test.sol";
+import {Constants} from "./Constants.sol";
+
+contract Target {
+    function output() public pure returns (uint256) {
+        return 255;
+    }
+}
+
+contract ForkBytecodeSetupTest is Test {
+    uint256 constant FORK_BLOCK = 19579636;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", FORK_BLOCK);
+        Target target = new Target();
+        require(255 == target.output(), "incorrect output after fork");
+    }
+
+    function testForkBytecodeSetupSuccess() public {}
+}

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup2.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup2.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console2 as console} from "forge-std/Test.sol";
+import {Constants} from "./Constants.sol";
+
+contract Target {
+    function output() public pure returns (uint256) {
+        return 255;
+    }
+}
+
+contract ForkBytecodeSetup2Test is Test {
+    uint256 constant FORK_BLOCK = 19579636;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", FORK_BLOCK);
+    }
+
+    function testForkBytecodeSetup2Success() public {
+        Target target = new Target();
+        require(255 == target.output(), "incorrect output after fork");
+    }
+}

--- a/crates/evm/core/src/era_revm/node.rs
+++ b/crates/evm/core/src/era_revm/node.rs
@@ -45,24 +45,22 @@ pub fn run_l2_tx_raw<S: ReadStorage>(
     let tx_result = vm.inspect(tracers.into(), VmExecutionMode::OneTx);
     let call_traces = Arc::try_unwrap(call_tracer_result).unwrap().take().unwrap_or_default();
 
-    if get_env_var::<bool>("ZK_DEBUG_INFO") {
-        let resolve_hashes = get_env_var::<bool>("ZK_DEBUG_RESOLVE_HASHES");
+    let resolve_hashes = get_env_var::<bool>("ZK_DEBUG_RESOLVE_HASHES");
 
-        tracing::info!("=== Console Logs: ");
-        let console_log_handler = ConsoleLogHandler::default();
-        for call in &call_traces {
-            console_log_handler.handle_call_recursive(call);
-        }
+    tracing::info!("=== Console Logs: ");
+    let console_log_handler = ConsoleLogHandler::default();
+    for call in &call_traces {
+        console_log_handler.handle_call_recursive(call);
+    }
 
-        tracing::info!("=== Calls: ");
-        for call in call_traces.iter() {
-            formatter::print_call(call, 0, &ShowCalls::All, resolve_hashes);
-        }
+    tracing::info!("=== Calls: ");
+    for call in call_traces.iter() {
+        formatter::print_call(call, 0, &ShowCalls::All, resolve_hashes);
+    }
 
-        tracing::info!("==== {}", format!("{} events", tx_result.logs.events.len()));
-        for event in &tx_result.logs.events {
-            formatter::print_event(event, resolve_hashes);
-        }
+    tracing::info!("==== {}", format!("{} events", tx_result.logs.events.len()));
+    for event in &tx_result.logs.events {
+        formatter::print_event(event, resolve_hashes);
     }
 
     let bytecodes = vm

--- a/crates/evm/core/src/era_revm/node.rs
+++ b/crates/evm/core/src/era_revm/node.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, str::FromStr, sync::Arc};
 
 use era_test_node::{
     console_log::ConsoleLogHandler,
@@ -45,22 +45,45 @@ pub fn run_l2_tx_raw<S: ReadStorage>(
     let tx_result = vm.inspect(tracers.into(), VmExecutionMode::OneTx);
     let call_traces = Arc::try_unwrap(call_tracer_result).unwrap().take().unwrap_or_default();
 
-    tracing::info!("=== Console Logs: ");
-    let console_log_handler = ConsoleLogHandler::default();
-    for call in &call_traces {
-        console_log_handler.handle_call_recursive(call);
+    if get_env_var::<bool>("ZK_DEBUG_INFO") {
+        let resolve_hashes = get_env_var::<bool>("ZK_DEBUG_RESOLVE_HASHES");
+
+        tracing::info!("=== Console Logs: ");
+        let console_log_handler = ConsoleLogHandler::default();
+        for call in &call_traces {
+            console_log_handler.handle_call_recursive(call);
+        }
+
+        tracing::info!("=== Calls: ");
+        for call in call_traces.iter() {
+            formatter::print_call(call, 0, &ShowCalls::All, resolve_hashes);
+        }
+
+        tracing::info!("==== {}", format!("{} events", tx_result.logs.events.len()));
+        for event in &tx_result.logs.events {
+            formatter::print_event(event, resolve_hashes);
+        }
     }
 
-    tracing::info!("=== Calls: ");
-    for call in call_traces.iter() {
-        formatter::print_call(call, 0, &ShowCalls::All, false);
-    }
-
-    let bytecodes: HashMap<U256, Vec<U256>> = vm
+    let bytecodes = vm
         .get_last_tx_compressed_bytecodes()
         .iter()
         .map(|b| bytecode_to_factory_dep(b.original.clone()))
         .collect();
     let modified_keys = storage.borrow().modified_storage_keys().clone();
     (tx_result, bytecodes, modified_keys)
+}
+
+fn get_env_var<T>(name: &str) -> T
+where
+    T: FromStr + Default,
+    T::Err: Debug,
+{
+    std::env::var(name)
+        .map(|value| {
+            value.parse::<T>().unwrap_or_else(|err| {
+                panic!("failed parsing env variable {}={}, {:?}", name, value, err)
+            })
+        })
+        .unwrap_or_default()
 }

--- a/crates/evm/core/src/fork/backend.rs
+++ b/crates/evm/core/src/fork/backend.rs
@@ -193,7 +193,6 @@ where
     fn request_account_storage(&mut self, address: Address, idx: U256, listener: StorageSender) {
         match self.storage_requests.entry((address, idx)) {
             Entry::Occupied(mut entry) => {
-                println!("occupied {:?}, {:?}, {:?}", &address, &idx, &self.block_id);
                 entry.get_mut().push(listener);
             }
             Entry::Vacant(entry) => {

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -113,7 +113,7 @@ impl Executor {
             .expect("failed writing account storage for known codes storage address");
 
         // setup modified keys in inspector to persist cheatcode address setup across forks
-        inspector.modified_storage_keys.insert(
+        inspector.storage_modifications.keys.insert(
             StorageKey::new(
                 AccountTreeId::new(ACCOUNT_CODE_STORAGE_ADDRESS),
                 H256::from_slice(
@@ -122,7 +122,7 @@ impl Executor {
             ),
             H256::from_slice(&empty_contract_code_hash.0),
         );
-        inspector.modified_storage_keys.insert(
+        inspector.storage_modifications.keys.insert(
             StorageKey::new(
                 AccountTreeId::new(zksync_types::H160(CHEATCODE_ADDRESS.0 .0)),
                 H256::from_slice(&empty_contract_code_hash.0),
@@ -350,7 +350,7 @@ impl Executor {
         let result = self.backend.inspect_ref(&mut env, &mut inspector)?;
         // record storage modifications
         if result.result.is_success() {
-            self.inspector.modified_storage_keys = inspector.modified_storage_keys.clone();
+            self.inspector.storage_modifications = inspector.storage_modifications.clone();
         }
         convert_executed_result(env, inspector, result, self.backend.has_snapshot_failure())
     }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -598,7 +598,7 @@ impl StorageModificationRecorder for &mut InspectorStack {
         self.storage_modifications.extend(storage_modifications);
     }
 
-    fn get(&self) -> &StorageModifications {
+    fn get_storage_modifications(&self) -> &StorageModifications {
         &self.storage_modifications
     }
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -5,7 +5,7 @@ use super::{
 use alloy_primitives::{Address, Bytes, B256, U256};
 use ethers_core::types::Log;
 use ethers_signers::LocalWallet;
-use foundry_common::{AsTracerPointer, StorageModificationRecorder};
+use foundry_common::{AsTracerPointer, StorageModificationRecorder, StorageModifications};
 use foundry_evm_core::{
     backend::DatabaseExt, debug::DebugArena, era_revm::storage_view::StorageView,
 };
@@ -18,11 +18,7 @@ use revm::{
     primitives::{BlockEnv, Env},
     EVMData, Inspector,
 };
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
-use zksync_types::{StorageKey, StorageValue};
+use std::{collections::BTreeMap, sync::Arc};
 
 #[derive(Clone, Debug, Default)]
 #[must_use = "builders do nothing unless you call `build` on them"]
@@ -214,7 +210,7 @@ pub struct InspectorStack {
     pub log_collector: Option<LogCollector>,
     pub printer: Option<TracePrinter>,
     pub tracer: Option<Tracer>,
-    pub modified_storage_keys: HashMap<StorageKey, StorageValue>,
+    pub storage_modifications: StorageModifications,
 }
 
 impl InspectorStack {
@@ -591,18 +587,18 @@ impl<DB: DatabaseExt + Send> AsTracerPointer<StorageView<RevmDatabaseForEra<DB>>
     {
         CheatcodeTracer::new(
             self.cheatcodes.as_ref().map(|c| c.config.clone()).unwrap_or_default(),
-            self.modified_storage_keys.clone(),
+            self.storage_modifications.clone(),
         )
         .into_tracer_pointer()
     }
 }
 
 impl StorageModificationRecorder for &mut InspectorStack {
-    fn record_modified_keys(&mut self, modified_keys: &HashMap<StorageKey, StorageValue>) {
-        self.modified_storage_keys.extend(modified_keys);
+    fn record_storage_modifications(&mut self, storage_modifications: StorageModifications) {
+        self.storage_modifications.extend(storage_modifications);
     }
 
-    fn get(&self) -> &HashMap<StorageKey, StorageValue> {
-        &self.modified_storage_keys
+    fn get(&self) -> &StorageModifications {
+        &self.storage_modifications
     }
 }

--- a/crates/zkforge/bin/cmd/zk_create.rs
+++ b/crates/zkforge/bin/cmd/zk_create.rs
@@ -279,6 +279,7 @@ impl ZkCreateArgs {
         project: &Project,
         contract_info: &ContractInfo,
     ) -> eyre::Result<Bytes> {
+        println!("FETCH");
         let output_path = Self::get_path_for_contract_output(project, contract_info);
         let contract_output = Self::get_contract_output(output_path)?;
         let contract_file_codes = &contract_output[contract_info.path.as_ref().unwrap()];

--- a/crates/zkforge/bin/cmd/zk_create.rs
+++ b/crates/zkforge/bin/cmd/zk_create.rs
@@ -279,7 +279,6 @@ impl ZkCreateArgs {
         project: &Project,
         contract_info: &ContractInfo,
     ) -> eyre::Result<Bytes> {
-        println!("FETCH");
         let output_path = Self::get_path_for_contract_output(project, contract_info);
         let contract_output = Self::get_contract_output(output_path)?;
         let contract_file_codes = &contract_output[contract_info.path.as_ref().unwrap()];

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-21"
+channel = "nightly-2023-09-30"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
# What :computer: 
* persists bytecodes on fork

# Why :hand:
* Required to deploy contract in stages other than `setUp` after a fork.

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
* Supersedes https://github.com/matter-labs/foundry-zksync/pull/230
* Still need to fix a edge case
