### PR TITLE
fix: improve script path detection

### DIFF
--- a/crates/zkforge/bin/cmd/script/build.rs
+++ b/crates/zkforge/bin/cmd/script/build.rs
@@ -88,15 +88,11 @@ impl ScriptArgs {
         let mut contract = CompactContractBytecode::default();
         let mut highlevel_known_contracts = BTreeMap::new();
 
-        dbg!(&self);
-
         //FIXME: remove - we temporarily parse this path:name (possibility)
         // since we don't handle name-only contract for now
         // otherwise self.path would be clean without the :name and we could
         // use that directly
         let contract_info = ContractInfo::from_str(&self.path)?;
-
-        dbg!(&contract_info);
 
         let mut target_fname =
             dunce::canonicalize(contract_info.path.wrap_err("unknown path for contract")?)
@@ -122,8 +118,6 @@ impl ScriptArgs {
             matched: false,
             target_id: None,
         };
-
-        dbg!(&extra_info);
 
         // link_with_nonce_or_address expects absolute paths
         let mut libs = libraries_addresses.clone();
@@ -167,12 +161,9 @@ impl ScriptArgs {
                 // if it's the target contract, grab the info
                 if extra.no_target_name {
                     // Match artifact source, and ignore interfaces
-                    println!("Comparing {} to {}", id.source.display(), extra.target_fname);
                     if id.source == std::path::Path::new(&extra.target_fname) &&
                         contract.bytecode.as_ref().map_or(false, |b| b.object.bytes_len() > 0)
                     {
-                        println!("TARGET CONTRACT");
-                        dbg!(&extra);
                         if extra.matched {
                             eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`")
                         }

--- a/crates/zkforge/bin/cmd/script/build.rs
+++ b/crates/zkforge/bin/cmd/script/build.rs
@@ -180,7 +180,8 @@ impl ScriptArgs {
                             .expect("The target specifier is malformed.");
                     let path = std::path::Path::new(&path);
 
-                    // Make sure the path to script is absolute
+                    // Make sure the path to script is absolute, since
+                    // `script_path` is an absolute path
                     let path = path
                         .is_relative()
                         .then(|| project.root().join(path))

--- a/crates/zkforge/bin/cmd/script/build.rs
+++ b/crates/zkforge/bin/cmd/script/build.rs
@@ -16,7 +16,7 @@ use foundry_compilers::{
     ArtifactId, Project, ProjectCompileOutput,
 };
 
-use std::{collections::BTreeMap, str::FromStr};
+use std::{collections::BTreeMap, path::Path, str::FromStr};
 use zkforge::link::{link_with_nonce_or_address, PostLinkInput, ResolvedDependency};
 
 impl ScriptArgs {
@@ -68,6 +68,7 @@ impl ScriptArgs {
             script_config.config.parsed_libraries()?,
             script_config.evm_opts.sender,
             script_config.sender_nonce,
+            &script_config.config.script,
         )?;
 
         output.sources = sources;
@@ -76,13 +77,14 @@ impl ScriptArgs {
         Ok(output)
     }
 
-    pub fn link(
+    pub fn link<P: AsRef<Path>>(
         &self,
         project: Project,
         contracts: ArtifactContracts,
         libraries_addresses: Libraries,
         sender: Address,
         nonce: u64,
+        script_path: P,
     ) -> Result<BuildOutput> {
         let mut run_dependencies = vec![];
         let mut contract = CompactContractBytecode::default();
@@ -178,11 +180,14 @@ impl ScriptArgs {
                             .expect("The target specifier is malformed.");
                     let path = std::path::Path::new(&path);
 
-                    // Remove dir prefix for files in script/ or scripts/ dir
-                    let new_path = path
-                        .strip_prefix("script/")
-                        .or_else(|_| path.strip_prefix("scripts/"))
-                        .unwrap_or(path);
+                    // Make sure the path to script is absolute
+                    let path = path
+                        .is_relative()
+                        .then(|| project.root().join(path))
+                        .unwrap_or_else(|| path.to_path_buf());
+
+                    // Remove dir prefix for files in script dir
+                    let new_path = path.strip_prefix(&script_path).unwrap_or(&path);
 
                     if new_path == id.source && name == id.name {
                         *extra.dependencies = unique_deps(dependencies);

--- a/crates/zkforge/bin/cmd/script/build.rs
+++ b/crates/zkforge/bin/cmd/script/build.rs
@@ -273,7 +273,6 @@ impl ScriptArgs {
     }
 }
 
-#[derive(Debug)]
 struct ExtraLinkingInfo<'a> {
     no_target_name: bool,
     target_fname: String,

--- a/crates/zkforge/bin/cmd/script/cmd.rs
+++ b/crates/zkforge/bin/cmd/script/cmd.rs
@@ -227,7 +227,7 @@ impl ScriptArgs {
         )
         .await
         .map_err(|err| {
-            eyre::eyre!("{err}\n\nIf you were trying to resume or verify a multi chain deployment, add `--multi` to your command invocation.") 
+            eyre::eyre!("{err}\n\nIf you were trying to resume or verify a multi chain deployment, add `--multi` to your command invocation.")
         })
     }
 
@@ -294,6 +294,7 @@ impl ScriptArgs {
                 Libraries::parse(&deployment_sequence.libraries)?,
                 script_config.config.sender, // irrelevant, since we're not creating any
                 0,                           // irrelevant, since we're not creating any
+                &script_config.config.script,
             )?;
 
             verify.known_contracts = flatten_contracts(&highlevel_known_contracts, false);
@@ -333,6 +334,7 @@ impl ScriptArgs {
             script_config.config.parsed_libraries()?,
             new_sender,
             nonce,
+            &script_config.config.script,
         )?;
 
         let mut txs = self.create_deploy_transactions(


### PR DESCRIPTION
# What :computer: 
* Fixes path detection for running scripts with forge. The `script` folder was only being checked, while the `scripts` folder was missing.

# Why :hand:
* Failing script running with forge

# Evidence :camera:
![image](https://github.com/matter-labs/foundry-zksync/assets/21188659/89e43b3c-95da-44be-998a-ae079e8e692b)
