### PR TITLE
fix: prevent tx from zkSync reserved addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,6 +4801,7 @@ dependencies = [
  "foundry-evm-core",
  "foundry-evm-coverage",
  "foundry-evm-traces",
+ "foundry-zksync-core",
  "hashbrown 0.14.3",
  "itertools 0.11.0",
  "parking_lot 0.12.1",

--- a/crates/evm/fuzz/Cargo.toml
+++ b/crates/evm/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ foundry-config.workspace = true
 foundry-evm-core.workspace = true
 foundry-evm-coverage.workspace = true
 foundry-evm-traces.workspace = true
+foundry-zksync-core.workspace = true
 
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-json-abi.workspace = true

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -105,7 +105,13 @@ fn select_random_sender(
         ),
     ])
     // Too many exclusions can slow down testing.
-    .prop_filter("senders not allowed", move |addr| !senders_ref.excluded.contains(addr))
+    .prop_filter("senders not allowed", move |addr| {
+        // TODO: Make this depended on the --zksync flag
+        // As of now this will exclude address < 2^16 also for evm fuzz tests
+        !senders_ref.excluded.contains(addr) &&
+            !foundry_zksync_core::is_system_address(*addr) &&
+            addr != &foundry_evm_core::constants::CHEATCODE_ADDRESS
+    })
     .boxed();
     if !senders.targeted.is_empty() {
         any::<prop::sample::Selector>()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
fuzz tester can currently fuzz the sender address and pick from the zkSync reserved address space (`< 65536`)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Exclude sender addresses below `65536`. This solution is currently applying to all fuzz tests and not just zksync ones.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
