### PR TITLE
chore: always upload era-test-node logs in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,7 @@ jobs:
 
         - name: Upload era_test_node log
           uses: actions/upload-artifact@v3
+          if: always()
           with:
             name: era_test_node.log
             path: era_test_node.log


### PR DESCRIPTION
# What :computer: 
* always upload era-test-node logs in ci

# Why :hand:
* The logs are especially important when cheatcode test failurer occur.

# Evidence :camera:
-

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
