### PR TITLE
fix: Propagate block environment to zkVM

### DIFF
--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -107,6 +107,8 @@ where
         msg_sender: env.tx.caller,
         contract: transact_to.to_address(),
         delegate_as: None,
+        block_number: env.block.number,
+        block_timestamp: env.block.timestamp,
     };
 
     match inspect::<_, DB::Error>(tx, env, db, &mut journaled_state, Default::default(), call_ctx) {
@@ -198,6 +200,8 @@ where
         msg_sender: call.caller,
         contract: CONTRACT_DEPLOYER_ADDRESS.to_address(),
         delegate_as: None,
+        block_number: env.block.number,
+        block_timestamp: env.block.timestamp,
     };
 
     inspect(tx, env, db, journaled_state, ccx, call_ctx)
@@ -248,6 +252,8 @@ where
             CallScheme::DelegateCall => Some(call.context.address),
             _ => None,
         },
+        block_number: env.block.number,
+        block_timestamp: env.block.timestamp,
     };
 
     inspect(tx, env, db, journaled_state, ccx, call_ctx)

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -231,10 +231,12 @@ impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer 
             if current.code_address == SYSTEM_CONTEXT_ADDRESS {
                 if calldata.starts_with(&SELECTOR_SYSTEM_CONTEXT_BLOCK_NUMBER) {
                     self.farcall_handler
-                        .set_immediate_return(self.call_context.block_number.to_be_bytes_vec())
+                        .set_immediate_return(self.call_context.block_number.to_be_bytes_vec());
+                    return
                 } else if calldata.starts_with(&SELECTOR_SYSTEM_CONTEXT_BLOCK_TIMESTAMP) {
                     self.farcall_handler
-                        .set_immediate_return(self.call_context.block_timestamp.to_be_bytes_vec())
+                        .set_immediate_return(self.call_context.block_timestamp.to_be_bytes_vec());
+                    return
                 }
             }
         }

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -18,7 +18,9 @@ use multivm::{
 };
 use once_cell::sync::OnceCell;
 use zksync_state::WriteStorage;
-use zksync_types::{BOOTLOADER_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H256, U256};
+use zksync_types::{
+    BOOTLOADER_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H256, SYSTEM_CONTEXT_ADDRESS, U256,
+};
 
 use crate::{
     convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertU256},
@@ -32,6 +34,12 @@ const SELECTOR_ACCOUNT_VERSION: [u8; 4] = hex!("bb0fd610");
 
 /// executeTransaction(bytes32, bytes32, tuple)
 const SELECTOR_EXECUTE_TRANSACTION: [u8; 4] = hex!("df9c1589");
+
+/// Selector for `getBlockNumber()`
+const SELECTOR_SYSTEM_CONTEXT_BLOCK_NUMBER: [u8; 4] = hex!("42cbb15c");
+
+/// Selector for `getBlockTimestamp()`
+const SELECTOR_SYSTEM_CONTEXT_BLOCK_TIMESTAMP: [u8; 4] = hex!("796b89b9");
 
 /// Represents the context for [CheatcodeContext]
 #[derive(Debug, Default)]
@@ -62,6 +70,11 @@ pub struct CallContext {
     /// Delegated contract's address. This is used
     /// to override `address(this)` for delegate calls.
     pub delegate_as: Option<Address>,
+
+    /// The current block number
+    pub block_number: rU256,
+    /// The current block timestamp
+    pub block_timestamp: rU256,
 }
 
 /// A tracer to allow for foundry-specific functionality.
@@ -207,6 +220,22 @@ impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer 
                     CallDepth::next(),
                     CallAction::SetMessageSender(self.call_context.msg_sender),
                 );
+            }
+        }
+
+        // Override block number and timestamp for the transaction
+        if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
+            let calldata = get_calldata(&state, memory);
+            let current = state.vm_local_state.callstack.current;
+
+            if current.code_address == SYSTEM_CONTEXT_ADDRESS {
+                if calldata.starts_with(&SELECTOR_SYSTEM_CONTEXT_BLOCK_NUMBER) {
+                    self.farcall_handler
+                        .set_immediate_return(self.call_context.block_number.to_be_bytes_vec())
+                } else if calldata.starts_with(&SELECTOR_SYSTEM_CONTEXT_BLOCK_TIMESTAMP) {
+                    self.farcall_handler
+                        .set_immediate_return(self.call_context.block_timestamp.to_be_bytes_vec())
+                }
             }
         }
 

--- a/zk-tests/src/Basic.t.sol
+++ b/zk-tests/src/Basic.t.sol
@@ -3,6 +3,16 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 
+contract BlockEnv {
+    uint256 public number;
+    uint256 public timestamp;
+
+    constructor() {
+        number = block.number;
+        timestamp = block.timestamp;
+    }
+}
+
 contract ZkBasicTest is Test {
     uint256 constant ERA_FORK_BLOCK = 19579636;
     uint256 constant ERA_FORK_BLOCK_TS = 1700601590;
@@ -45,5 +55,22 @@ contract ZkBasicTest is Test {
 
         vm.selectFork(forkEth);
         require(TEST_ADDRESS.balance == 100, "eth balance mismatch");
+    }
+
+    function testZkPropagatedBlockEnv() public {
+        BlockEnv be = new BlockEnv();
+        require(be.number() == block.number, "propagated block number is the same as current");
+        require(be.timestamp() == block.timestamp, "propagated block timestamp is the same as current");
+
+        be = new BlockEnv();
+        require(be.number() == block.number, "propagated block number stays constant");
+        require(be.timestamp() == block.timestamp, "propagated block timestamp stays constant");
+
+        vm.roll(42);
+        vm.warp(42);
+
+        be = new BlockEnv();
+        require(be.number() == block.number, "propagated block number rolls");
+        require(be.timestamp() == block.timestamp, "propagated block timestamp warps");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

CrossChainReceiverTest currently has 4 failing tests.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The assertions that are failing are all related to `block.timestamp` being different than expected, this is because each zk call happens in a new transaction in a new batch, and all batches need to have increasing numbers and timestamps.
We override what the VM returns for `block.timestamp` and `block.number` so we can provide the expected test environment.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
Depends on https://github.com/Moonsong-Labs/aave-delivery-infrastructure/pull/3
