### PR TITLE
feat: update cheatcodes-test CI to use local era-test-node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,11 +96,11 @@ jobs:
 
       steps:
       - name: Checkout code
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.sha }}
-      
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -115,15 +115,33 @@ jobs:
       name: cheatcode-test
       runs-on: ubuntu-22.04-github-hosted-16core
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             submodules: recursive
             ref: ${{ github.event.pull_request.head.sha }}
-  
+
         - name: Install Rust
           uses: actions-rust-lang/setup-rust-toolchain@v1
           with:
             toolchain: nightly-2023-09-30
-  
+
+        - name: Run era-test-node
+          uses: dutterbutter/era-test-node-action@latest
+          with:
+            mode: fork
+            network: mainnet
+            log: info
+            logFilePath: era_test_node.log
+            target: x86_64-unknown-linux-gnu
+            releaseTag: latest
+
         - name: Test Cheatcodes
+          env:
+            RPC_MAINNET: http://localhost:8011
           run: cd crates/era-cheatcodes/tests && ./test.sh
+
+        - name: Upload era_test_node log
+          uses: actions/upload-artifact@v3
+          with:
+            name: era_test_node.log
+            path: era_test_node.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
 
         - name: Test Cheatcodes
           env:
-            RPC_MAINNET: http://localhost:8011
+            ERA_TEST_NODE_RPC_URL: http://localhost:8011
           run: cd crates/era-cheatcodes/tests && ./test.sh
 
         - name: Upload era_test_node log

--- a/crates/era-cheatcodes/tests/foundry.toml
+++ b/crates/era-cheatcodes/tests/foundry.toml
@@ -5,6 +5,6 @@ libs = ['lib']
 
 [rpc_endpoints]
 local = "${ERA_TEST_NODE_RPC_URL}"
-mainnet = "${RPC_MAINNET}"
+mainnet = "https://mainnet.era.zksync.io:443"
 testnet = "https://testnet.era.zksync.dev:443"
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/crates/era-cheatcodes/tests/foundry.toml
+++ b/crates/era-cheatcodes/tests/foundry.toml
@@ -5,6 +5,6 @@ libs = ['lib']
 
 [rpc_endpoints]
 local = "${ERA_TEST_NODE_RPC_URL}"
-mainnet = "https://mainnet.era.zksync.io:443"
+mainnet = "${RPC_MAINNET}"
 testnet = "https://testnet.era.zksync.dev:443"
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/crates/era-cheatcodes/tests/src/cheatcodes/Fork.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/Fork.t.sol
@@ -22,7 +22,7 @@ contract ForkTest is Test {
             "Local node doesn't have blocks above 1000"
         );
 
-        vm.createSelectFork("mainnet", FORK_BLOCK);
+        vm.createSelectFork("local", FORK_BLOCK);
 
         require(decimals_before == 0, "Contract exists locally");
     }
@@ -46,7 +46,7 @@ contract ForkTest is Test {
     }
 
     function testCreateSelectFork() public {
-        uint256 forkId = vm.createFork("mainnet", FORK_BLOCK + 100);
+        uint256 forkId = vm.createFork("local", FORK_BLOCK + 100);
 
         vm.selectFork(forkId);
 
@@ -69,7 +69,7 @@ contract ForkTest is Test {
     }
 
     function testActiveFork() public {
-        uint256 data = vm.createFork("mainnet", FORK_BLOCK + 100);
+        uint256 data = vm.createFork("local", FORK_BLOCK + 100);
 
         uint256 forkId = uint256(bytes32(data));
         vm.selectFork(forkId);

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecode.t.sol
@@ -15,7 +15,7 @@ contract ForkBytecodeTest is Test {
 
     function testCreateSelectForkHasNonDeployedBytecodes() public {
         console.log("run");
-        vm.createSelectFork("mainnet", FORK_BLOCK);
+        vm.createSelectFork("local", FORK_BLOCK);
 
         // target should be able to deploy
         Target target = new Target();
@@ -23,7 +23,7 @@ contract ForkBytecodeTest is Test {
     }
 
     function testSelectForkForkHasNonDeployedBytecodes() public {
-        uint256 forkId = vm.createFork("mainnet", FORK_BLOCK);
+        uint256 forkId = vm.createFork("local", FORK_BLOCK);
         vm.selectFork(forkId);
 
         // target should be able to deploy

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup.t.sol
@@ -14,7 +14,7 @@ contract ForkBytecodeSetupTest is Test {
     uint256 constant FORK_BLOCK = 19579636;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", FORK_BLOCK);
+        vm.createSelectFork("local", FORK_BLOCK);
         Target target = new Target();
         require(255 == target.output(), "incorrect output after fork");
     }

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup2.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkBytecodeSetup2.t.sol
@@ -14,7 +14,7 @@ contract ForkBytecodeSetup2Test is Test {
     uint256 constant FORK_BLOCK = 19579636;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", FORK_BLOCK);
+        vm.createSelectFork("local", FORK_BLOCK);
     }
 
     function testForkBytecodeSetup2Success() public {

--- a/crates/era-cheatcodes/tests/src/cheatcodes/ForkStorage.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/ForkStorage.t.sol
@@ -22,7 +22,7 @@ contract ForkStorageTest is Test {
         // Contract gets successfully deployed
         require(255 == target.output(), "incorrect output");
 
-        vm.createSelectFork("mainnet", FORK_BLOCK);
+        vm.createSelectFork("local", FORK_BLOCK);
 
         // Contract is still deployed
         require(255 == target.output(), "incorrect output after fork");

--- a/crates/era-cheatcodes/tests/src/cheatcodes/Persistent.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/Persistent.t.sol
@@ -22,8 +22,8 @@ contract ForkPersistentTest is Test {
 
     /// checks that marking as persistent works
     function testMakePersistent() public {
-        uint256 fork1 = vm.createFork("mainnet", FORK_BLOCK + 100);
-        uint256 fork2 = vm.createFork("mainnet", FORK_BLOCK + 100);
+        uint256 fork1 = vm.createFork("local", FORK_BLOCK + 100);
+        uint256 fork2 = vm.createFork("local", FORK_BLOCK + 100);
 
         DummyContract dummy = new DummyContract();
 

--- a/crates/era-cheatcodes/tests/src/cheatcodes/RollFork.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/RollFork.t.sol
@@ -8,7 +8,7 @@ contract RollForkTest is Test {
     uint256 mainnetFork;
 
     function setUp() public {
-        mainnetFork = vm.createFork("mainnet");
+        mainnetFork = vm.createFork("local");
     }
 
     // test that we can switch between forks, and "roll" blocks
@@ -22,7 +22,7 @@ contract RollForkTest is Test {
         assertEq(block.number, mainBlock - 1);
 
         // can also roll by id
-        uint256 otherMain = vm.createFork("mainnet", block.number - 1);
+        uint256 otherMain = vm.createFork("local", block.number - 1);
         vm.rollFork(otherMain, mainBlock - 10);
 
         assertEq(block.number, mainBlock - 1); // should not have rolled

--- a/crates/era-cheatcodes/tests/src/cheatcodes/RpcUrls.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/RpcUrls.t.sol
@@ -10,9 +10,7 @@ contract RpcUrlsTest is Test {
         string memory rpc_url = vm.rpcUrl("mainnet");
         require(
             keccak256(bytes(rpc_url)) ==
-                keccak256(
-                    abi.encodePacked("https://mainnet.era.zksync.io:443")
-                ),
+                keccak256(abi.encodePacked(vm.envString("RPC_MAINNET"))),
             "rpc url retrieved does not match expected value"
         );
     }
@@ -34,7 +32,7 @@ contract RpcUrlsTest is Test {
         );
         require(
             keccak256(bytes(rpc_urls[1][1])) ==
-                keccak256("https://mainnet.era.zksync.io:443"),
+                keccak256(bytes(vm.envString("RPC_MAINNET"))),
             "invalid url for [1]"
         );
         require(

--- a/crates/era-cheatcodes/tests/src/cheatcodes/RpcUrls.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/RpcUrls.t.sol
@@ -17,7 +17,7 @@ contract RpcUrlsTest is Test {
         );
     }
 
-    function testRpcUrls() public view {
+    function testRpcUrls() public {
         string[2][] memory rpc_urls = vm.rpcUrls();
 
         require(
@@ -25,7 +25,15 @@ contract RpcUrlsTest is Test {
             "invalid alias for [0]"
         );
         require(
-            keccak256(bytes(rpc_urls[0][1])) == keccak256("local"),
+            keccak256(bytes(rpc_urls[0][1])) ==
+                keccak256(
+                    bytes(
+                        vm.envOr(
+                            string("ERA_TEST_NODE_RPC_URL"),
+                            string("local")
+                        )
+                    )
+                ),
             "invalid url for [0]"
         );
         require(

--- a/crates/era-cheatcodes/tests/src/cheatcodes/RpcUrls.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/RpcUrls.t.sol
@@ -10,7 +10,9 @@ contract RpcUrlsTest is Test {
         string memory rpc_url = vm.rpcUrl("mainnet");
         require(
             keccak256(bytes(rpc_url)) ==
-                keccak256(abi.encodePacked(vm.envString("RPC_MAINNET"))),
+                keccak256(
+                    abi.encodePacked("https://mainnet.era.zksync.io:443")
+                ),
             "rpc url retrieved does not match expected value"
         );
     }
@@ -32,7 +34,7 @@ contract RpcUrlsTest is Test {
         );
         require(
             keccak256(bytes(rpc_urls[1][1])) ==
-                keccak256(bytes(vm.envString("RPC_MAINNET"))),
+                keccak256("https://mainnet.era.zksync.io:443"),
             "invalid url for [1]"
         );
         require(

--- a/crates/era-cheatcodes/tests/src/cheatcodes/Transact.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/Transact.t.sol
@@ -17,7 +17,7 @@ contract CheatcodeTransactTest is Test {
 
     function testTransact() public {
         // A random block https://explorer.zksync.io/block/23942350
-        vm.createSelectFork("mainnet", 23942350);
+        vm.createSelectFork("local", 23942350);
 
         // A random transfer in the next block
         bytes32 transaction = 0x272c2251368cae9eceaea67f52855c9858fd6b00dd68d6dfadab3ab1d66f9e4b;
@@ -50,7 +50,7 @@ contract CheatcodeTransactTest is Test {
 
     function testTransactCooperatesWithCheatcodes() public {
         // A random block https://explorer.zksync.io/block/20570164
-        vm.createSelectFork("mainnet", 20570164);
+        vm.createSelectFork("local", 20570164);
 
         // a random ERC20 USDT transfer transaction in the next block: https://explorer.zksync.io/tx/0xa4124eed3fcb2eea3883915839004107a76597107a74c5eaf00a7d6c43638152
         bytes32 transaction = 0xa4124eed3fcb2eea3883915839004107a76597107a74c5eaf00a7d6c43638152;

--- a/crates/era-cheatcodes/tests/test.sh
+++ b/crates/era-cheatcodes/tests/test.sh
@@ -7,6 +7,7 @@ REPO_ROOT="../../.."
 SOLC_VERSION=${SOLC_VERSION:-"v0.8.20"}
 SOLC="solc-${SOLC_VERSION}"
 BINARY_PATH="${REPO_ROOT}/target/release/zkforge"
+RPC_MAINNET=${RPC_MAINNET:-"https://mainnet.era.zksync.io:443"}
 
 function download_solc() {
   case "$(uname -s)" in

--- a/crates/era-cheatcodes/tests/test.sh
+++ b/crates/era-cheatcodes/tests/test.sh
@@ -7,7 +7,6 @@ REPO_ROOT="../../.."
 SOLC_VERSION=${SOLC_VERSION:-"v0.8.20"}
 SOLC="solc-${SOLC_VERSION}"
 BINARY_PATH="${REPO_ROOT}/target/release/zkforge"
-RPC_MAINNET=${RPC_MAINNET:-"https://mainnet.era.zksync.io:443"}
 
 function download_solc() {
   case "$(uname -s)" in


### PR DESCRIPTION
# What :computer: 
* Update cheatcodes-test CI to use local era-test-node

# Why :hand:
* To fix rate limit issue caused when executing cheatcodes-test CI due to rate limiting by mainnet RPC

# Evidence :camera:
CI run.