### PR TITLE
fix: add back removed zksync zkcast subcommands

### DIFF
--- a/crates/zkcast/bin/main.rs
+++ b/crates/zkcast/bin/main.rs
@@ -344,6 +344,9 @@ async fn main() -> Result<()> {
             println!("{}", Cast::new(&provider).transaction(tx_hash, field, raw, json).await?)
         }
 
+        Subcommands::ZkSendTx(cmd) => cmd.run().await?,
+        Subcommands::ZkDepositTx(cmd) => cmd.run().await?,
+
         // 4Byte
         Subcommands::FourByte { selector } => {
             let selector = stdin::unwrap_line(selector)?;

--- a/crates/zkcast/bin/opts.rs
+++ b/crates/zkcast/bin/opts.rs
@@ -2,6 +2,7 @@ use crate::cmd::{
     access_list::AccessListArgs, bind::BindArgs, call::CallArgs, create2::Create2Args,
     estimate::EstimateArgs, find_block::FindBlockArgs, interface::InterfaceArgs, logs::LogsArgs,
     rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs, wallet::WalletSubcommands,
+    zk_deposit::ZkDepositTxArgs, zk_send::ZkSendTxArgs,
 };
 use alloy_primitives::{Address, B256, U256};
 use clap::{Parser, Subcommand, ValueHint};
@@ -434,6 +435,18 @@ pub enum Subcommands {
     /// Sign and publish a transaction.
     #[clap(name = "send", visible_alias = "s")]
     SendTx(SendTxArgs),
+
+    /// Sends zkSync specific transactions for L2 → L1 Withdrawals
+    #[clap(name = "zk-send")]
+    #[clap(visible_aliases = ["zks", "zksend"])]
+    #[clap(about = "Sign and publish a zksync transaction.")]
+    ZkSendTx(ZkSendTxArgs),
+
+    /// Sends zkSync specific transactions for L1 → L2 Deposits
+    #[clap(name = "zk-deposit")]
+    #[clap(visible_aliases = ["zkd", "zkdeposit"])]
+    #[clap(about = "Bridge Assets from L1 to L2.")]
+    ZkDepositTx(ZkDepositTxArgs),
 
     /// Publish a raw transaction to the network.
     #[clap(name = "publish", visible_alias = "p")]


### PR DESCRIPTION
# What :computer: 
* add back removed zksync zkcast subcommands `zk-send`, and `zk-deposit` 

# Why :hand:
* These commands enable L2 → L1 Withdrawals and L1 → L2 Deposits
* Looks like these were removed during the previous rebase

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended
![Screenshot 2024-02-07 at 3 54 39 PM](https://github.com/matter-labs/foundry-zksync/assets/29983536/1b1eb29b-f77f-454b-a1f8-d61eac64d738)

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
