### PR TITLE
fix: remove fork usage in era-test-node ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,8 +128,7 @@ jobs:
         - name: Run era-test-node
           uses: dutterbutter/era-test-node-action@latest
           with:
-            mode: fork
-            network: mainnet
+            mode: run
             log: info
             logFilePath: era_test_node.log
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,9 @@ jobs:
         - name: Run era-test-node
           uses: dutterbutter/era-test-node-action@latest
           with:
-            mode: run
+            mode: fork
+            network: mainnet
+            forkAtHeight: 20760265
             log: info
             logFilePath: era_test_node.log
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
# What :computer: 
* Removes `fork` usage in era-test-node GH action

# Why :hand:
* If there are protocol updates in zksync-era, the fork feature on era-test-node breaks until updated

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
