### PR TITLE
fix: script broadcast error and request memoization on zksolc

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -132,7 +132,7 @@ pub struct Cheatcodes {
     pub labels: HashMap<Address, String>,
 
     /// Remembered private keys
-    pub script_wallets: Vec<LocalWallet>,
+    pub script_wallets: Arc<RwLock<Vec<LocalWallet>>>,
 
     /// Whether the skip cheatcode was activated
     pub skip: bool,

--- a/crates/cheatcodes/src/script.rs
+++ b/crates/cheatcodes/src/script.rs
@@ -112,7 +112,7 @@ fn broadcast_key<DB: DatabaseExt>(
 
     let result = broadcast(ccx, Some(new_origin), single_call);
     if result.is_ok() {
-        ccx.state.script_wallets.push(wallet);
+        ccx.state.script_wallets.write().unwrap().push(wallet);
     }
     result
 }

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -89,7 +89,7 @@ impl Cheatcode for rememberKeyCall {
         let Self { privateKey } = self;
         let wallet = parse_wallet(privateKey)?.with_chain_id(ccx.data.env.cfg.chain_id);
         let address = wallet.address();
-        ccx.state.script_wallets.push(wallet);
+        ccx.state.script_wallets.write().unwrap().push(wallet);
         Ok(address.to_alloy().abi_encode())
     }
 }

--- a/crates/common/src/zksolc_manager.rs
+++ b/crates/common/src/zksolc_manager.rs
@@ -68,9 +68,10 @@ pub enum ZkSolcVersion {
     V1321,
     V1322,
     V1323,
+    V140,
 }
 
-pub const DEFAULT_ZKSOLC_VERSION: &str = "v1.3.23";
+pub const DEFAULT_ZKSOLC_VERSION: &str = "v1.4.0";
 
 /// `parse_version` parses a string representation of a `zksolc` compiler version
 /// and returns the `ZkSolcVersion` enum variant if it matches a supported version.
@@ -101,6 +102,7 @@ fn parse_version(version: &str) -> Result<ZkSolcVersion> {
         "v1.3.21" => Ok(ZkSolcVersion::V1321),
         "v1.3.22" => Ok(ZkSolcVersion::V1322),
         "v1.3.23" => Ok(ZkSolcVersion::V1323),
+        "v1.4.0" => Ok(ZkSolcVersion::V140),
         _ => Err(Error::msg(
             "ZkSolc compiler version not supported. Proper version format: 'v1.3.x'",
         )),
@@ -131,6 +133,7 @@ impl ZkSolcVersion {
             ZkSolcVersion::V1321 => "v1.3.21",
             ZkSolcVersion::V1322 => "v1.3.22",
             ZkSolcVersion::V1323 => "v1.3.23",
+            ZkSolcVersion::V140 => "v1.4.0",
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1049,6 +1049,7 @@ impl Config {
             mode: Some(mode),
             details,
             fallback_to_optimizing_for_size: Some(self.fallback_oz),
+            disable_system_request_memoization: false,
         }
     }
 

--- a/crates/config/src/zksolc_config.rs
+++ b/crates/config/src/zksolc_config.rs
@@ -118,6 +118,9 @@ pub struct Optimizer {
     /// Whether to try to recompile with -Oz if the bytecode is too large.
     #[serde(rename = "fallbackToOptimizingForSize")]
     pub fallback_to_optimizing_for_size: Option<bool>,
+    /// Whether to disable the system request memoization.
+    #[serde(rename = "disableSystemRequestMemoization")]
+    pub disable_system_request_memoization: bool,
 }
 /// A builder for `ZkSolcConfig`.
 #[derive(Default)]

--- a/crates/era-cheatcodes/src/cheatcodes.rs
+++ b/crates/era-cheatcodes/src/cheatcodes.rs
@@ -6,7 +6,10 @@ use crate::{
 use alloy_primitives::{Address, Bytes, FixedBytes, I256 as rI256};
 use alloy_sol_types::{SolInterface, SolValue};
 use era_test_node::utils::bytecode_to_factory_dep;
-use ethers::{signers::Signer, types::TransactionRequest};
+use ethers::{
+    signers::{LocalWallet, Signer},
+    types::TransactionRequest,
+};
 use eyre::Context;
 use foundry_cheatcodes::{BroadcastableTransaction, BroadcastableTransactions, CheatsConfig};
 use foundry_cheatcodes_spec::Vm;
@@ -169,6 +172,7 @@ pub struct CheatcodeTracer {
     transact_logs: Vec<LogEntry>,
     mocked_calls: MockedCalls,
     farcall_handler: FarCallHandler,
+    script_wallets: Arc<RwLock<Vec<LocalWallet>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -1124,11 +1128,13 @@ impl CheatcodeTracer {
         cheatcodes_config: Arc<CheatsConfig>,
         storage_modifications: StorageModifications,
         broadcastable_transactions: Arc<RwLock<BroadcastableTransactions>>,
+        script_wallets: Arc<RwLock<Vec<LocalWallet>>>,
     ) -> Self {
         Self {
             config: cheatcodes_config,
             storage_modifications,
             broadcastable_transactions,
+            script_wallets,
             ..Default::default()
         }
     }
@@ -1898,6 +1904,7 @@ impl CheatcodeTracer {
 
                 let origin = wallet.address();
                 tracing::info!("👷 Starting broadcast with origin from private key: {origin}");
+                self.script_wallets.write().unwrap().push(wallet);
                 self.start_broadcast(&storage, &state, Some(origin))
             }
             startPrank_0(startPrank_0Call { msgSender: msg_sender }) => {

--- a/crates/era-cheatcodes/tests/src/cheatcodes/Roll.t.sol
+++ b/crates/era-cheatcodes/tests/src/cheatcodes/Roll.t.sol
@@ -5,7 +5,6 @@ import {Test, console2 as console} from "../../lib/forge-std/src/Test.sol";
 import {Constants} from "./Constants.sol";
 
 contract CheatcodeRollTest is Test {
-    address constant TEST_ADDRESS = 0x6Eb28604685b1F182dAB800A1Bfa4BaFdBA8a79a;
     uint256 constant NEW_BLOCK_NUMBER = 10;
 
     function testRoll() public {

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -635,9 +635,10 @@ impl Executor {
     /// Adjust the gas parameters of an executor for ZKSync.
     /// zksync vm allows max gas limit to be u32, and additionally the account balance must be able
     /// to pay for the gas + value. Hence we cap the gas limit what the caller can actually pay.
-    pub fn adjust_zksync_gas_parameters(&mut self) {
+    pub fn adjust_zksync_gas_parameters(&mut self, override_caller: Option<Address>) {
         let tx_env = &self.env.tx;
-        let caller_balance = self.get_balance(tx_env.caller).unwrap_or_default();
+        let caller = override_caller.unwrap_or(tx_env.caller);
+        let caller_balance = self.get_balance(caller).unwrap_or_default();
         let min_gas_price =
             u256_to_revm_u256(fix_l2_gas_price(revm_u256_to_u256(tx_env.gas_price)));
         let max_allowed_gas_limit = caller_balance

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -313,7 +313,7 @@ impl InspectorStack {
             script_wallets: self
                 .cheatcodes
                 .as_ref()
-                .map(|cheatcodes| cheatcodes.script_wallets.clone())
+                .map(|cheatcodes| cheatcodes.script_wallets.read().unwrap().clone())
                 .unwrap_or_default(),
             cheatcodes: self.cheatcodes,
             chisel_state: self.chisel_state.and_then(|state| state.state),
@@ -593,6 +593,7 @@ impl<DB: DatabaseExt + Send> AsTracerPointer<StorageView<RevmDatabaseForEra<DB>>
                 .as_ref()
                 .map(|c| c.broadcastable_transactions.clone())
                 .unwrap_or_default(),
+            self.cheatcodes.as_ref().map(|c| c.script_wallets.clone()).unwrap_or_default(),
         )
         .into_tracer_pointer()
     }

--- a/crates/zkforge/bin/cmd/script/executor.rs
+++ b/crates/zkforge/bin/cmd/script/executor.rs
@@ -144,7 +144,10 @@ impl ScriptArgs {
                     .get(transaction.rpc.as_ref().expect("to have been filled already."))
                     .expect("to have been built.")
                     .write();
-                runner.executor.adjust_zksync_gas_parameters();
+
+                runner.executor.adjust_zksync_gas_parameters(
+                    transaction.transaction.from().map(|a| a.to_alloy()),
+                );
 
                 let deps = transaction.factory_deps;
                 if let TypedTransaction::Legacy(mut tx) = transaction.transaction {

--- a/crates/zkforge/bin/cmd/script/runner.rs
+++ b/crates/zkforge/bin/cmd/script/runner.rs
@@ -192,7 +192,7 @@ impl ScriptRunner {
 
     /// Executes the method that will collect all broadcastable transactions.
     pub fn script(&mut self, address: Address, calldata: Bytes) -> Result<ScriptResult> {
-        self.executor.adjust_zksync_gas_parameters();
+        self.executor.adjust_zksync_gas_parameters(None);
         self.call(self.sender, address, calldata, U256::ZERO, false)
     }
 

--- a/crates/zkforge/bin/cmd/test/mod.rs
+++ b/crates/zkforge/bin/cmd/test/mod.rs
@@ -175,6 +175,9 @@ impl TestArgs {
         let compiler_path = setup_zksolc_manager(DEFAULT_ZKSOLC_VERSION.to_owned()).await?;
         zksolc_cfg.compiler_path = compiler_path;
 
+        // Disable system request memoization to allow modifying system contracts storage
+        zksolc_cfg.settings.optimizer.disable_system_request_memoization = true;
+
         let mut zksolc = ZkSolc::new(zksolc_cfg, project);
         let (output, contract_bytecodes) = match zksolc.compile() {
             Ok(compiled) => compiled,


### PR DESCRIPTION
# What :computer: 
* Fixes script broadcast deployment when using a private key
* Upgrades zksolc to v.1.4.0
* Disables request memoization (zksolc >= v.1.3.3) which allows for modifying system contracts storage on foundry tests

# Why :hand:
* Fix #261
* Fix era-cheatcodes tests failing

# Evidence :camera:
![image](https://github.com/matter-labs/foundry-zksync/assets/21188659/77ef2d16-f505-44f4-aacc-a007066e1629)
![image](https://github.com/matter-labs/foundry-zksync/assets/21188659/457634f1-dcd8-471e-a7c2-89bf48fddb2c)
