### PR TITLE
fix: allow switching accounts with empty bytecode to zk vm

### DIFF
--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -20,10 +20,8 @@ impl Cheatcode for mockCall_0Call {
         // check Solidity might perform.
         let empty_bytecode = acc.info.code.as_ref().map_or(true, Bytecode::is_empty);
         if empty_bytecode {
-            let code = Bytecode::new_raw(Bytes::copy_from_slice(
-                &foundry_zksync_core::cheatcodes::EMPTY_CODE,
-            ))
-            .to_checked();
+            let code = Bytecode::new_raw(Bytes::copy_from_slice(&foundry_zksync_core::EMPTY_CODE))
+                .to_checked();
             ccx.data.journaled_state.set_code(*callee, code.clone());
         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -13,7 +13,7 @@ use crate::{
     Vm::{self, AccountAccess},
 };
 
-use alloy_primitives::{Address, Bytes, Log, LogData, B256, U256, U64};
+use alloy_primitives::{keccak256, Address, Bytes, Log, LogData, B256, U256, U64};
 use alloy_rpc_types::request::{TransactionInput, TransactionRequest};
 use alloy_sol_types::{SolInterface, SolValue};
 use foundry_cheatcodes_common::{
@@ -29,10 +29,11 @@ use foundry_evm_core::{
         HARDHAT_CONSOLE_ADDRESS,
     },
 };
-use foundry_zksync_compiler::DualCompiledContracts;
+use foundry_zksync_compiler::{DualCompiledContract, DualCompiledContracts};
 use foundry_zksync_core::{
+    cheatcodes::EMPTY_CODE,
     convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
-    hash_bytecode, ZkTransactionMetadata,
+    ZkTransactionMetadata,
 };
 use itertools::Itertools;
 use revm::{
@@ -257,7 +258,24 @@ impl Cheatcodes {
     pub fn new(config: Arc<CheatsConfig>) -> Self {
         let labels = config.labels.clone();
         let script_wallets = config.script_wallets.clone();
-        let dual_compiled_contracts = config.dual_compiled_contracts.clone();
+        let mut dual_compiled_contracts = config.dual_compiled_contracts.clone();
+
+        // We add the empty bytecode manually so it is correctly translated in zk mode.
+        // This is used in many places in foundry, e.g. in cheatcode contract's account code.
+        let empty_bytes = Bytes::from_static(&[0]);
+        dual_compiled_contracts.push(DualCompiledContract {
+            name: String::from("EmptyEVMBytecode"),
+            zk_bytecode_hash: foundry_zksync_core::hash_bytecode(&EMPTY_CODE),
+            zk_deployed_bytecode: EMPTY_CODE.to_vec(),
+            zk_factory_deps: Default::default(),
+            evm_bytecode_hash: B256::from_slice(&keccak256(&empty_bytes)[..]),
+            evm_deployed_bytecode: Bytecode::new_raw(empty_bytes.clone())
+                .to_checked()
+                .bytecode
+                .to_vec(),
+            evm_bytecode: Bytecode::new_raw(empty_bytes).to_checked().bytecode.to_vec(),
+        });
+
         let startup_zk = config.use_zk;
         Self {
             config,
@@ -364,7 +382,7 @@ impl Cheatcodes {
     /// accounts
     pub fn select_evm<DB: DatabaseExt>(&mut self, data: &mut EVMData<'_, DB>) {
         if !self.use_zk_vm {
-            tracing::info!("already in  EVM");
+            tracing::info!("already in EVM");
             return
         }
 
@@ -1677,8 +1695,11 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
             // get the current persisted factory deps to pass to zk create
             let persisted_factory_deps = self.persisted_factory_deps.clone();
             // and extend it for future calls
-            self.persisted_factory_deps
-                .extend(factory_deps.iter().map(|dep| (hash_bytecode(dep), dep.clone())));
+            self.persisted_factory_deps.extend(
+                factory_deps
+                    .iter()
+                    .map(|dep| (foundry_zksync_core::hash_bytecode(dep), dep.clone())),
+            );
 
             tracing::debug!(contract = zk_contract.name, "using dual compiled contract");
             let ccx = foundry_zksync_core::vm::CheatcodeTracerContext {

--- a/crates/zksync/core/src/cheatcodes.rs
+++ b/crates/zksync/core/src/cheatcodes.rs
@@ -15,7 +15,10 @@ use zksync_types::{
 };
 use zksync_utils::bytecode::hash_bytecode;
 
-use crate::convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256};
+use crate::{
+    convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
+    EMPTY_CODE,
+};
 
 /// Sets `block.timestamp`.
 pub fn warp<'a, DB>(
@@ -173,9 +176,6 @@ pub fn etch<'a, DB>(
     account.info.code_hash = B256::from(bytecode_hash.to_be_bytes());
     account.info.code = Some(bytecode.clone());
 }
-
-/// Represents an empty code
-pub const EMPTY_CODE: [u8; 32] = [0; 32];
 
 /// Sets code for a mocked account. If not done, the mocked call will revert.
 /// The call has no effect if the mocked account already has a bytecode entry.

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -41,6 +41,9 @@ use zksync_web3_rs::{
 
 type Result<T> = std::result::Result<T, eyre::Report>;
 
+/// Represents an empty code
+pub const EMPTY_CODE: [u8; 32] = [0; 32];
+
 /// The minimum possible address that is not reserved in the zkSync space.
 const MIN_VALID_ADDRESS: u32 = 2u32.pow(16);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Accounts with empty bytecode (`0x0`) could not be translated to zk-vm as the corresponding `DualCompiledContract` is not available. This causes cheatcode address to not work correctly when switching VMs.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Adds a manual `DualCompiledContract` entry for the empty bytecode (`0x0`), with its corresponding valid zk-vm bytecode.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
Makes the following tetsts pass https://github.com/Moonsong-Labs/aave-delivery-infrastructure/pull/14
