### PR TITLE
fix: avoid test contract migration

### DIFF
--- a/crates/evm/core/src/backend/fuzz.rs
+++ b/crates/evm/core/src/backend/fuzz.rs
@@ -261,6 +261,10 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     fn has_cheatcode_access(&self, account: &Address) -> bool {
         self.backend.has_cheatcode_access(account)
     }
+
+    fn get_test_contract_address(&self) -> Option<Address> {
+        self.backend.get_test_contract_address()
+    }
 }
 
 impl<'a> DatabaseRef for FuzzBackendWrapper<'a> {

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -339,6 +339,9 @@ pub trait DatabaseExt: Database<Error = DatabaseError> {
         }
         Ok(())
     }
+
+    /// Retrieves test contract's address
+    fn get_test_contract_address(&self) -> Option<Address>;
 }
 
 /// Provides the underlying `revm::Database` implementation.
@@ -1487,6 +1490,10 @@ impl DatabaseExt for Backend {
 
     fn has_cheatcode_access(&self, account: &Address) -> bool {
         self.inner.cheatcode_access_accounts.contains(account)
+    }
+
+    fn get_test_contract_address(&self) -> Option<Address> {
+        self.test_contract_address()
     }
 }
 

--- a/zk-tests/src/SetupForkFailure.t.sol
+++ b/zk-tests/src/SetupForkFailure.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console2 as console} from "forge-std/Test.sol";
+
+contract Number {
+    function ten() public pure returns (uint8) {
+        return 10;
+    }
+}
+
+contract ZkSetupForkFailureTest is Test {
+    uint256 constant ETH_FORK_BLOCK = 18993187;
+    address constant TEST_ADDRESS = 0x6Eb28604685b1F182dAB800A1Bfa4BaFdBA8a79a;
+    Number number;
+
+    function setUp() public {
+        vm.createSelectFork(
+            "https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf",
+            ETH_FORK_BLOCK
+        );
+        number = new Number();
+    }
+
+    function testFail_ZkSetupForkFailureExecutesTest() public pure {
+        assert(false);
+    }
+}

--- a/zk-tests/src/SetupForkFailure.t.sol
+++ b/zk-tests/src/SetupForkFailure.t.sol
@@ -1,27 +1,19 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test, console2 as console} from "forge-std/Test.sol";
-
-contract Number {
-    function ten() public pure returns (uint8) {
-        return 10;
-    }
-}
+import {Test} from "forge-std/Test.sol";
 
 contract ZkSetupForkFailureTest is Test {
     uint256 constant ETH_FORK_BLOCK = 18993187;
-    address constant TEST_ADDRESS = 0x6Eb28604685b1F182dAB800A1Bfa4BaFdBA8a79a;
-    Number number;
 
     function setUp() public {
         vm.createSelectFork(
             "https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf",
             ETH_FORK_BLOCK
         );
-        number = new Number();
     }
 
+    // We test that the following function is called after EVM fork from zk context
     function testFail_ZkSetupForkFailureExecutesTest() public pure {
         assert(false);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
During forking during `setUp` when run with `--zksync`, the test contract isn't in the `persisted_accounts` list during initialization and as such isn't migrated to zksync. This causes it to be incorrectly migrated to an empty code account when a evm fork is encountered.

This in turn causes the test to _silently pass_ as it's never called (since we've effectively erased the test contract). Such a failure can be detected by a negative test, which foundry provides via `testFail`, i.e. if the function doesn't revert the test fails -ensuring that the test is executed.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Avoid migrating test contract at all, since we never call it in zksync context.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
An alternate solution would be to detect if the test contract is in `persisted_accounts` and has not been migrated yet, to selectively migrate it to zksync during Cheatcode tracer init.
