### PR TITLE
fix: switch to `ci` branch on test repo

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo build --release --bin forge
 
       - name: Clone Aave Delivery Infrastructure
-        run: git clone https://github.com/Moonsong-Labs/aave-delivery-infrastructure.git --depth=1 -b feat/zksync
+        run: git clone https://github.com/Moonsong-Labs/aave-delivery-infrastructure.git --depth=1 -b ci
 
       - name: Run tests using built binary
         run: |


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently we are running the aave delivery infrastructure tests on the same branch that we'll propose the BGD team to merge. This branch has a few tests that fail, which we'd like to keep separate from the CI from the time being.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
A specific `ci` branch has been made on the test repo, so we use that one instead
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
