### PR TITLE
fix: Log matching

### DIFF
--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -2249,7 +2249,7 @@ fn compare_logs(expected_logs: &[LogEntry], actual_logs: &[LogEntry], checks: Em
     while let Some(expected_log) = expected_iter.peek() {
         let mut found = false;
 
-        while let Some(actual_log) = actual_iter.next() {
+        for actual_log in actual_iter.by_ref() {
             if are_logs_equal(expected_log, actual_log, &checks) {
                 found = true;
                 break

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -2247,14 +2247,19 @@ fn compare_logs(expected_logs: &[LogEntry], actual_logs: &[LogEntry], checks: Em
     let mut actual_iter = actual_logs.iter();
 
     while let Some(expected_log) = expected_iter.peek() {
-        if let Some(actual_log) = actual_iter.next() {
+        let mut found = false;
+
+        while let Some(actual_log) = actual_iter.next() {
             if are_logs_equal(expected_log, actual_log, &checks) {
-                expected_iter.next(); // Move to the next expected log
-            } else {
-                return false
+                found = true;
+                break
             }
+        }
+
+        if found {
+            expected_iter.next(); // Move to the next expected log
         } else {
-            // No more actual logs to compare
+            // Expected log not found in the remaining actual logs
             return false
         }
     }

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ExpectEmit.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ExpectEmit.t.sol
@@ -77,6 +77,7 @@ contract Emitter {
         uint256 topic3,
         bytes memory data
     ) public {
+        emit LogTopic1(1, topic2, topic3, data); // Event not expected
         emit LogTopic1(topic1, topic2, topic3, data);
     }
 }


### PR DESCRIPTION
# What :computer: 
* Fix the compare logs function to be correct according to [Foundry documentation](https://book.getfoundry.sh/cheatcodes/expect-emit)

# Why
* In the past implementation if a given log A was expected but was not the first one found in the actual logs it would fail. This is not how the documentation presents the use case. It should need the right order of expected logs but there could be new ones after, before or in the middle of that expected logs. 
