### PR TITLE
fix: avoid create from default caller in zk vm

### DIFF
--- a/crates/zksync/compiler/src/zksolc/mod.rs
+++ b/crates/zksync/compiler/src/zksolc/mod.rs
@@ -119,7 +119,7 @@ impl DualCompiledContracts {
                     debug!(
                         name = contract.name,
                         deps = contract.zk_factory_deps.len(),
-                        "new factory depdendency"
+                        "new factory dependency"
                     );
 
                     for nested_dep in &contract.zk_factory_deps {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
When using `--avoid-contracts` for test files, the respective contracts are not compiled for zksync. This is generally okay since tests always run in EVM.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Avoid running create from default caller (`0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`) in zk-vm.

## Note
* This can still cause issues if the required contracts in the test are not available in zksolc.
* It is unknown if this limitation can cause other issues where this expectation (default caller creating a zk contract) is assumed to be valid.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
