### PR TITLE
feat: add deploy and rebuild on missing library dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,11 +2226,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
 ]
@@ -7374,9 +7373,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -12681,6 +12680,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "anvil",
+ "async-recursion",
  "async-trait",
  "axum",
  "clap 4.4.6",

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1303,6 +1303,22 @@ impl Config {
         })
     }
 
+    /// Sets the `libraries` entry inside a `foundry.toml` file but only if it exists
+    ///
+    /// # Errors
+    ///
+    /// An error if the `foundry.toml` could not be parsed.
+    pub fn update_libraries(&self) -> eyre::Result<()> {
+        self.update(|doc| {
+            let profile = self.profile.as_str().as_str();
+            let libraries: toml_edit::Value =
+                self.libraries.iter().map(toml_edit::Value::from).collect();
+            let libraries = toml_edit::value(libraries);
+            doc[Config::PROFILE_SECTION][profile]["libraries"] = libraries;
+            true
+        })
+    }
+
     /// Serialize the config type as a String of TOML.
     ///
     /// This serializes to a table with the name of the profile

--- a/crates/zkforge/Cargo.toml
+++ b/crates/zkforge/Cargo.toml
@@ -53,6 +53,7 @@ alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
 
+async-recursion = "1.0.5"
 async-trait = "0.1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete = "4"

--- a/crates/zkforge/bin/cmd/zk_build.rs
+++ b/crates/zkforge/bin/cmd/zk_build.rs
@@ -144,7 +144,8 @@ impl ZkBuildArgs {
         zksolc_cfg.compiler_path = compiler_path;
 
         // TODO: add filter support
-        let _ = foundry_common::zk_compile::compile_smart_contracts(zksolc_cfg, project);
+        foundry_common::zk_compile::compile_smart_contracts(zksolc_cfg, project)?;
+
         Ok(())
     }
     /// Returns the `Project` for the current workspace


### PR DESCRIPTION
# What :computer: 
* Adds the feature to detect missing library dependencies on build
* Adds the feature to deploy missing library dependencies and rebuild project

The flow for detecting and deploing missing library dependencies is the following:

1. Developer attempts to build the project with zkforge zkbuild.
2. Compilation fails due to missing library dependencies.
3. Developer is prompted to deploy libraries first. Information of missing library dependencies is saved to a temporary file in the project.
4. User runs zkforge zkcreate --deploy-missing-libraries --private-key <PRIVATE_KEY> --rpc-url <RPC_URL> --chain <CHAIN>
5. Libraries are built and deployed following the necessary order to avoid having missing library dependencies, e.g.:
    a. Contract Counter depends on library Math which itself depends on library FixedPoint.
    b. Zkforge detects this dependency tree, and starts by building and deploying FixedPoint.
    c. After FixedPoint has been deployed, Math library is built and deployed linking the address of the deployed FixedPoint library.
    d. Finally, the `foundry.toml` configuration file is updated with the deployed addresses of the libraries
6. Project is built with the linked dependencies.

# Why :hand:
* Fixes #260 

# Evidence :camera:
-