### PR TITLE
fix: mocked return from payable functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck 0.4.1",
+ "heck",
  "indexmap 2.2.3",
  "proc-macro-error",
  "proc-macro2 1.0.78",
@@ -788,7 +788,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "clap_complete",
  "clap_complete_fig",
  "crc 3.0.1",
@@ -870,7 +870,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bytes",
- "clap 4.5.1",
+ "clap",
  "futures 0.3.30",
  "hyper",
  "parity-tokio-ipc",
@@ -1228,34 +1228,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomic-write-file"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
-dependencies = [
- "nix 0.27.1",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "aurora-engine-modexp"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfacad86e9e138fca0670949eb8ed4ffdf73a55bded8887efe0863cd1a3a6f70"
 dependencies = [
  "hex",
- "num 0.4.1",
+ "num",
 ]
 
 [[package]]
@@ -1367,6 +1346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,30 +1379,7 @@ source = "git+https://github.com/matter-labs/bellman?branch=dev#5520aa2274afe73d
 dependencies = [
  "arrayvec 0.7.4",
  "bit-vec",
- "blake2s_const 0.6.0 (git+https://github.com/matter-labs/bellman?branch=dev)",
- "blake2s_simd",
- "byteorder",
- "cfg-if 1.0.0",
- "crossbeam 0.7.3",
- "futures 0.3.30",
- "hex",
- "lazy_static",
- "num_cpus",
- "pairing_ce 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6",
- "serde",
- "smallvec",
- "tiny-keccak 1.5.0",
-]
-
-[[package]]
-name = "bellman_ce"
-version = "0.3.2"
-source = "git+https://github.com/matter-labs/bellman?branch=snark-wrapper#e01e5fa08a97a113e76ec8a69d06fe6cc2c82d17"
-dependencies = [
- "arrayvec 0.7.4",
- "bit-vec",
- "blake2s_const 0.6.0 (git+https://github.com/matter-labs/bellman?branch=snark-wrapper)",
+ "blake2s_const",
  "blake2s_simd",
  "byteorder",
  "cfg-if 1.0.0",
@@ -1611,16 +1573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2s_const"
-version = "0.6.0"
-source = "git+https://github.com/matter-labs/bellman?branch=snark-wrapper#e01e5fa08a97a113e76ec8a69d06fe6cc2c82d17"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake2s_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,7 +1648,7 @@ dependencies = [
  "convert_case",
  "crossbeam 0.8.4",
  "crypto-bigint 0.5.5",
- "cs_derive 0.1.0 (git+https://github.com/nbaztec/era-boojum?branch=foundry-fix)",
+ "cs_derive",
  "derivative",
  "ethereum-types 0.14.1",
  "firestorm",
@@ -1717,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -1727,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
@@ -1965,7 +1917,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "clap_complete",
  "clap_complete_fig",
  "comfy-table",
@@ -2082,7 +2034,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-rpc-types",
- "clap 4.5.1",
+ "clap",
  "criterion",
  "dirs 5.0.1",
  "eyre",
@@ -2166,39 +2118,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "circuit_definitions"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#aff36380e6a740f7286c9c522e1416b8d38327ce"
+name = "circuit_encodings"
+version = "0.1.40"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#39665dffd576cff5007c80dd0e1b5334e230bd3b"
 dependencies = [
- "crossbeam 0.8.4",
  "derivative",
- "seq-macro",
  "serde",
- "snark_wrapper",
  "zk_evm 1.4.0",
  "zkevm_circuits 1.4.0",
 ]
 
 [[package]]
-name = "circuit_definitions"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#e957ef50421393914dee7796b0091586e5153192"
+name = "circuit_encodings"
+version = "0.1.41"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#f7bd71fd4216e2c51ab7b09a95909fe48c75f35b"
 dependencies = [
- "crossbeam 0.8.4",
  "derivative",
- "seq-macro",
  "serde",
- "snark_wrapper",
  "zk_evm 1.4.1",
  "zkevm_circuits 1.4.1",
 ]
 
 [[package]]
-name = "circuit_testing"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-circuit_testing.git?branch=main#164c0adac85be39ee44bd9456b2b91cdede5af80"
+name = "circuit_encodings"
+version = "0.1.42"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#3149a162a729581005fbad6dbcef027a3ee1b214"
 dependencies = [
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "derivative",
+ "serde",
+ "zk_evm 1.4.1",
+ "zkevm_circuits 1.4.1",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
+dependencies = [
+ "bellman_ce",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.40"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#39665dffd576cff5007c80dd0e1b5334e230bd3b"
+dependencies = [
+ "bellman_ce",
+ "circuit_encodings 0.1.40",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.0",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.41"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#f7bd71fd4216e2c51ab7b09a95909fe48c75f35b"
+dependencies = [
+ "bellman_ce",
+ "circuit_encodings 0.1.41",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.1",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.42"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#3149a162a729581005fbad6dbcef027a3ee1b214"
+dependencies = [
+ "bellman_ce",
+ "circuit_encodings 0.1.42",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.1",
 ]
 
 [[package]]
@@ -2210,21 +2210,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -2258,7 +2243,7 @@ version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
 dependencies = [
- "clap 4.5.1",
+ "clap",
 ]
 
 [[package]]
@@ -2267,7 +2252,7 @@ version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110"
 dependencies = [
- "clap 4.5.1",
+ "clap",
  "clap_complete",
 ]
 
@@ -2277,7 +2262,7 @@ version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.50",
@@ -2319,23 +2304,14 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/solidity_plonk_verifier.git?branch=dev#82f96b7156551087f1c9bfe4f0ea68845b6debfc"
 dependencies = [
  "ethereum-types 0.14.1",
- "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
+ "franklin-crypto",
  "handlebars",
  "hex",
  "paste",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git)",
+ "rescue_poseidon",
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "codegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff61280aed771c3070e7dcc9e050c66f1eb1e3b96431ba66f9f74641d02fc41d"
-dependencies = [
- "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -2636,7 +2612,7 @@ dependencies = [
  "anes",
  "cast 0.3.0",
  "ciborium",
- "clap 4.5.1",
+ "clap",
  "criterion-plot",
  "futures 0.3.30",
  "is-terminal",
@@ -2891,18 +2867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cs_derive"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#ed8ab8984cae05d00d9d62196753c8d40df47c7d"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "serde",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,36 +2882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
  "nix 0.27.1",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.72+curl-8.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
  "windows-sys 0.52.0",
 ]
 
@@ -3491,19 +3425,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
@@ -3545,13 +3466,13 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.17"
-source = "git+https://github.com/matter-labs/era-test-node.git?rev=2d5047237650a3249aeade484b0d2f4750615519#2d5047237650a3249aeade484b0d2f4750615519"
+version = "0.1.0-alpha.19"
+source = "git+https://github.com/matter-labs/era-test-node.git?rev=de98cebbb85264224019e0923b29da125967d803#de98cebbb85264224019e0923b29da125967d803"
 dependencies = [
  "anyhow",
  "bigdecimal 0.2.2",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "colored",
  "ethabi 16.0.0",
  "eyre",
@@ -4345,7 +4266,7 @@ dependencies = [
  "anvil",
  "async-trait",
  "axum",
- "clap 4.5.1",
+ "clap",
  "clap_complete",
  "clap_complete_fig",
  "comfy-table",
@@ -4539,7 +4460,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "clap 4.5.1",
+ "clap",
  "color-eyre",
  "dotenvy",
  "ethers-core",
@@ -4585,7 +4506,7 @@ dependencies = [
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-trait",
- "clap 4.5.1",
+ "clap",
  "comfy-table",
  "const-hex",
  "derive_more",
@@ -4879,7 +4800,7 @@ version = "0.0.2"
 dependencies = [
  "alloy-primitives",
  "async-trait",
- "clap 4.5.1",
+ "clap",
  "const-hex",
  "derive_builder",
  "ethers-core",
@@ -4957,7 +4878,7 @@ version = "0.0.5"
 source = "git+https://github.com/matter-labs/franklin-crypto?branch=dev#5695d07c7bc604c2c39a27712ffac171d39ee1ed"
 dependencies = [
  "arr_macro",
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "bellman_ce",
  "bit-vec",
  "blake2 0.9.2",
  "blake2-rfc_bellman_edition",
@@ -4969,39 +4890,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "num-bigint 0.4.4",
- "num-derive 0.2.5",
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "serde",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "smallvec",
- "splitmut",
- "tiny-keccak 1.5.0",
-]
-
-[[package]]
-name = "franklin-crypto"
-version = "0.0.5"
-source = "git+https://github.com/matter-labs/franklin-crypto?branch=snark_wrapper#2546c63b91b59bdb0ad342d26f03fb57477550b2"
-dependencies = [
- "arr_macro",
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=snark-wrapper)",
- "bit-vec",
- "blake2 0.9.2",
- "blake2-rfc_bellman_edition",
- "blake2s_simd",
- "boojum",
- "byteorder",
- "derivative",
- "digest 0.9.0",
- "hex",
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "lazy_static",
- "num-bigint 0.4.4",
- "num-derive 0.2.5",
+ "num-derive",
  "num-integer",
  "num-traits",
  "rand 0.4.6",
@@ -5800,29 +5689,11 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -6334,7 +6205,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.8",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -6596,7 +6467,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d94b7505034e2737e688e1153bf81e6f93ad296695c43958d6da2e4321f0a990"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-crate 2.0.0",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -6770,6 +6641,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kzg"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#3149a162a729581005fbad6dbcef027a3ee1b214"
+dependencies = [
+ "boojum",
+ "derivative",
+ "rayon",
+ "serde",
+ "serde_json",
+ "zkevm_circuits 1.4.1",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6901,7 +6785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -7107,7 +6990,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "clap_complete",
  "elasticlunr-rs",
  "env_logger 0.11.2",
@@ -7324,9 +7207,13 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
+ "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.40",
+ "circuit_sequencer_api 0.1.41",
+ "circuit_sequencer_api 0.1.42",
  "hex",
  "itertools 0.10.5",
  "once_cell",
@@ -7337,9 +7224,6 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.3.3",
- "zkevm_test_harness 1.4.0",
- "zkevm_test_harness 1.4.1",
  "zksync_contracts",
  "zksync_state",
  "zksync_system_constants",
@@ -7488,29 +7372,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint 0.3.3",
- "num-complex 0.3.1",
- "num-integer",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits",
-]
-
-[[package]]
-name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint 0.4.4",
- "num-complex 0.4.5",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
 ]
 
@@ -7523,7 +7393,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -7557,16 +7426,6 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "num-complex"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
@@ -7590,17 +7449,6 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7635,19 +7483,6 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
@@ -7675,7 +7510,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.8",
+ "hermit-abi",
  "libc",
 ]
 
@@ -8709,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "metrics",
@@ -8767,7 +8602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck",
  "itertools 0.11.0",
  "log",
  "multimap",
@@ -9329,37 +9164,13 @@ dependencies = [
 [[package]]
 name = "rescue_poseidon"
 version = "0.4.1"
-source = "git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2#126937ef0e7a281f1ff9f512ac41a746a691a342"
-dependencies = [
- "addchain",
- "arrayvec 0.7.4",
- "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder",
- "derivative",
- "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=snark_wrapper)",
- "lazy_static",
- "log",
- "num-bigint 0.3.3",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.4.6",
- "serde",
- "sha3 0.9.1",
- "smallvec",
- "typemap_rev",
-]
-
-[[package]]
-name = "rescue_poseidon"
-version = "0.4.1"
 source = "git+https://github.com/matter-labs/rescue-poseidon.git#d059b5042df5ed80e151f05751410b524a54d16c"
 dependencies = [
  "addchain",
  "arrayvec 0.7.4",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder",
- "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
+ "franklin-crypto",
  "num-bigint 0.3.3",
  "num-integer",
  "num-iter",
@@ -9732,9 +9543,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec 0.7.4",
  "borsh",
@@ -9821,9 +9632,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -9852,7 +9663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.0",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -9869,19 +9680,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c333bb734fcdedcea57de1602543590f545f127dc8b533324318fd492c5c70b"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -10429,6 +10240,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.3",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10709,16 +10533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snark_wrapper"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/snark-wrapper.git?branch=main#76959cadabeec344b9fa1458728400d60340e496"
-dependencies = [
- "derivative",
- "rand 0.4.6",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
-]
-
-[[package]]
 name = "snow"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10837,9 +10651,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -10850,9 +10664,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
  "ahash 0.8.9",
  "atoi",
@@ -10862,7 +10676,6 @@ dependencies = [
  "chrono",
  "crc 3.0.1",
  "crossbeam-queue 0.3.11",
- "dotenvy",
  "either",
  "event-listener 2.5.3",
  "futures-channel",
@@ -10895,9 +10708,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -10908,14 +10721,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
- "atomic-write-file",
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2 1.0.78",
@@ -10935,9 +10747,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -10980,9 +10792,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -11012,7 +10824,6 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha1",
  "sha2 0.10.8",
  "smallvec",
  "sqlx-core",
@@ -11024,9 +10835,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
  "chrono",
@@ -11103,12 +10914,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -11118,30 +10923,6 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -11176,7 +10957,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "rustversion",
@@ -11189,7 +10970,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "rustversion",
@@ -11202,7 +10983,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "rustversion",
@@ -11332,29 +11113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_vm"
-version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#ed8ab8984cae05d00d9d62196753c8d40df47c7d"
-dependencies = [
- "arrayvec 0.7.4",
- "cs_derive 0.1.0 (git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3)",
- "derivative",
- "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
- "hex",
- "itertools 0.10.5",
- "num-bigint 0.4.4",
- "num-derive 0.3.3",
- "num-integer",
- "num-traits",
- "once_cell",
- "rand 0.4.6",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git)",
- "serde",
- "smallvec",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11469,36 +11227,6 @@ dependencies = [
  "nom",
  "phf 0.11.2",
  "phf_codegen 0.11.2",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
-dependencies = [
- "env_logger 0.11.2",
- "test-log-macros",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 2.0.50",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -11689,7 +11417,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.2",
+ "rustls 0.22.3",
  "rustls-pki-types",
  "tokio",
 ]
@@ -12074,12 +11802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap_rev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12215,6 +11937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12302,12 +12030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "vergen"
 version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12364,7 +12086,7 @@ dependencies = [
 [[package]]
 name = "vlog"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "chrono",
  "sentry",
@@ -12376,7 +12098,7 @@ dependencies = [
 [[package]]
 name = "vm_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "multivm",
@@ -13047,7 +12769,7 @@ dependencies = [
  "blake2 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e)",
  "k256 0.11.6",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -13063,7 +12785,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2#fbee2
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -13078,7 +12800,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3#fbee20
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -13093,7 +12815,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.4.0#dd76fc
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -13108,7 +12830,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.4.1#6250db
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -13141,52 +12863,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "zkevm-assembly"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2#3c61d450cbe6548068be8f313ed02f1bd229a865"
-dependencies = [
- "env_logger 0.9.3",
- "hex",
- "lazy_static",
- "log",
- "nom",
- "num-bigint 0.4.4",
- "num-traits",
- "sha3 0.10.8",
- "smallvec",
- "structopt",
- "thiserror",
- "zkevm_opcode_defs 1.3.2",
-]
-
-[[package]]
-name = "zkevm-assembly"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#50282016d01bd2fd147021dd558209778db2268b"
-dependencies = [
- "env_logger 0.9.3",
- "hex",
- "lazy_static",
- "log",
- "nom",
- "num-bigint 0.4.4",
- "num-traits",
- "sha3 0.10.8",
- "smallvec",
- "structopt",
- "thiserror",
- "zkevm_opcode_defs 1.4.1",
-]
-
-[[package]]
 name = "zkevm_circuits"
 version = "1.4.0"
-source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=main#fb3e2574b5c890342518fc930c145443f039a105"
+source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=v1.4.0#fb3e2574b5c890342518fc930c145443f039a105"
 dependencies = [
  "arrayvec 0.7.4",
  "bincode",
  "boojum",
- "cs_derive 0.1.0 (git+https://github.com/nbaztec/era-boojum?branch=foundry-fix)",
+ "cs_derive",
  "derivative",
  "hex",
  "itertools 0.10.5",
@@ -13202,12 +12886,12 @@ dependencies = [
 [[package]]
 name = "zkevm_circuits"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=v1.4.1#3a973afb3cf2b50b7138c1af61cc6ac3d7d0189f"
+source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=v1.4.1#8bf24543ffc5bafab34182388394e887ecb37d17"
 dependencies = [
  "arrayvec 0.7.4",
  "bincode",
  "boojum",
- "cs_derive 0.1.0 (git+https://github.com/nbaztec/era-boojum?branch=foundry-fix)",
+ "cs_derive",
  "derivative",
  "hex",
  "itertools 0.10.5",
@@ -13260,91 +12944,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "zkevm_test_harness"
-version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#d52b56d6ba8196c8a3c74c4933654469e6f27a5a"
-dependencies = [
- "bincode",
- "circuit_testing",
- "codegen 0.2.0",
- "crossbeam 0.8.4",
- "derivative",
- "env_logger 0.11.2",
- "hex",
- "num-bigint 0.4.4",
- "num-integer",
- "num-traits",
- "rayon",
- "serde",
- "serde_json",
- "smallvec",
- "structopt",
- "sync_vm",
- "test-log",
- "tracing",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
-]
-
-[[package]]
-name = "zkevm_test_harness"
-version = "1.4.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#aff36380e6a740f7286c9c522e1416b8d38327ce"
-dependencies = [
- "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0)",
- "codegen 0.2.0",
- "crossbeam 0.8.4",
- "derivative",
- "env_logger 0.11.2",
- "hex",
- "rand 0.4.6",
- "rayon",
- "serde",
- "serde_json",
- "smallvec",
- "structopt",
- "test-log",
- "tracing",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
-]
-
-[[package]]
-name = "zkevm_test_harness"
-version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#e957ef50421393914dee7796b0091586e5153192"
-dependencies = [
- "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1)",
- "codegen 0.2.0",
- "crossbeam 0.8.4",
- "curl",
- "derivative",
- "env_logger 0.11.2",
- "hex",
- "lazy_static",
- "rand 0.4.6",
- "rayon",
- "reqwest",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
- "serde",
- "serde_json",
- "smallvec",
- "snark_wrapper",
- "structopt",
- "test-log",
- "tracing",
- "walkdir",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1)",
-]
-
-[[package]]
 name = "zksync-web3-rs"
 version = "0.1.0"
 source = "git+https://github.com/lambdaclass/zksync-web3-rs.git?rev=70327ae5413c517bd4d27502507cdd96ee40cd22#70327ae5413c517bd4d27502507cdd96ee40cd22"
 dependencies = [
  "async-trait",
- "clap 4.5.1",
+ "clap",
  "env_logger 0.10.2",
  "ethers",
  "ethers-contract",
@@ -13360,7 +12965,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "serde",
  "serde_json",
@@ -13370,7 +12975,7 @@ dependencies = [
 [[package]]
 name = "zksync_circuit_breaker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13390,13 +12995,13 @@ dependencies = [
 [[package]]
 name = "zksync_commitment_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
+ "circuit_sequencer_api 0.1.40",
+ "circuit_sequencer_api 0.1.41",
  "multivm",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.0",
- "zkevm_test_harness 1.4.1",
  "zksync_types",
  "zksync_utils",
 ]
@@ -13404,7 +13009,7 @@ dependencies = [
 [[package]]
 name = "zksync_concurrency"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -13422,7 +13027,7 @@ dependencies = [
 [[package]]
 name = "zksync_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -13433,7 +13038,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_bft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13454,7 +13059,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "blst",
@@ -13472,7 +13077,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_executor"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -13492,7 +13097,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_network"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13517,7 +13122,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_roles"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -13537,7 +13142,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13555,7 +13160,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_sync_blocks"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "thiserror",
@@ -13570,7 +13175,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "thiserror",
  "zksync_concurrency",
@@ -13579,7 +13184,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "envy",
  "ethabi 18.0.0",
@@ -13593,7 +13198,7 @@ dependencies = [
 [[package]]
 name = "zksync_core"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -13601,7 +13206,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "bigdecimal 0.3.1",
  "bitflags 1.3.2",
  "chrono",
  "ctrlc",
@@ -13612,15 +13216,17 @@ dependencies = [
  "lru",
  "metrics",
  "multivm",
- "num 0.3.1",
  "once_cell",
+ "pin-project-lite",
  "prometheus_exporter",
  "prost",
  "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
+ "thread_local",
  "tokio",
  "tower",
  "tower-http",
@@ -13635,6 +13241,7 @@ dependencies = [
  "zksync_consensus_bft",
  "zksync_consensus_crypto",
  "zksync_consensus_executor",
+ "zksync_consensus_network",
  "zksync_consensus_roles",
  "zksync_consensus_storage",
  "zksync_consensus_utils",
@@ -13651,6 +13258,7 @@ dependencies = [
  "zksync_object_store",
  "zksync_protobuf",
  "zksync_protobuf_build",
+ "zksync_protobuf_config",
  "zksync_prover_interface",
  "zksync_queued_job_processor",
  "zksync_state",
@@ -13664,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
@@ -13678,7 +13286,7 @@ dependencies = [
 [[package]]
 name = "zksync_dal"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "bigdecimal 0.3.1",
@@ -13686,7 +13294,6 @@ dependencies = [
  "chrono",
  "hex",
  "itertools 0.10.5",
- "num 0.4.1",
  "once_cell",
  "prost",
  "rand 0.8.5",
@@ -13713,7 +13320,7 @@ dependencies = [
 [[package]]
 name = "zksync_env_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "envy",
@@ -13725,10 +13332,11 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "async-trait",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp",
  "serde",
  "thiserror",
  "tracing",
@@ -13742,7 +13350,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "async-trait",
  "hex",
@@ -13760,7 +13368,7 @@ dependencies = [
 [[package]]
 name = "zksync_health_check"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -13768,18 +13376,21 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "vise",
 ]
 
 [[package]]
 name = "zksync_l1_contract_interface"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
- "codegen 0.1.0",
+ "circuit_sequencer_api 0.1.0",
+ "codegen",
+ "hex",
+ "kzg",
+ "once_cell",
  "sha2 0.10.8",
  "sha3 0.10.8",
- "zkevm_test_harness 1.3.3",
- "zkevm_test_harness 1.4.1",
  "zksync_prover_interface",
  "zksync_types",
 ]
@@ -13787,7 +13398,7 @@ dependencies = [
 [[package]]
 name = "zksync_mempool"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "tracing",
  "zksync_types",
@@ -13796,7 +13407,7 @@ dependencies = [
 [[package]]
 name = "zksync_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "leb128",
  "once_cell",
@@ -13814,7 +13425,7 @@ dependencies = [
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -13824,7 +13435,7 @@ dependencies = [
 [[package]]
 name = "zksync_object_store"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13846,7 +13457,7 @@ dependencies = [
 [[package]]
 name = "zksync_protobuf"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -13864,10 +13475,10 @@ dependencies = [
 [[package]]
 name = "zksync_protobuf_build"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=5b3d383d7a65b0fbe2a771fecf4313f5083be9ae#5b3d383d7a65b0fbe2a771fecf4313f5083be9ae"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=842d4fd79f1d7dae946b6873ded7ad391d554814#842d4fd79f1d7dae946b6873ded7ad391d554814"
 dependencies = [
  "anyhow",
- "heck 0.4.1",
+ "heck",
  "prettyplease",
  "proc-macro2 1.0.78",
  "prost-build",
@@ -13878,15 +13489,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksync_protobuf_config"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
+dependencies = [
+ "anyhow",
+ "pretty_assertions",
+ "prost",
+ "rand 0.8.5",
+ "serde_json",
+ "serde_yaml",
+ "zksync_basic_types",
+ "zksync_config",
+ "zksync_protobuf",
+ "zksync_protobuf_build",
+ "zksync_types",
+]
+
+[[package]]
 name = "zksync_prover_interface"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "chrono",
+ "circuit_sequencer_api 0.1.42",
  "serde",
  "serde_with",
  "strum 0.24.1",
- "zkevm_test_harness 1.3.3",
  "zksync_object_store",
  "zksync_types",
 ]
@@ -13894,7 +13523,7 @@ dependencies = [
 [[package]]
 name = "zksync_queued_job_processor"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13907,7 +13536,7 @@ dependencies = [
 [[package]]
 name = "zksync_state"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
@@ -13924,7 +13553,7 @@ dependencies = [
 [[package]]
 name = "zksync_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "num_cpus",
  "once_cell",
@@ -13936,7 +13565,7 @@ dependencies = [
 [[package]]
 name = "zksync_system_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -13946,13 +13575,14 @@ dependencies = [
 [[package]]
 name = "zksync_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "hex",
- "num 0.4.1",
+ "itertools 0.10.5",
+ "num",
  "num_enum 0.6.1",
  "once_cell",
  "prost",
@@ -13976,7 +13606,7 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
  "anyhow",
  "bigdecimal 0.3.1",
@@ -13984,7 +13614,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "metrics",
- "num 0.4.1",
+ "num",
  "reqwest",
  "serde",
  "thiserror",
@@ -13998,15 +13628,13 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854#d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=90dee732295d8eaf48a5308c39238a0f5838cc35#90dee732295d8eaf48a5308c39238a0f5838cc35"
 dependencies = [
- "bigdecimal 0.3.1",
- "chrono",
- "itertools 0.10.5",
+ "anyhow",
  "jsonrpsee",
+ "pin-project-lite",
  "rlp",
  "serde",
- "serde_json",
  "thiserror",
  "zksync_types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,15 +184,15 @@ alloy-rlp = "0.3.3"
 solang-parser = "=0.3.3"
 
 ## zksync
-era_test_node = { git="https://github.com/matter-labs/era-test-node.git" , rev = "2d5047237650a3249aeade484b0d2f4750615519" }
+era_test_node = { git="https://github.com/matter-labs/era-test-node.git" , rev = "de98cebbb85264224019e0923b29da125967d803" }
 zksync-web3-rs = {git = "https://github.com/lambdaclass/zksync-web3-rs.git", rev = "70327ae5413c517bd4d27502507cdd96ee40cd22"}
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854" }
-zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854" }
-multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854" }
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "d1e47744c773fa38aa22aaaa3dbb9dbffe7e9854" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "90dee732295d8eaf48a5308c39238a0f5838cc35" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "90dee732295d8eaf48a5308c39238a0f5838cc35" }
+zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "90dee732295d8eaf48a5308c39238a0f5838cc35" }
+multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "90dee732295d8eaf48a5308c39238a0f5838cc35" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "90dee732295d8eaf48a5308c39238a0f5838cc35" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "90dee732295d8eaf48a5308c39238a0f5838cc35" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "90dee732295d8eaf48a5308c39238a0f5838cc35" }
 
 ## misc
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/crates/zksync/core/src/vm/farcall.rs
+++ b/crates/zksync/core/src/vm/farcall.rs
@@ -155,11 +155,13 @@ impl FarCallHandler {
                     next_context_u128_value: 0,
                 })
             }
-            // Mimic calls must use the active base_memory_page to populate return data
+            // Mimic calls case is used to handle the case when a value is sent to a function.
+            // These calls go through a call to MsgValue simulator contract and then do a mimic call
+            // to the actual contract.
             FarCallOpcode::Mimic => self.before_far_call_stack.map(|before| ImmediateReturn {
                 return_data,
-                // base_memory_page for returndata must be set to current base_memory_page
-                // and not of the caller for mimic calls. Reasons unknown, but required in zk vm.
+                // base_memory_page for returndata must be set to current base_memory_page and not
+                // of the caller for calls with value. Reasons unknown, but required in zk vm.
                 return_base_memory_page: self
                     .after_far_call_stack
                     .map(|after| after.base_memory_page.0)
@@ -170,8 +172,8 @@ impl FarCallHandler {
                 next_sp: before.sp,
                 next_exception_handler_location: before.exception_handler_location,
                 next_this_address: before.this_address,
-                // `is_local_frame` needs to tbe set to `true` when doing mimic calls.
-                // Reasons unknown, but required in zk vm.
+                // `is_local_frame` for return satck needs to be set to same as before state when
+                // returning from calls with value. Reasons unknown, but required in zk vm.
                 next_is_local_frame: before.is_local_frame,
                 next_context_u128_value: 0,
             }),

--- a/crates/zksync/core/src/vm/farcall.rs
+++ b/crates/zksync/core/src/vm/farcall.rs
@@ -33,7 +33,6 @@ type DecodedOpcode = ZkDecodedOpcode<8, EncodingModeProduction>;
 pub(crate) struct ImmediateReturn {
     pub(crate) return_data: Vec<u8>,
     pub(crate) return_base_memory_page: u32,
-
     pub(crate) next_pc: PcOrImm,
     pub(crate) next_code_page: u32,
     pub(crate) next_base_memory_page: u32,

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -525,7 +525,7 @@ fn inspect_inner<S: ReadStorage + Send>(
     let resolve_hashes = get_env_var::<bool>("ZK_DEBUG_RESOLVE_HASHES");
     tracing::info!("=== Calls: ");
     for call in call_traces.iter() {
-        formatter::print_call(call, 0, &ShowCalls::All, resolve_hashes);
+        formatter::print_call(call, 0, &ShowCalls::All, resolve_hashes, true);
     }
 
     tracing::info!("==== {}", format!("{} events", tx_result.logs.events.len()));

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    str::FromStr,
     sync::Arc,
 };
 
@@ -19,7 +18,7 @@ use multivm::{
 };
 use once_cell::sync::OnceCell;
 use zksync_state::WriteStorage;
-use zksync_types::{BOOTLOADER_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H160, H256, U256};
+use zksync_types::{BOOTLOADER_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H256, U256};
 
 use crate::{
     convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertU256},
@@ -28,9 +27,17 @@ use crate::{
 
 use super::farcall::FarCallHandler;
 
+/// Selector for retrieving account version.
+/// We use this to override the caller's account version when deploying a contract
+/// So non-EOA addresses can also deploy within the VM.
+///
 /// extendedAccountVersion(address)
 const SELECTOR_ACCOUNT_VERSION: [u8; 4] = hex!("bb0fd610");
 
+/// Selector for  executing a VM transaction.
+/// We use this to override the `msg.sender` for the call context
+/// to account for transitive calls.
+///
 /// executeTransaction(bytes32, bytes32, tuple)
 const SELECTOR_EXECUTE_TRANSACTION: [u8; 4] = hex!("df9c1589");
 
@@ -76,9 +83,6 @@ pub struct CheatcodeTracer {
     pub result: Arc<OnceCell<CheatcodeTracerResult>>,
     /// Handle farcall state.
     farcall_handler: FarCallHandler,
-    debug: bool,
-    next_ret: u16,
-    tabs: u16,
 }
 
 impl CheatcodeTracer {
@@ -108,101 +112,10 @@ impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer 
         &mut self,
         state: VmLocalStateData<'_>,
         data: BeforeExecutionData,
-        memory: &SimpleMemory<H>,
+        _memory: &SimpleMemory<H>,
         _storage: zksync_state::StoragePtr<S>,
     ) {
         self.farcall_handler.track_before_far_calls(&state, &data);
-
-        let current = state.vm_local_state.callstack.current;
-
-        if (self.debug && self.next_ret > 0) ||
-            matches!(data.opcode.variant.opcode, Opcode::FarCall(_))
-        {
-            match data.opcode.variant.opcode {
-                Opcode::FarCall(_call) => {
-                    self.tabs += 1;
-                }
-                Opcode::Ret(_) => {
-                    self.tabs = self.tabs.saturating_sub(1);
-                    if self.next_ret > 0 {
-                        self.next_ret -= 1;
-                    }
-                }
-                _ => (),
-            }
-
-            // println!(
-            //     "{}-pc={:<4?} [{}] bm={:<5?} sp={:<4?} mpc={:<4?} | {:30} {:?} cp={:<5?} axh={:<4} v={:<3?} ex={:?}",
-            //     "\t".repeat(self.tabs as usize),
-            //     current.pc,
-            //     current.is_local_frame,
-            //     current.base_memory_page.0,
-            //     current.sp,
-            //     state.vm_local_state.memory_page_counter,
-            //     format!("{:?}", data.opcode.variant.opcode),
-            //     current.this_address,
-            //     current.code_page.0,
-            //     current.aux_heap_bound,
-            //     current.context_u128_value,
-            //     current.exception_handler_location,
-            // );
-        }
-
-        // match data.opcode.variant.opcode {
-        //     Opcode::FarCall(_) => {
-        //         let current = state.vm_local_state.callstack.current;
-        //         let ptr= state.vm_local_state.registers[multivm::zk_evm_latest::zkevm_opcode_defs::RET_IMPLICIT_RETURNDATA_PARAMS_REGISTER as usize];
-        //         let ptr = FatPointer::from_u256(ptr.value);
-        //         let b = memory.read_unaligned_bytes(
-        //             ptr.memory_page as usize,
-        //             ptr.start as usize,
-        //             ptr.length as usize,
-        //         );
-        //         println!(
-        //             "\tBEFORE:FARCALL pc={:?} [{}] bm={:?} {:?} | {}",
-        //             current.pc,
-        //             current.is_local_frame,
-        //             current.base_memory_page.0,
-        //             ptr,
-        //             hex::encode(b)
-        //         );
-        //     }
-        //     Opcode::Ret(_) => {
-        //         let current = state.vm_local_state.callstack.current;
-        //         if self.next_ret > 0 {
-        //             let ptr= state.vm_local_state.registers[multivm::zk_evm_latest::zkevm_opcode_defs::RET_IMPLICIT_RETURNDATA_PARAMS_REGISTER as usize];
-        //             let ptr = FatPointer::from_u256(ptr.value);
-        //             let b = memory.read_unaligned_bytes(
-        //                 ptr.memory_page as usize,
-        //                 ptr.start as usize,
-        //                 ptr.length as usize,
-        //             );
-        //             let ret_abi = multivm::zk_evm_latest::zkevm_opcode_defs::RetABI::from_u256(data.src0_value.value);
-        //             // we want to mark with one that was will become a new current (taken from
-        //             // stack)
-        //             let multivm::zk_evm_latest::zkevm_opcode_defs::RetABI { mut memory_quasi_fat_pointer, page_forwarding_mode } = ret_abi;
-
-        //             println!(
-        //                 "\tBEFORE:RET pc={:?} [{}] bm={:?} {:?} {:?} {:?} | {}",
-        //                 current.pc,
-        //                 current.is_local_frame,
-        //                 current.base_memory_page.0,
-        //                 ptr,
-        //                 memory_quasi_fat_pointer,
-        //                 page_forwarding_mode,
-        //                 hex::encode(b)
-        //             );
-
-
-        //             // state.memory.populate_page(
-        //             //     ptr.memory_page as usize,
-        //             //     data,
-        //             //     Timestamp(state.local_state.timestamp),
-        //             // );
-        //         }
-        //     }
-        //     _ => (),
-        // }
     }
 
     fn after_execution(
@@ -214,95 +127,6 @@ impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer 
     ) {
         self.farcall_handler.track_after_far_calls(&state, &data);
         self.farcall_handler.track_call_actions(&state, &data);
-
-        // self.debug = true;
-        // let current = state.vm_local_state.callstack.current;
-        // let maybe_calldata = if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
-        //     let calldata = get_calldata(&state, memory);
-        //     if !self.debug && hex::encode(&calldata) == "0bcd3b33" {
-        //         println!("FOUND");
-        //         self.debug = true;
-        //     }
-
-        //     if self.debug && hex::encode(&calldata) == "a851ae78" {
-        //         println!("STOP");
-        //         println!("STOP");
-        //         self.debug = false
-        //     }
-        //     if self.debug &&
-        //         current.this_address ==
-        //             H160::from_str("b5c1df089600415b21fb76bf89900adb575947c8").unwrap()
-        //     {
-        //         println!("-----> {}", "-".repeat(400));
-        //         self.next_ret = 4;
-        //     }
-        //     let x = hex::encode(&calldata);
-        //     if x.len() > 8 {
-        //         x[..8].to_string()
-        //     } else {
-        //         x
-        //     }
-        // } else {
-        //     String::from(" ")
-        // };
-
-        // if self.debug {
-        //     println!(
-        //         "{}+pc={:<4?} [{}] bm={:<5?} sp={:<4?} mpc={:4<} | {:30} {:?}cp={:<5?} axh={:<4} v={:<3?} ex={:?}",
-        //         "\t".repeat(self.tabs as usize),
-        //         current.pc,
-        //         current.is_local_frame,
-        //         current.base_memory_page.0,
-        //         current.sp,
-        //         state.vm_local_state.memory_page_counter,
-        //         format!("{:?} {}", data.opcode.variant.opcode, maybe_calldata),
-        //         current.this_address,
-        //         current.code_page.0,
-        //         current.aux_heap_bound,
-        //         current.context_u128_value,
-        //         current.exception_handler_location,
-        //     );
-        //     match data.opcode.variant.opcode {
-        //         Opcode::FarCall(_call) => {
-        //             let ptr= state.vm_local_state.registers[multivm::zk_evm_latest::zkevm_opcode_defs::RET_IMPLICIT_RETURNDATA_PARAMS_REGISTER as usize];
-        //             let ptr = FatPointer::from_u256(ptr.value);
-        //             let b = memory.read_unaligned_bytes(
-        //                 ptr.memory_page as usize,
-        //                 ptr.start as usize,
-        //                 ptr.length as usize,
-        //             );
-        //             println!(
-        //                 "\tAFTER:FARCALL pc={:?} [{}] bm={:?} {:?} | {}",
-        //                 current.pc,
-        //                 current.is_local_frame,
-        //                 current.base_memory_page.0,
-        //                 ptr,
-        //                 hex::encode(b)
-        //             );
-        //         }
-        //         Opcode::Ret(_) => {
-        //             self.tabs = self.tabs.saturating_sub(1);
-        //             if self.next_ret > 0 {
-        //                 let ptr= state.vm_local_state.registers[multivm::zk_evm_latest::zkevm_opcode_defs::RET_IMPLICIT_RETURNDATA_PARAMS_REGISTER as usize];
-        //                 let ptr = FatPointer::from_u256(ptr.value);
-        //                 let b = memory.read_unaligned_bytes(
-        //                     ptr.memory_page as usize,
-        //                     ptr.start as usize,
-        //                     ptr.length as usize,
-        //                 );
-        //                 println!(
-        //                     "\tAFTER:RET pc={:?} [{}] bm={:?} {:?} | {}",
-        //                     current.pc,
-        //                     current.is_local_frame,
-        //                     current.base_memory_page.0,
-        //                     ptr,
-        //                     hex::encode(b)
-        //                 );
-        //             }
-        //         }
-        //         _ => (),
-        //     }
-        // }
 
         // Checks contract calls for expectCall cheatcode
         if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
@@ -353,11 +177,6 @@ impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer 
                 }) {
                     let return_data = return_data.data.clone().to_vec();
                     tracing::info!("returning mocked value {:?}", hex::encode(&return_data));
-                    self.tabs = self.tabs.saturating_sub(1);
-                    for (i, cs) in state.vm_local_state.callstack.inner.iter().rev().enumerate().take(3) {
-                        
-                        println!("> CS [{i}] pc={} bm={}", cs.pc, cs.base_memory_page.0);
-                    }
                     self.farcall_handler.set_immediate_return(return_data);
                     return;
                 }

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -30,22 +30,28 @@ use crate::{
 use super::farcall::FarCallHandler;
 
 /// Selector for retrieving account version.
-/// We use this to override the caller's account version when deploying a contract
+/// This is used to override the caller's account version when deploying a contract
 /// So non-EOA addresses can also deploy within the VM.
 ///
 /// extendedAccountVersion(address)
 const SELECTOR_ACCOUNT_VERSION: [u8; 4] = hex!("bb0fd610");
 
 /// Selector for  executing a VM transaction.
-/// We use this to override the `msg.sender` for the call context
+/// This is used to override the `msg.sender` for the call context
 /// to account for transitive calls.
 ///
 /// executeTransaction(bytes32, bytes32, tuple)
 const SELECTOR_EXECUTE_TRANSACTION: [u8; 4] = hex!("df9c1589");
 
+/// Selector for retrieving the current block number.
+/// This is used to override the current `block.number` to foundry test's context.
+///
 /// Selector for `getBlockNumber()`
 const SELECTOR_SYSTEM_CONTEXT_BLOCK_NUMBER: [u8; 4] = hex!("42cbb15c");
 
+/// Selector for retrieving the current block timestamp.
+/// This is used to override the current `block.timestamp` to foundry test's context.
+///
 /// Selector for `getBlockTimestamp()`
 const SELECTOR_SYSTEM_CONTEXT_BLOCK_TIMESTAMP: [u8; 4] = hex!("796b89b9");
 

--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -3,17 +3,17 @@ pragma solidity ^0.8.13;
 
 import {Test, console2 as console} from "forge-std/Test.sol";
 
-contract Mock {
+contract InnerMock {
     function getBytes() public payable returns (bytes memory) {
         bytes memory r = bytes(hex"abcd");
         return r;
     }
 }
 
-contract NestedMock {
-    Mock private inner;
+contract Mock {
+    InnerMock private inner;
 
-    constructor(Mock _inner) payable {
+    constructor(InnerMock _inner) payable {
         inner = _inner;
     }
 
@@ -107,11 +107,11 @@ contract ZkCheatcodesTest is Test {
         require(number == 10, "era etched code incorrect");
     }
 
-    function testZkCheatcodesMockMemoryReturn() public {
-        Mock inner = new Mock();
-        // Allocate some funds to NestedMock so it can pay for the inner call
-        NestedMock target = new NestedMock{value: 50}(inner);
-        
+    function testZkCheatcodesValueFunctionMockReturn() public {
+        InnerMock inner = new InnerMock();
+        // Send some funds to so it can pay for the inner call
+        Mock target = new Mock{value: 50}(inner);
+
         bytes memory dataBefore = target.getBytes();
         assertEq(dataBefore, bytes(hex"abcd"));
 

--- a/zk-tests/test.sh
+++ b/zk-tests/test.sh
@@ -3,10 +3,11 @@
 # Fail fast and on piped commands
 set -o pipefail -e
 
-REPO_ROOT="../"
+REPO_ROOT=".."
 SOLC_VERSION=${SOLC_VERSION:-"v0.8.20"}
 SOLC="solc-${SOLC_VERSION}"
-BINARY_PATH="${REPO_ROOT}/target/release/forge"
+FORGE="${REPO_ROOT}/target/release/forge"
+CAST="${REPO_ROOT}/target/release/cast"
 ERA_TEST_NODE_VERSION="v0.1.0-alpha.15"
 ERA_TEST_NODE_PID=0
 RPC_URL="http://localhost:8011"
@@ -64,7 +65,7 @@ function download_era_test_node() {
 
 function wait_for_build() {
   local timeout=$1
-  while ! [ -x "${BINARY_PATH}" ]; do
+  while ! [ -x "${FORGE}" ]; do
     ((timeout--))
     if [ $timeout -le 0 ]; then
       echo "Build timed out waiting for binary to be created."
@@ -101,7 +102,7 @@ function start_era_test_node() {
 trap cleanup ERR
 
 echo "Solc: ${SOLC_VERSION}"
-echo "forge binary: ${BINARY_PATH}"
+echo "forge binary: ${FORGE}"
 echo "era-test-node: ${ERA_TEST_NODE_VERSION}"
 
 # Download solc
@@ -122,31 +123,31 @@ command -v git &>/dev/null || {
 
 build_forge "${REPO_ROOT}"
 
-"${BINARY_PATH}" install transmissions11/solmate Openzeppelin/openzeppelin-contracts --no-commit
+"${FORGE}" install transmissions11/solmate Openzeppelin/openzeppelin-contracts --no-commit
 
 echo "Running tests..."
-RUST_LOG=warn "${BINARY_PATH}" test --use "./${SOLC}" -vvv  || fail "forge test failed"
+RUST_LOG=warn "${FORGE}" test --use "./${SOLC}" -vvv  || fail "forge test failed"
 
 echo "Running tests with '--zksync'..."
-RUST_LOG=warn "${BINARY_PATH}" test --use "./${SOLC}" -vvv --zksync  || fail "forge test --zksync failed"
+RUST_LOG=warn "${FORGE}" test --use "./${SOLC}" -vvv --zksync  || fail "forge test --zksync failed"
 
 echo "Running script..."
 start_era_test_node
-RUST_LOG=warn "${BINARY_PATH}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}" --slow  -vvv  || fail "forge script failed"
-RUST_LOG=warn "${BINARY_PATH}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}" --slow  -vvv  || fail "forge script failed on 2nd deploy"
+RUST_LOG=warn "${FORGE}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}" --slow  -vvv  || fail "forge script failed"
+RUST_LOG=warn "${FORGE}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e" --chain 260 --gas-estimate-multiplier 310 --rpc-url http://localhost:8011 --use "./${SOLC}" --slow  -vvv  || fail "forge script failed on 2nd deploy"
 
 echo "Running NFT script"
-RUST_LOG=warn "${BINARY_PATH}" script ./script/NFT.s.sol:MyScript --broadcast --private-key $PRIVATE_KEY --rpc-url $RPC_URL --use 0.8.20 --zksync  || fail "forge script failed"
+RUST_LOG=warn "${FORGE}" script ./script/NFT.s.sol:MyScript --broadcast --private-key $PRIVATE_KEY --rpc-url $RPC_URL --use 0.8.20 --zksync  || fail "forge script failed"
 
 # Deploy ERC20
 echo "Deploying MyToken..."
-MYTOKEN_DEPLOYMENT=$(RUST_LOG=warn "${BINARY_PATH}" create ./src/ERC20.sol:MyToken --rpc-url $RPC_URL --private-key $PRIVATE_KEY --use 0.8.20 --zksync) || fail "forge script failed"
+MYTOKEN_DEPLOYMENT=$(RUST_LOG=warn "${FORGE}" create ./src/ERC20.sol:MyToken --rpc-url $RPC_URL --private-key $PRIVATE_KEY --use 0.8.20 --zksync) || fail "forge script failed"
 MYTOKEN_ADDRESS=$(echo $MYTOKEN_DEPLOYMENT | awk '/Deployed to:/ {for (i=1; i<=NF; i++) if ($i == "to:") print $(i+1)}')
 echo "MyToken deployed at: $MYTOKEN_ADDRESS"
 
 # Deploy TokenReceiver
 echo "Deploying TokenReceiver..."
-TOKENRECEIVER_DEPLOYMENT=$(RUST_LOG=warn "${BINARY_PATH}" create ./src/TokenReceiver.sol:TokenReceiver --rpc-url $RPC_URL --private-key $PRIVATE_KEY --use "./${SOLC}" --zksync) || fail "forge script failed"
+TOKENRECEIVER_DEPLOYMENT=$(RUST_LOG=warn "${FORGE}" create ./src/TokenReceiver.sol:TokenReceiver --rpc-url $RPC_URL --private-key $PRIVATE_KEY --use "./${SOLC}" --zksync) || fail "forge script failed"
 TOKENRECEIVER_ADDRESS=$(echo $TOKENRECEIVER_DEPLOYMENT | awk '/Deployed to:/ {for (i=1; i<=NF; i++) if ($i == "to:") print $(i+1)}')
 echo "TokenReceiver deployed at: $TOKENRECEIVER_ADDRESS"
 
@@ -156,12 +157,12 @@ sleep 10
 # Interact: Transfer tokens from MyToken to TokenReceiver
 echo "Transferring tokens from MyToken to TokenReceiver..."
 AMOUNT="1" # 1 token, for example
-TRANSACTION=$("${REPO_ROOT}"/target/release/cast send --rpc-url $RPC_URL --private-key $PRIVATE_KEY $MYTOKEN_ADDRESS "transfer(address,uint256)" $TOKENRECEIVER_ADDRESS $AMOUNT)
+TRANSACTION=$("${CAST}" send --rpc-url $RPC_URL --private-key $PRIVATE_KEY $MYTOKEN_ADDRESS "transfer(address,uint256)" $TOKENRECEIVER_ADDRESS $AMOUNT)
 
 # Assert that the transaction was committed looking for the transaction hash "transactionHash" keyword
-echo "Transaction: $TRANSACTION"
+echo "Transaction: ${TRANSACTION}"
 echo "Checking transaction status..."
-echo $TRANSACTION | grep -q "transactionHash" || fail "Transaction failed"
+echo "${TRANSACTION}" | grep -q "transactionHash" || fail "Transaction failed"
 stop_era_test_node
 
 success


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Current mocked payable functions panic when a mocked return is triggered.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
After careful investigation of the `FARCALL` and `RET` opcodes and the `era-zk_evm`. Certain differences were observed owing to the role `MsgValueSimulator` contract plays causing differences in the `base_memory_page` used for returning data and the propagation of `is_local_frame`, which doesn't work for normal farcalls. 

## Note
This scenario is currently not well understood as it's quite primitive in nature, and may need to be fixed again in future as different edge cases arise.

`zksync-era` deps were updated as debugging was not possible anymore with older pinned hashes for many of the transitive deps.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
