### PR TITLE
chore: fix typos

### DIFF
--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -28,7 +28,7 @@ impl CheatsManager {
         let mut state = self.state.write();
         // When somebody **explicitly** impersonates an account we need to store it so we are able
         // to return it from `eth_accounts`. That's why we do not simply call `is_impersonated()`
-        // which does not check that list when auto impersonation is enabeld.
+        // which does not check that list when auto impersonation is enabled.
         if state.impersonated_accounts.contains(&addr) {
             // need to check if already impersonated, so we don't overwrite the code
             return true

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1130,7 +1130,7 @@ impl SimpleCast {
         Ok(format!("{sign}{value}"))
     }
 
-    /// Concatencates hex strings
+    /// Concatenates hex strings
     ///
     /// # Example
     ///

--- a/crates/zkforge/tests/it/fork.rs
+++ b/crates/zkforge/tests/it/fork.rs
@@ -92,7 +92,7 @@ async fn test_transact_fork() {
     TestConfig::filter(filter).await.run().await;
 }
 
-/// Tests that we can create the same fork (provider,block) concurretnly in different tests
+/// Tests that we can create the same fork (provider,block) concurrently in different tests
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_same_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}ForkSame"));


### PR DESCRIPTION
1. Fix `crates/anvil/src/eth/backend/cheats.rs`  typo
2. Fix `crates/cast/src/lib.rs`  typo
3. Fix `crates/zkforge/tests/it/fork.rs`  typo