### PR TITLE
fix: specify create calls explicitly

### DIFF
--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -93,13 +93,14 @@ pub struct CallContext {
     /// Delegated contract's address. This is used
     /// to override `address(this)` for delegate calls.
     pub delegate_as: Option<Address>,
-
     /// The current block number
     pub block_number: rU256,
     /// The current block timestamp
     pub block_timestamp: rU256,
     /// The current block basefee
     pub block_basefee: rU256,
+    /// Whether the current call is a create.
+    pub is_create: bool,
 }
 
 /// A tracer to allow for foundry-specific functionality.

--- a/zk-tests/src/Contracts.t.sol
+++ b/zk-tests/src/Contracts.t.sol
@@ -4,6 +4,15 @@ pragma solidity ^0.8.13;
 import {Test, console2 as console} from "forge-std/Test.sol";
 import {ConstantNumber} from "./ConstantNumber.sol";
 
+interface ISystemContractDeployer {
+    function getNewAddressCreate2(
+        address _sender,
+        bytes32 _bytecodeHash,
+        bytes32 _salt,
+        bytes calldata _input
+    ) external view returns (address newAddress);
+}
+
 contract Number {
     function ten() public pure returns (uint8) {
         return 10;
@@ -229,5 +238,25 @@ contract ZkContractsTest is Test {
         );
 
         return address(uint160(uint256(address_hash)));
+    }
+
+    function testZkContractsCallSystemContract() public {
+        (bool success, ) = address(vm).call(
+            abi.encodeWithSignature("zkVm(bool)", true)
+        );
+        require(success, "zkVm() call failed");
+
+        ISystemContractDeployer deployer = ISystemContractDeployer(
+            address(0x0000000000000000000000000000000000008006)
+        );
+
+        address addr = deployer.getNewAddressCreate2(
+            address(this),
+            0x0100000781e55a60f3f14fd7dd67e3c8caab896b7b0fca4a662583959299eede,
+            0x0100000781e55a60f3f14fd7dd67e3c8caab896b7b0fca4a662583959299eede,
+            ""
+        );
+
+        assertEq(address(0x46efB6258A2A539f7C8b44e2EF659D778fb5BAAd), addr);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Previously all calls to `SYSTEM_DEPLOYER` contract were being treated as create calls, and being decoded as such, which resulted in failures.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Demarcate calls explicitly as create calls, instead of assuming all calls to `SYSTEM_DEPLOYER` are create.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
