### PR TITLE
fix: zkforge script repeated deploys

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,9 @@
 [submodule "smoke-test/lib/forge-std"]
 	path = smoke-test/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "smoke-test/lib/solmate"]
+	path = smoke-test/lib/solmate
+	url = https://github.com/transmissions11/solmate
+[submodule "smoke-test/lib/openzeppelin-contracts"]
+	path = smoke-test/lib/openzeppelin-contracts
+	url = https://github.com/Openzeppelin/openzeppelin-contracts

--- a/crates/common/src/zk_utils/mod.rs
+++ b/crates/common/src/zk_utils/mod.rs
@@ -176,6 +176,8 @@ pub struct StorageModifications {
     pub keys: HashMap<StorageKey, StorageValue>,
     /// Bytecode modifications.
     pub bytecodes: HashMap<H256, Vec<u8>>,
+    /// Recorded known codes.
+    pub known_codes: HashMap<H256, Vec<u8>>,
 }
 
 impl StorageModifications {
@@ -183,6 +185,7 @@ impl StorageModifications {
     pub fn extend(&mut self, other: StorageModifications) {
         self.keys.extend(other.keys);
         self.bytecodes.extend(other.bytecodes);
+        self.known_codes.extend(other.known_codes);
     }
 }
 

--- a/smoke-test/.gitignore
+++ b/smoke-test/.gitignore
@@ -1,3 +1,6 @@
 zkout/
 solc-v*
 *.log
+era_test_node
+cache/
+broadcast/

--- a/smoke-test/script/Counter.s.sol
+++ b/smoke-test/script/Counter.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {Script} from "forge-std/Script.sol";
+import {Counter} from "../src/Counter.sol";
+
+contract CounterScript is Script, Test {
+    Counter counter;
+
+    function setUp() public {
+        // Deploy the Counter contract
+        counter = new Counter();
+    }
+
+    function run() public {
+        // Set the number to a specific value
+        uint256 initialValue = 42;
+        vm.startBroadcast(address(0xBC989fDe9e54cAd2aB4392Af6dF60f04873A033A));
+        counter.setNumber(initialValue);
+
+        // Increment the number
+        counter.increment();
+        vm.stopBroadcast();
+    }
+}

--- a/smoke-test/script/Counter.s.sol
+++ b/smoke-test/script/Counter.s.sol
@@ -3,14 +3,25 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 import {Script} from "forge-std/Script.sol";
-import {Counter} from "../src/Counter.sol";
+
+contract CounterExample {
+    uint256 public number = 0;
+
+    function increment() public {
+        number += 1;
+    }
+
+    function setNumber(uint256 value) public {
+        number = value;
+    }
+}
 
 contract CounterScript is Script, Test {
-    Counter counter;
+    CounterExample counter;
 
     function setUp() public {
-        // Deploy the Counter contract
-        counter = new Counter();
+        // Deploy the CounterExample contract
+        counter = new CounterExample();
     }
 
     function run() public {

--- a/smoke-test/script/NFT.s.sol
+++ b/smoke-test/script/NFT.s.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+import {NFT} from "../src/NFT.sol";
+
+contract NFTScript is Script {
+    function run() external {
+        vm.startBroadcast();
+
+        new NFT("NFT_tutorial", "TUT12", "baseUri");
+        
+        vm.stopBroadcast();
+    }
+}

--- a/smoke-test/src/Counter.sol
+++ b/smoke-test/src/Counter.sol
@@ -15,6 +15,11 @@ contract Counter {
         console.log("incrementBy", amount);
         number += uint256(amount);
     }
+
+    function setNumber(uint256 value) public {
+        console.log("setNumber", value);
+        number = value;
+    }
 }
 
 contract CounterTest is Test {

--- a/smoke-test/src/Counter.sol
+++ b/smoke-test/src/Counter.sol
@@ -15,11 +15,6 @@ contract Counter {
         console.log("incrementBy", amount);
         number += uint256(amount);
     }
-
-    function setNumber(uint256 value) public {
-        console.log("setNumber", value);
-        number = value;
-    }
 }
 
 contract CounterTest is Test {

--- a/smoke-test/src/NFT.sol
+++ b/smoke-test/src/NFT.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "solmate/tokens/ERC721.sol";
+import "openzeppelin-contracts/contracts/utils/Strings.sol";
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
+
+error MintPriceNotPaid();
+error MaxSupply();
+error NonExistentTokenURI();
+error WithdrawTransfer();
+
+contract NFT is ERC721, Ownable {
+
+    uint8 n = 10;
+    using Strings for uint256;
+    string public baseURI;
+    uint256 public currentTokenId;
+    uint256 public constant TOTAL_SUPPLY = 10_000;
+    uint256 public constant MINT_PRICE = 0.08 ether;
+
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        string memory _baseURI
+    ) ERC721(_name, _symbol) Ownable(msg.sender) {
+        baseURI = _baseURI;
+    }
+
+
+    function mintTo(address recipient) public payable returns (uint256) {
+        if (msg.value != MINT_PRICE) {
+            revert MintPriceNotPaid();
+        }
+        uint256 newTokenId = ++currentTokenId;
+        if (newTokenId > TOTAL_SUPPLY) {
+            revert MaxSupply();
+        }
+        _safeMint(recipient, newTokenId);
+        return newTokenId;
+    }
+
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        if (ownerOf(tokenId) == address(0)) {
+            revert NonExistentTokenURI();
+        }
+        return
+            bytes(baseURI).length > 0
+                ? string(abi.encodePacked(baseURI, tokenId.toString()))
+                : "";
+    }
+
+    function withdrawPayments(address payable payee) external onlyOwner {
+        uint256 balance = address(this).balance;
+        (bool transferTx, ) = payee.call{value: balance}("");
+        if (!transferTx) {
+            revert WithdrawTransfer();
+        }
+    }
+}

--- a/smoke-test/test.sh
+++ b/smoke-test/test.sh
@@ -5,10 +5,13 @@ set -o pipefail -e
 
 SOLC_VERSION=${SOLC_VERSION:-"v0.8.20"}
 SOLC="solc-${SOLC_VERSION}"
+ERA_TEST_NODE_VERSION="v0.1.0-alpha.15"
+ERA_TEST_NODE_PID=0
 BINARY_PATH="../target/release/zkforge"
 
 function cleanup() {
   echo "Cleaning up..."
+  stop_era_test_node
   rm -f "./${SOLC}"
 }
 
@@ -39,6 +42,17 @@ function download_solc() {
   chmod +x "${SOLC}"
 }
 
+function download_era_test_node() {
+  local arch
+  case "$(uname -s)" in
+  Darwin*) arch="apple-darwin" ;;
+  *) arch="unknown-linux-gnu" ;;
+  esac
+  wget --quiet -O "era_test_node.tar.gz" "https://github.com/matter-labs/era-test-node/releases/download/${1}/era_test_node-${1}-x86_64-${arch}.tar.gz"
+  tar -xvf "era_test_node.tar.gz" && rm "era_test_node.tar.gz"
+  chmod +x "era_test_node"
+}
+
 function wait_for_build() {
   local timeout=$1
   while ! [ -x "${BINARY_PATH}" ]; do
@@ -59,13 +73,33 @@ function build_zkforge() {
   wait_for_build 30
 }
 
+function stop_era_test_node() {
+  echo "Stopping era-test-node..."
+  if [ ${ERA_TEST_NODE_PID} -ne 0 ]; then
+    kill -9 "${ERA_TEST_NODE_PID}"
+  fi;
+  ERA_TEST_NODE_PID=0
+  sleep 3
+}
+
+function start_era_test_node() {
+  echo "Starting era-test-node..."
+  ./era_test_node run &
+  ERA_TEST_NODE_PID=$!
+  sleep 3
+}
+
 trap cleanup ERR
 
 echo "Solc: ${SOLC_VERSION}"
 echo "Zkforge binary: ${BINARY_PATH}"
+echo "era-test-node: ${ERA_TEST_NODE_VERSION}"
 
 # Download solc
 download_solc "${SOLC_VERSION}"
+
+# Download era test node
+download_era_test_node "${ERA_TEST_NODE_VERSION}"
 
 # Check for necessary tools
 command -v cargo &>/dev/null || {
@@ -101,5 +135,23 @@ RUST_LOG=debug "${BINARY_PATH}" test --use "./${SOLC}" --match-test 'testFuzz_In
 
 echo "[6] Check invariant test works"
 RUST_LOG=debug "${BINARY_PATH}" test --use "./${SOLC}" --match-test 'invariant_alwaysIncrements' &>run.log || fail "zkforge invariant test failed"
+
+echo "Running scripts..."
+
+echo "[1] Contract transacts"
+start_era_test_node
+RUST_LOG=info "${BINARY_PATH}" script ./script/Counter.s.sol:CounterScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" \
+  --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}"  &>run.log || fail "zkforge script transact failed"
+stop_era_test_node
+
+echo "[2] Contract deploys (once)"
+start_era_test_node
+RUST_LOG=info "${BINARY_PATH}" script ./script/NFT.s.sol:NFTScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" \
+  --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}"  &>run.log || fail "zkforge script deploy (once) failed"
+echo "[3] Contract deploys (twice)"
+RUST_LOG=info "${BINARY_PATH}" script ./script/NFT.s.sol:NFTScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" \
+  --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}"  &>run.log || fail "zkforge script deploy (twice) failed"
+stop_era_test_node
+
 
 success


### PR DESCRIPTION
# What :computer: 
* This would earlier fail as the factory deps would not be added if the contract was already deployed on chain (since it would never return it in the changeset from the VM)
* Adds scripting functionality to smoke tests
* Adds `is Test` to Counter script since `setUp` calls within scripts call `failed()` which is defined on `DSTest`.

# Why :hand:
* Repeated deploys must not fail
* Added smoke tests to prevent regressions

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
* Using a different variation of Counter contract for script as adding `setNumber` causes certain cases of invariant testing to fail in the original contract (as expected)
