### PR TITLE
docs: log error if trying to mock `tx.origin`

### DIFF
--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -32,6 +32,7 @@ impl Cheatcode for mockCall_0Call {
                 *callee,
                 ccx.data.db,
                 &mut ccx.data.journaled_state,
+                ccx.caller,
             );
         }
 

--- a/crates/zksync/core/src/cheatcodes.rs
+++ b/crates/zksync/core/src/cheatcodes.rs
@@ -183,10 +183,15 @@ pub fn set_mocked_account<'a, DB>(
     address: Address,
     db: &'a mut DB,
     journaled_state: &'a mut JournaledState,
+    caller: Address,
 ) where
     DB: Database,
     <DB as Database>::Error: Debug,
 {
+    if address == caller {
+        tracing::error!("using `mockCall` cheatcode on caller isn't supported in zkVM");
+    }
+
     let account_code_addr = zksync_types::ACCOUNT_CODE_STORAGE_ADDRESS.to_address();
     let known_code_addr = zksync_types::KNOWN_CODES_STORAGE_ADDRESS.to_address();
     {

--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -155,8 +155,17 @@ contract ZkCheatcodesTest is Test {
         assertEq(dataAfter, bytes(hex"a1b1"));
     }
 
-    function testZkCheatcodesCanMockTestContract() public {
-        testZkCheatcodesCanMockCall(address(this));
+    function testZkCheatcodesCanMockCallTestContract() public {
+        address thisAddress = address(this);
+
+        vm.mockCall(
+            thisAddress,
+            abi.encodeWithSelector(IMyProxyCaller.transact.selector),
+            abi.encode()
+        );
+
+        MyProxyCaller transactor = new MyProxyCaller();
+        transactor.transact(thisAddress);
     }
 
     function testZkCheatcodesCanMockCall(address mockMe) public {

--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -155,16 +155,17 @@ contract ZkCheatcodesTest is Test {
         assertEq(dataAfter, bytes(hex"a1b1"));
     }
 
-     function testZkCheatcodesCanMockCallTestContract() public {
-        address thisAddress = address(this);
+    function testZkCheatcodesCanMockCall(address mockMe) public {
+        //zkVM currently doesn't support mocking the transaction sender
+        vm.assume(mockMe != tx.origin);
 
         vm.mockCall(
-            thisAddress,
+            mockMe,
             abi.encodeWithSelector(IMyProxyCaller.transact.selector),
             abi.encode()
         );
 
         MyProxyCaller transactor = new MyProxyCaller();
-        transactor.transact(thisAddress);
+        transactor.transact(mockMe);
     }
 }

--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -155,7 +155,13 @@ contract ZkCheatcodesTest is Test {
         assertEq(dataAfter, bytes(hex"a1b1"));
     }
 
+    function testZkCheatcodesCanMockTestContract() public {
+        testZkCheatcodesCanMockCall(address(this));
+    }
+
     function testZkCheatcodesCanMockCall(address mockMe) public {
+        vm.assume(mockMe != address(vm));
+
         //zkVM currently doesn't support mocking the transaction sender
         vm.assume(mockMe != tx.origin);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Our current implementation of zkVM doesn't allow us to make calls to the `tx.origin` address.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add a test to document this limitation, and add an error log when mocking the `tx.origin` address, assuming that the intention is for that address to be called.