### PR TITLE
fix: use tx_nonce for transactions, handle multiple deploys for same bytecode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,7 +4909,6 @@ dependencies = [
  "dirs 5.0.1",
  "eyre",
  "foundry-compilers",
- "futures 0.3.30",
  "globset",
  "reqwest",
  "semver 1.0.22",

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -371,6 +371,9 @@ impl Cheatcodes {
         let account_code_account = ACCOUNT_CODE_STORAGE_ADDRESS.to_address();
         journaled_account(data, account_code_account).expect("failed to load account");
 
+        // TODO we might need to store the deployment nonce under the contract storage
+        // to not lose it across VMs.
+
         let block_info_key = CURRENT_VIRTUAL_BLOCK_INFO_POSITION.to_ru256();
         let (block_info, _) =
             data.journaled_state.sload(system_account, block_info_key, data.db).unwrap_or_default();
@@ -464,6 +467,7 @@ impl Cheatcodes {
             let nonce_key = get_nonce_key(&zk_address).key().to_ru256();
             l2_eth_storage.insert(balance_key, StorageSlot::new(info.balance));
 
+            // TODO we need to find a proper way to handle deploy nonces instead of replicating
             let full_nonce = nonces_to_full_nonce(info.nonce.into(), info.nonce.into());
             nonce_storage.insert(nonce_key, StorageSlot::new(full_nonce.to_ru256()));
 

--- a/crates/zksync/compiler/Cargo.toml
+++ b/crates/zksync/compiler/Cargo.toml
@@ -29,7 +29,6 @@ ansi_term = "0.12.1"
 globset = "0.4"
 eyre = "0.6"
 semver = "1"
-futures = "0.3"
 url = "2"
 anyhow = { version = "1.0.70" }
 dirs = { version = "5.0.0" }

--- a/crates/zksync/compiler/src/zksolc/config.rs
+++ b/crates/zksync/compiler/src/zksolc/config.rs
@@ -338,8 +338,23 @@ impl ZkSolcConfigBuilder {
         let compiler_path = if let Some(compiler_path) = self.compiler_path {
             compiler_path
         } else if let Some(compiler_version) = self.compiler_version {
-            futures::executor::block_on(setup_zksolc_manager(compiler_version))
-                .map_err(|err| format!("failed setting up zksolc: {err:?}"))?
+            // TODO: we are forcibly converting this method to sync since it can be called either
+            // within a sync (tests) or async (binary) context. We should fix that and stick to
+            // a single context
+            match tokio::runtime::Handle::try_current() {
+                Ok(handle) => std::thread::spawn(move || {
+                    handle
+                        .block_on(setup_zksolc_manager(compiler_version))
+                        .map_err(|err| err.to_string())
+                })
+                .join()
+                .map_err(|err| format!("{err:?}"))?,
+                Err(_) => tokio::runtime::Runtime::new()
+                    .expect("failed starting runtime")
+                    .block_on(setup_zksolc_manager(compiler_version))
+                    .map_err(|err| err.to_string()),
+            }
+            .map_err(|err| format!("failed setting up zksolc: {err:?}"))?
         } else {
             return Err("must specify either the compiler_version or compiler_path".to_string());
         };

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -159,3 +159,9 @@ pub async fn estimate_gas<M: Middleware>(
 
     Ok(EstimatedGas { price: gas_price.to_ru256(), limit: fee.gas_limit.to_ru256() })
 }
+
+/// Returns true if the provided address is a reserved zkSync system address
+/// All addresses less than 2^16 are considered reserved addresses.
+pub fn is_system_address(address: Address) -> bool {
+    address.to_h256().to_ru256().lt(&rU256::from(2u128.pow(16)))
+}

--- a/crates/zksync/core/src/state.rs
+++ b/crates/zksync/core/src/state.rs
@@ -2,10 +2,10 @@ use revm::primitives::{Address as rAddress, U256 as rU256};
 
 use zksync_types::{
     get_nonce_key,
-    utils::{nonces_to_full_nonce, storage_key_for_eth_balance},
+    utils::{decompose_full_nonce, nonces_to_full_nonce, storage_key_for_eth_balance},
 };
 
-use crate::convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertU256};
+use crate::convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256};
 
 /// Returns balance storage slot
 pub fn get_balance_storage(address: rAddress) -> (rAddress, rU256) {
@@ -26,4 +26,19 @@ pub fn get_nonce_storage(address: rAddress) -> (rAddress, rU256) {
 /// Returns full nonce value
 pub fn new_full_nonce(tx_nonce: u64, deploy_nonce: u64) -> rU256 {
     nonces_to_full_nonce(tx_nonce.into(), deploy_nonce.into()).to_ru256()
+}
+
+/// Represents a ZKSync account nonce with two 64-bit transaction and deployment nonces.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct FullNonce {
+    /// Transaction nonce.
+    pub tx_nonce: u64,
+    /// Deployment nonce.
+    pub deploy_nonce: u64,
+}
+
+/// Decomposes a full nonce into transaction and deploy nonces.
+pub fn parse_full_nonce(full_nonce: rU256) -> FullNonce {
+    let (tx, deploy) = decompose_full_nonce(full_nonce.to_u256());
+    FullNonce { tx_nonce: tx.as_u64(), deploy_nonce: deploy.as_u64() }
 }

--- a/crates/zksync/core/src/vm/db.rs
+++ b/crates/zksync/core/src/vm/db.rs
@@ -115,7 +115,7 @@ where
         Self { db, journaled_state, factory_deps, override_keys }
     }
 
-    /// Returns the nonce for a given account from NonceHolder storage.
+    /// Returns the code hash for a given account from AccountCode storage.
     pub fn get_code_hash(&mut self, address: Address) -> H256 {
         let address = address.to_h160();
         let code_key = get_code_key(&address);

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -80,15 +80,11 @@ where
     );
 
     let caller = env.tx.caller;
-    let (transact_to, nonce) = match env.tx.transact_to {
-        TransactTo::Call(to) => {
-            (to.to_h160(), ZKVMData::new(db, &mut journaled_state).get_tx_nonce(caller))
-        }
+    let nonce = ZKVMData::new(db, &mut journaled_state).get_tx_nonce(caller);
+    let transact_to = match env.tx.transact_to {
+        TransactTo::Call(to) => to.to_h160(),
         TransactTo::Create(CreateScheme::Create) |
-        TransactTo::Create(CreateScheme::Create2 { .. }) => (
-            CONTRACT_DEPLOYER_ADDRESS,
-            ZKVMData::new(db, &mut journaled_state).get_deploy_nonce(caller),
-        ),
+        TransactTo::Create(CreateScheme::Create2 { .. }) => CONTRACT_DEPLOYER_ADDRESS,
     };
 
     let (gas_limit, max_fee_per_gas) = gas_params(env, db, &mut journaled_state, caller);
@@ -174,7 +170,7 @@ where
     let caller = call.caller;
     let calldata = encode_create_params(&call.scheme, contract.zk_bytecode_hash, constructor_input);
     let factory_deps = vec![contract.zk_deployed_bytecode.clone()];
-    let nonce = ZKVMData::new(db, journaled_state).get_deploy_nonce(caller);
+    let nonce = ZKVMData::new(db, journaled_state).get_tx_nonce(caller);
 
     let (gas_limit, max_fee_per_gas) = gas_params(env, db, journaled_state, caller);
     let tx = L2Tx::new(
@@ -373,6 +369,22 @@ where
                 let bytecode = Bytecode::new_raw(Bytes::from(bytecode));
                 let hash = B256::from_slice(v.as_bytes());
                 codes.insert(k.key().to_h160().to_address(), (hash, bytecode));
+            } else {
+                // We populate bytecodes for all non-system addresses
+                let contract_address = k.key().to_ru256();
+                if !contract_address.lt(&rU256::from(2u128.pow(16))) {
+                    if let Some(bytecode) = (&mut era_db).load_factory_dep(*v) {
+                        let hash = B256::from_slice(v.as_bytes());
+                        let bytecode = Bytecode::new_raw(Bytes::from(bytecode));
+                        codes.insert(k.key().to_h160().to_address(), (hash, bytecode));
+                    } else {
+                        tracing::warn!(
+                            "no bytecode was found for {:?} requested by account {:?}",
+                            *v,
+                            k.key().to_h160()
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -1,5 +1,6 @@
 use crate::{
     convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
+    is_system_address,
     vm::tracer::CheatcodeTracer,
 };
 use alloy_primitives::Log;
@@ -371,15 +372,14 @@ where
                 codes.insert(k.key().to_h160().to_address(), (hash, bytecode));
             } else {
                 // We populate bytecodes for all non-system addresses
-                let contract_address = k.key().to_ru256();
-                if !contract_address.lt(&rU256::from(2u128.pow(16))) {
+                if !is_system_address(k.key().to_h160().to_address()) {
                     if let Some(bytecode) = (&mut era_db).load_factory_dep(*v) {
                         let hash = B256::from_slice(v.as_bytes());
                         let bytecode = Bytecode::new_raw(Bytes::from(bytecode));
                         codes.insert(k.key().to_h160().to_address(), (hash, bytecode));
                     } else {
                         tracing::warn!(
-                            "no bytecode was found for {:?} requested by account {:?}",
+                            "no bytecode was found for {:?}, requested by account {:?}",
                             *v,
                             k.key().to_h160()
                         );

--- a/zk-tests/test.sh
+++ b/zk-tests/test.sh
@@ -28,7 +28,6 @@ function success() {
 
 function fail() {
   echo "Displaying run.log..."
-  cat run.log
   echo ''
   echo '=================================='
   printf "\e[31m> [FAILURE]\e[0m %s\n" "$1"
@@ -130,6 +129,7 @@ RUST_LOG=warn "${BINARY_PATH}" test --use "./${SOLC}" -vvv --zksync  || fail "fo
 echo "Running script..."
 start_era_test_node
 RUST_LOG=warn "${BINARY_PATH}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}" --slow  -vvv  || fail "forge script failed"
+RUST_LOG=warn "${BINARY_PATH}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}" --slow  -vvv  || fail "forge script failed on 2nd deploy"
 stop_era_test_node
 
 success


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
* Transaction failures due to duplicate (deployment) nonces
* Multiple deployments of the same contract do not return the bytecode for subsequent deployments, and as such the new address (from second deployment onwards) does not have a valid bytecode causing failures.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* Deployment nonces are handled internally, and as such only transaction nonces must be used for both `CALL` and `CREATE`
* For all non-system addresses, the bytecode is fetched via rpc and stored in the foundry account info.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
smoke test passes
![image](https://github.com/matter-labs/foundry-zksync/assets/1564843/e2dc86e8-890c-4d6a-a3b8-f06729c4a548)
