### PR TITLE
chore: update binary location in installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For the most effective use of our library, we recommend familiarizing yourself w
 
 Follow these steps to quickly install the binaries for `foundry-zksync`:
 
-Note: This installation overrides any existing forge and cast binaries in ~/.foundry. You can use forge without the --zksync flag for standard EVM chains. To revert to a previous installation, follow the instructions [here](https://book.getfoundry.sh/getting-started/installation#using-foundryup).
+**Note:** This installation overrides any existing forge and cast binaries in ~/.foundry. You can use forge without the --zksync flag for standard EVM chains. To revert to a previous installation, follow the instructions [here](https://book.getfoundry.sh/getting-started/installation#using-foundryup).
 
 1. **Clone the Repository**:
    Begin by cloning the `foundry-zksync` repository from GitHub. This will download the latest version of the source code to your local machine.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ For the most effective use of our library, we recommend familiarizing yourself w
 
 Follow these steps to quickly install the binaries for `foundry-zksync`:
 
+Note: This installation overrides any existing forge and cast binaries in ~/.foundry. You can use forge without the --zksync flag for standard EVM chains. To revert to a previous installation, follow the instructions [here](https://book.getfoundry.sh/getting-started/installation#using-foundryup).
+
 1. **Clone the Repository**:
    Begin by cloning the `foundry-zksync` repository from GitHub. This will download the latest version of the source code to your local machine.
 

--- a/foundryup-zksync/foundryup-zksync
+++ b/foundryup-zksync/foundryup-zksync
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
-FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry-zksync"}
+FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 

--- a/foundryup-zksync/install
+++ b/foundryup-zksync/install
@@ -4,7 +4,7 @@ set -eo pipefail
 echo "Installing foundryup-zksync..."
 
 BASE_DIR="${XDG_CONFIG_HOME:-$HOME}"
-FOUNDRY_DIR="${FOUNDRY_DIR-"$BASE_DIR/.foundry-zksync"}"
+FOUNDRY_DIR="${FOUNDRY_DIR-"$BASE_DIR/.foundry"}"
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- Having the binaries installed in the same location as upstream allows binary installation to be overridden removing the issues of multiple forge versions
- Adds note in readme outlining this behaviour 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
