### PR TITLE
fix: bump svm version to `v0.3.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10701,9 +10701,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.3.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597e3a746727984cb7ea2487b6a40726cad0dbe86628e7d429aa6b8c4c153db4"
+checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
 dependencies = [
  "dirs 5.0.1",
  "fs2",

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -1053,8 +1053,8 @@ impl ZkSolc {
     /// The versioned sources can then be used for further processing or analysis.
     fn get_versioned_sources(&mut self) -> Result<BTreeMap<Solc, SolidityVersionSources>> {
         // Step 1: Retrieve Project Sources
-        let sources = self.project.paths.read_input_files()
-            .wrap_err("Could not read input files")?;
+        let sources =
+            self.project.paths.read_input_files().wrap_err("Could not read input files")?;
 
         // Step 2: Resolve Graph of Sources and Versions
         let graph = Graph::resolve_sources(&self.project.paths, sources)

--- a/crates/common/src/zk_compile.rs
+++ b/crates/common/src/zk_compile.rs
@@ -193,7 +193,7 @@ pub fn compile_smart_contracts(
             Ok(output)
         }
         Err(err) => {
-            eyre::bail!("Failed to compile smart contracts with zksolc: {}", err);
+            eyre::bail!("Failed to compile smart contracts with zksolc: {:#}", err);
         }
     }
 }
@@ -940,7 +940,8 @@ impl ZkSolc {
     /// The versioned sources can then be used for further processing or analysis.
     fn get_versioned_sources(&mut self) -> Result<BTreeMap<Solc, SolidityVersionSources>> {
         // Step 1: Retrieve Project Sources
-        let sources = self.project.paths.read_input_files()?;
+        let sources = self.project.paths.read_input_files()
+            .wrap_err("Could not read input files")?;
 
         // Step 2: Resolve Graph of Sources and Versions
         let graph = Graph::resolve_sources(&self.project.paths, sources)

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -88,7 +88,7 @@ paste = "1.0"
 path-slash = "0.2"
 pretty_assertions.workspace = true
 serial_test = "2"
-svm = { package = "svm-rs", version = "0.3", default-features = false, features = ["rustls"] }
+svm = { package = "svm-rs", version = "0.3.5", default-features = false, features = ["rustls"] }
 tempfile = "3"
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 

--- a/crates/zkforge/Cargo.toml
+++ b/crates/zkforge/Cargo.toml
@@ -94,7 +94,7 @@ paste = "1.0"
 path-slash = "0.2"
 pretty_assertions.workspace = true
 serial_test = "2"
-svm = { package = "svm-rs", version = "0.3", default-features = false, features = ["rustls"] }
+svm = { package = "svm-rs", version = "0.3.5", default-features = false, features = ["rustls"] }
 tempfile = "3"
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 

--- a/crates/zkforge/bin/cmd/zk_build.rs
+++ b/crates/zkforge/bin/cmd/zk_build.rs
@@ -144,7 +144,7 @@ impl ZkBuildArgs {
         zksolc_cfg.compiler_path = compiler_path;
 
         // TODO: add filter support
-        let _ = foundry_common::zk_compile::compile_smart_contracts(zksolc_cfg, project);
+        foundry_common::zk_compile::compile_smart_contracts(zksolc_cfg, project)?;
         Ok(())
     }
     /// Returns the `Project` for the current workspace


### PR DESCRIPTION
# What :computer: 
* Update `svm` crate version `v0.3.0` -> `v0.3.5`.
* Add error handling to the `zkbuild` command of the zkforge.

# Why :hand:
* To support the `solc` `^0.8.21`. You can check the previous list of supported versions [here](https://raw.githubusercontent.com/alloy-rs/solc-builds/55ef6c89b8a09c16feee4a424f8a53f822831a61/macosx/aarch64/list.json) (it is specific for macOs and aarch, but for other variations of OSs and ARCHs the max version is the same). And [here](https://raw.githubusercontent.com/alloy-rs/solc-builds/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64/list.json) is the updated one.
* To improve the user experience. Otherwise, it ignores errors and makes debugging impossible.
* Fixes #272
* Fixes #276 

# Evidence :camera:
<img width="1451" alt="image" src="https://github.com/matter-labs/foundry-zksync/assets/57064990/e55e130a-ad22-4821-9856-e236dd8d4e1b">

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
