### PR TITLE
fix: support deploying nested lib directly in create

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -119,7 +119,7 @@ impl CreateArgs {
 
         let mut config = self.eth.try_load_config_emit_warnings()?;
         let zksync = self.opts.compiler.zksync;
-        let libraries_to_deploy = if zksync && self.deploy_missing_libraries {
+        let libs_batches = if zksync && self.deploy_missing_libraries {
             let missing_libraries =
                 ZkLibrariesManager::get_detected_missing_libraries(project.root())?;
 
@@ -136,108 +136,74 @@ impl CreateArgs {
 
             info!("Resolving missing libraries");
 
-            ZkLibrariesManager::resolve_libraries(missing_libraries, &all_deployed_libraries)
-                .map(|batches| batches.into_iter().flatten().collect::<Vec<ContractInfo>>())?
+            ZkLibrariesManager::resolve_libraries(missing_libraries, &all_deployed_libraries)?
         } else {
             vec![]
         };
-        let deploying_libraries = !libraries_to_deploy.is_empty();
-
-        let (avoid_contracts, contracts_to_compile) = if !deploying_libraries {
-            (
-                self.opts.compiler.avoid_contracts.clone(),
-                self.opts.compiler.contracts_to_compile.clone(),
-            )
-        } else {
-            (
-                None,
-                Some(
-                    libraries_to_deploy
-                        .iter()
-                        .map(|lib| lib.path.clone().expect("libraries must specify path"))
-                        .map(|path| {
-                            PathBuf::from(path)
-                                .file_name()
-                                .expect("contract path to have filename")
-                                .to_string_lossy()
-                                .to_string()
-                        })
-                        .collect(),
-                ),
-            )
-        };
-
-        let mut zksolc = ZkSolc::new(
-            config
-                .new_zksolc_config_builder()
-                .and_then(|builder| {
-                    builder
-                        .avoid_contracts(avoid_contracts)
-                        .contracts_to_compile(contracts_to_compile)
-                        .build()
-                })
-                .map_err(|e| eyre::eyre!(e))?,
-            config.zk_project()?,
-        );
-        let (zk_output, _contract_bytecodes) = match zksolc.compile() {
-            Ok(compiled) => compiled,
-            Err(e) => return Err(eyre::eyre!("Failed to compile with zksolc: {}", e)),
-        };
-        let dual_compiled_contracts = DualCompiledContracts::new(&output, &zk_output);
+        let deploying_libraries = !libs_batches.is_empty();
 
         let contracts_to_deploy = if !deploying_libraries {
-            vec![self
+            vec![vec![self
                 .contract
                 .clone()
-                .ok_or_else(|| eyre::eyre!("Contract to deploy must be passed"))?]
+                .ok_or_else(|| eyre::eyre!("Contract to deploy must be passed"))?]]
         } else {
-            libraries_to_deploy
+            libs_batches
         };
 
-        for mut contract in contracts_to_deploy {
-            if let Some(ref mut path) = contract.path {
-                // paths are absolute in the project's output
-                *path = canonicalized(project.root().join(&path)).to_string_lossy().to_string();
-            }
+        for contracts_batch in contracts_to_deploy {
+            let (avoid_contracts, contracts_to_compile) = if !deploying_libraries {
+                (
+                    self.opts.compiler.avoid_contracts.clone(),
+                    self.opts.compiler.contracts_to_compile.clone(),
+                )
+            } else {
+                (
+                    None,
+                    Some(
+                        contracts_batch
+                            .iter()
+                            .map(|lib| lib.path.clone().expect("libraries must specify path"))
+                            .map(|path| {
+                                PathBuf::from(path)
+                                    .file_name()
+                                    .expect("contract path to have filename")
+                                    .to_string_lossy()
+                                    .to_string()
+                            })
+                            .collect(),
+                    ),
+                )
+            };
 
-            let (abi, bin, _) = remove_contract(&mut output, &contract)?;
+            let mut zksolc = ZkSolc::new(
+                config
+                    .new_zksolc_config_builder()
+                    .and_then(|builder| {
+                        builder
+                            .avoid_contracts(avoid_contracts)
+                            .contracts_to_compile(contracts_to_compile)
+                            .build()
+                    })
+                    .map_err(|e| eyre::eyre!(e))?,
+                config.zk_project()?,
+            );
+            let (zk_output, _contract_bytecodes) = match zksolc.compile() {
+                Ok(compiled) => compiled,
+                Err(e) => return Err(eyre::eyre!("Failed to compile with zksolc: {}", e)),
+            };
+            let dual_compiled_contracts = DualCompiledContracts::new(&output, &zk_output);
 
-            let (bin, zk_data) = if zksync {
-                let contract = bin
-                    .object
-                    .as_bytes()
-                    .and_then(|bytes| dual_compiled_contracts.find_by_evm_bytecode(&bytes.0))
-                    .ok_or(eyre::eyre!(
-                        "Could not find zksolc contract for contract {}",
-                        contract.name
-                    ))?;
+            for mut contract in contracts_batch {
+                if let Some(ref mut path) = contract.path {
+                    // paths are absolute in the project's output
+                    *path = canonicalized(project.root().join(&path)).to_string_lossy().to_string();
+                }
 
-                let zk_bin = CompactBytecode {
-                    object: BytecodeObject::Bytecode(Bytes::from(
-                        contract.zk_deployed_bytecode.clone(),
-                    )),
-                    link_references: Default::default(),
-                    source_map: Default::default(),
-                };
+                let (abi, bin, _) = remove_contract(&mut output, &contract)?;
 
-                let mut factory_deps = dual_compiled_contracts.fetch_all_factory_deps(contract);
-
-                // for manual specified factory deps
-                for mut contract in std::mem::take(&mut self.factory_deps) {
-                    if let Some(path) = contract.path.as_mut() {
-                        *path =
-                            canonicalized(project.root().join(&path)).to_string_lossy().to_string();
-                    }
-
-                    let (_, bin, _) =
-                        remove_contract(&mut output, &contract).with_context(|| {
-                            format!(
-                                "Unable to find specified factory deps ({}) in project",
-                                contract.name
-                            )
-                        })?;
-
-                    let zk = bin
+                let (bin, zk_data) = if zksync {
+                    let contract = bin
                         .object
                         .as_bytes()
                         .and_then(|bytes| dual_compiled_contracts.find_by_evm_bytecode(&bytes.0))
@@ -246,88 +212,131 @@ impl CreateArgs {
                             contract.name
                         ))?;
 
-                    // if the dep isn't already present,
-                    // fetch all deps and add them to the final list
-                    if !factory_deps.contains(&zk.zk_deployed_bytecode) {
-                        let additional_factory_deps =
-                            dual_compiled_contracts.fetch_all_factory_deps(zk);
-                        factory_deps.extend(additional_factory_deps);
-                        factory_deps.dedup();
+                    let zk_bin = CompactBytecode {
+                        object: BytecodeObject::Bytecode(Bytes::from(
+                            contract.zk_deployed_bytecode.clone(),
+                        )),
+                        link_references: Default::default(),
+                        source_map: Default::default(),
+                    };
+
+                    let mut factory_deps = dual_compiled_contracts.fetch_all_factory_deps(contract);
+
+                    // for manual specified factory deps
+                    for mut contract in std::mem::take(&mut self.factory_deps) {
+                        if let Some(path) = contract.path.as_mut() {
+                            *path = canonicalized(project.root().join(&path))
+                                .to_string_lossy()
+                                .to_string();
+                        }
+
+                        let (_, bin, _) =
+                            remove_contract(&mut output, &contract).with_context(|| {
+                                format!(
+                                    "Unable to find specified factory deps ({}) in project",
+                                    contract.name
+                                )
+                            })?;
+
+                        let zk = bin
+                            .object
+                            .as_bytes()
+                            .and_then(|bytes| {
+                                dual_compiled_contracts.find_by_evm_bytecode(&bytes.0)
+                            })
+                            .ok_or(eyre::eyre!(
+                                "Could not find zksolc contract for contract {}",
+                                contract.name
+                            ))?;
+
+                        // if the dep isn't already present,
+                        // fetch all deps and add them to the final list
+                        if !factory_deps.contains(&zk.zk_deployed_bytecode) {
+                            let additional_factory_deps =
+                                dual_compiled_contracts.fetch_all_factory_deps(zk);
+                            factory_deps.extend(additional_factory_deps);
+                            factory_deps.dedup();
+                        }
                     }
+
+                    (
+                        zk_bin,
+                        Some((contract, factory_deps.into_iter().map(|bc| bc.to_vec()).collect())),
+                    )
+                } else {
+                    (bin, None)
+                };
+
+                let bin = match bin.object {
+                    BytecodeObject::Bytecode(_) => bin.object,
+                    _ => {
+                        let link_refs = bin
+                            .link_references
+                            .iter()
+                            .flat_map(|(path, names)| {
+                                names.keys().map(move |name| format!("\t{name}: {path}"))
+                            })
+                            .collect::<Vec<String>>()
+                            .join("\n");
+                        eyre::bail!("Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time\n{}", link_refs)
+                    }
+                };
+
+                // Add arguments to constructor
+                let provider = utils::get_provider(&config)?;
+                let params = match abi.constructor {
+                    Some(ref v) => {
+                        let constructor_args =
+                            if let Some(ref constructor_args_path) = self.constructor_args_path {
+                                read_constructor_args_file(constructor_args_path.to_path_buf())?
+                            } else {
+                                self.constructor_args.clone()
+                            };
+                        self.parse_constructor_args(v, &constructor_args)?
+                    }
+                    None => vec![],
+                };
+
+                // respect chain, if set explicitly via cmd args
+                let chain_id = if let Some(chain_id) = self.chain_id() {
+                    chain_id
+                } else {
+                    provider.get_chainid().await?.as_u64()
+                };
+                let address = if self.unlocked {
+                    // Deploy with unlocked account
+                    let sender = self.eth.wallet.from.expect("required");
+                    let provider = provider.with_sender(sender.to_ethers());
+                    self.deploy(&contract, abi, bin, params, provider, chain_id, zk_data, None)
+                        .await?
+                } else {
+                    // Deploy with signer
+                    let signer = self.eth.wallet.signer().await?;
+                    let zk_signer = self.eth.wallet.signer().await?;
+                    let provider =
+                        SignerMiddleware::new_with_provider_chain(provider, signer).await?;
+                    self.deploy(
+                        &contract,
+                        abi,
+                        bin,
+                        params,
+                        provider,
+                        chain_id,
+                        zk_data,
+                        Some(zk_signer),
+                    )
+                    .await?
+                };
+
+                if deploying_libraries {
+                    config.libraries.push(format!(
+                        "{}:{}:{:#02x}",
+                        contract.path.expect("library must have path"),
+                        contract.name,
+                        address
+                    ));
+                    config.update_libraries()?;
                 }
-
-                (zk_bin, Some((contract, factory_deps.into_iter().map(|bc| bc.to_vec()).collect())))
-            } else {
-                (bin, None)
-            };
-
-            let bin = match bin.object {
-                BytecodeObject::Bytecode(_) => bin.object,
-                _ => {
-                    let link_refs = bin
-                        .link_references
-                        .iter()
-                        .flat_map(|(path, names)| {
-                            names.keys().map(move |name| format!("\t{name}: {path}"))
-                        })
-                        .collect::<Vec<String>>()
-                        .join("\n");
-                    eyre::bail!("Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time\n{}", link_refs)
-                }
-            };
-
-            // Add arguments to constructor
-            let provider = utils::get_provider(&config)?;
-            let params = match abi.constructor {
-                Some(ref v) => {
-                    let constructor_args =
-                        if let Some(ref constructor_args_path) = self.constructor_args_path {
-                            read_constructor_args_file(constructor_args_path.to_path_buf())?
-                        } else {
-                            self.constructor_args.clone()
-                        };
-                    self.parse_constructor_args(v, &constructor_args)?
-                }
-                None => vec![],
-            };
-
-            // respect chain, if set explicitly via cmd args
-            let chain_id = if let Some(chain_id) = self.chain_id() {
-                chain_id
-            } else {
-                provider.get_chainid().await?.as_u64()
-            };
-            let address = if self.unlocked {
-                // Deploy with unlocked account
-                let sender = self.eth.wallet.from.expect("required");
-                let provider = provider.with_sender(sender.to_ethers());
-                self.deploy(&contract, abi, bin, params, provider, chain_id, zk_data, None).await?
-            } else {
-                // Deploy with signer
-                let signer = self.eth.wallet.signer().await?;
-                let zk_signer = self.eth.wallet.signer().await?;
-                let provider = SignerMiddleware::new_with_provider_chain(provider, signer).await?;
-                self.deploy(
-                    &contract,
-                    abi,
-                    bin,
-                    params,
-                    provider,
-                    chain_id,
-                    zk_data,
-                    Some(zk_signer),
-                )
-                .await?
-            };
-
-            if deploying_libraries {
-                config.libraries.push(format!(
-                    "{}:{}:{:#02x}",
-                    contract.path.expect("library must have path"),
-                    contract.name,
-                    address
-                ));
-                config.update_libraries()?;
             }
         }
 

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -353,6 +353,7 @@ impl CreateArgs {
                     compiler: CompilerArgs {
                         avoid_contracts: self.opts.compiler.avoid_contracts.take(),
                         contracts_to_compile: self.opts.compiler.contracts_to_compile.take(),
+                        zksync: self.opts.compiler.zksync,
                         ..Default::default()
                     },
                     ..Default::default()

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -1,5 +1,5 @@
 use super::{retry::RetryArgs, verify};
-use crate::cmd::build::BuildArgs;
+
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt, ResolveSolType};
 use alloy_json_abi::{Constructor, JsonAbi};
 use alloy_primitives::{Address, Bytes};
@@ -17,7 +17,7 @@ use ethers_middleware::SignerMiddleware;
 use ethers_providers::Middleware;
 use eyre::{Context, Result};
 use foundry_cli::{
-    opts::{CompilerArgs, CoreBuildArgs, EthereumOpts, EtherscanOpts, TransactionOpts},
+    opts::{CoreBuildArgs, EthereumOpts, EtherscanOpts, TransactionOpts},
     utils::{self, read_constructor_args_file, remove_contract, LoadConfig},
 };
 use foundry_common::{
@@ -34,7 +34,7 @@ use foundry_compilers::{
 use foundry_config::Chain;
 use foundry_wallets::WalletSigner;
 use foundry_zksync_compiler::{
-    DualCompiledContract, DualCompiledContracts, libraries as zklibs, ZkSolc,
+    libraries as zklibs, DualCompiledContract, DualCompiledContracts, ZkSolc,
 };
 
 use serde_json::json;
@@ -118,8 +118,7 @@ impl CreateArgs {
 
         // Resolve missing libraries
         let libs_batches = if zksync && self.deploy_missing_libraries {
-            let missing_libraries =
-                zklibs::get_detected_missing_libraries(&project_root)?;
+            let missing_libraries = zklibs::get_detected_missing_libraries(&project_root)?;
 
             let mut all_deployed_libraries = Vec::with_capacity(config.libraries.len());
             for library in &config.libraries {

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -136,7 +136,8 @@ impl CreateArgs {
 
             info!("Resolving missing libraries");
 
-            ZkLibrariesManager::resolve_libraries(missing_libraries, &all_deployed_libraries)?
+            ZkLibrariesManager::resolve_libraries(missing_libraries, &all_deployed_libraries)
+                .map(|batches| batches.into_iter().flatten().collect::<Vec<ContractInfo>>())?
         } else {
             vec![]
         };

--- a/crates/zksync/compiler/src/lib.rs
+++ b/crates/zksync/compiler/src/lib.rs
@@ -8,5 +8,4 @@ mod zksolc;
 
 pub use zksolc::*;
 
-mod libraries;
-pub use libraries::*;
+pub mod libraries;

--- a/crates/zksync/compiler/src/libraries.rs
+++ b/crates/zksync/compiler/src/libraries.rs
@@ -15,13 +15,13 @@ pub struct ZkLibrariesManager;
 
 impl ZkLibrariesManager {
     /// Return the missing libraries cache path
-    pub(crate) fn get_missing_libraries_cache_path(project_root: &Path) -> PathBuf {
-        project_root.join(".zksolc-libraries-cache/missing_library_dependencies.json")
+    pub(crate) fn get_missing_libraries_cache_path(project_root: impl AsRef<Path>) -> PathBuf {
+        project_root.as_ref().join(".zksolc-libraries-cache/missing_library_dependencies.json")
     }
 
     /// Add libraries to missing libraries cache
     pub(crate) fn add_dependencies_to_missing_libraries_cache(
-        project_root: &Path,
+        project_root: impl AsRef<Path>,
         libraries: &[ZkMissingLibrary],
     ) -> eyre::Result<()> {
         let file_path = Self::get_missing_libraries_cache_path(project_root);
@@ -33,7 +33,7 @@ impl ZkLibrariesManager {
 
     /// Returns the detected missing libraries from previous compilation
     pub fn get_detected_missing_libraries(
-        project_root: &Path,
+        project_root: impl AsRef<Path>,
     ) -> eyre::Result<Vec<ZkMissingLibrary>> {
         let library_paths = Self::get_missing_libraries_cache_path(project_root);
         if !library_paths.exists() {
@@ -44,7 +44,7 @@ impl ZkLibrariesManager {
     }
 
     /// Performs cleanup of cached missing libraries
-    pub fn cleanup_detected_missing_libraries(project_root: &Path) -> eyre::Result<()> {
+    pub fn cleanup_detected_missing_libraries(project_root: impl AsRef<Path>) -> eyre::Result<()> {
         fs::remove_file(Self::get_missing_libraries_cache_path(project_root))?;
         Ok(())
     }

--- a/crates/zksync/compiler/src/libraries.rs
+++ b/crates/zksync/compiler/src/libraries.rs
@@ -112,7 +112,7 @@ impl ZkLibrariesManager {
                     let lib_name = split.next().unwrap();
 
                     !batch.iter().any(|lib| {
-                        lib.path.as_ref().map(|s| s.as_str()) == Some(lib_path) &&
+                        lib.path.as_deref() == Some(lib_path) &&
                             lib.name.as_str() == lib_name
                     })
                 })

--- a/crates/zksync/compiler/src/libraries.rs
+++ b/crates/zksync/compiler/src/libraries.rs
@@ -112,8 +112,7 @@ impl ZkLibrariesManager {
                     let lib_name = split.next().unwrap();
 
                     !batch.iter().any(|lib| {
-                        lib.path.as_deref() == Some(lib_path) &&
-                            lib.name.as_str() == lib_name
+                        lib.path.as_deref() == Some(lib_path) && lib.name.as_str() == lib_name
                     })
                 })
             }

--- a/crates/zksync/compiler/src/libraries.rs
+++ b/crates/zksync/compiler/src/libraries.rs
@@ -1,3 +1,5 @@
+//! Handles resolution and storage of missing libraries emitted by zksolc
+
 use std::{
     fs,
     io::Write,
@@ -10,114 +12,108 @@ use foundry_compilers::info::ContractInfo;
 
 use crate::ZkMissingLibrary;
 
-/// Manages non-inlineable libraries for zkSolc
-pub struct ZkLibrariesManager;
+/// Return the missing libraries cache path
+pub(crate) fn get_missing_libraries_cache_path(project_root: impl AsRef<Path>) -> PathBuf {
+    project_root.as_ref().join(".zksolc-libraries-cache/missing_library_dependencies.json")
+}
 
-impl ZkLibrariesManager {
-    /// Return the missing libraries cache path
-    pub(crate) fn get_missing_libraries_cache_path(project_root: impl AsRef<Path>) -> PathBuf {
-        project_root.as_ref().join(".zksolc-libraries-cache/missing_library_dependencies.json")
+/// Add libraries to missing libraries cache
+pub(crate) fn add_dependencies_to_missing_libraries_cache(
+    project_root: impl AsRef<Path>,
+    libraries: &[ZkMissingLibrary],
+) -> eyre::Result<()> {
+    let file_path = get_missing_libraries_cache_path(project_root);
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    fs::File::create(file_path)?
+        .write_all(serde_json::to_string_pretty(libraries).unwrap().as_bytes())?;
+    Ok(())
+}
+
+/// Returns the detected missing libraries from previous compilation
+pub fn get_detected_missing_libraries(
+    project_root: impl AsRef<Path>,
+) -> eyre::Result<Vec<ZkMissingLibrary>> {
+    let library_paths = get_missing_libraries_cache_path(project_root);
+    if !library_paths.exists() {
+        eyre::bail!("No missing libraries found");
     }
 
-    /// Add libraries to missing libraries cache
-    pub(crate) fn add_dependencies_to_missing_libraries_cache(
-        project_root: impl AsRef<Path>,
-        libraries: &[ZkMissingLibrary],
-    ) -> eyre::Result<()> {
-        let file_path = Self::get_missing_libraries_cache_path(project_root);
-        fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-        fs::File::create(file_path)?
-            .write_all(serde_json::to_string_pretty(libraries).unwrap().as_bytes())?;
-        Ok(())
-    }
+    Ok(serde_json::from_reader(fs::File::open(&library_paths)?)?)
+}
 
-    /// Returns the detected missing libraries from previous compilation
-    pub fn get_detected_missing_libraries(
-        project_root: impl AsRef<Path>,
-    ) -> eyre::Result<Vec<ZkMissingLibrary>> {
-        let library_paths = Self::get_missing_libraries_cache_path(project_root);
-        if !library_paths.exists() {
-            eyre::bail!("No missing libraries found");
+/// Performs cleanup of cached missing libraries
+pub fn cleanup_detected_missing_libraries(project_root: impl AsRef<Path>) -> eyre::Result<()> {
+    fs::remove_file(get_missing_libraries_cache_path(project_root))?;
+    Ok(())
+}
+
+/// Retrieve ordered list of libraries to deploy
+///
+/// Libraries are grouped in batches, where the next batch
+/// may have dependencies on the previous one, thus
+/// it's recommended to build & deploy one batch before moving onto the next
+pub fn resolve_libraries(
+    mut missing_libraries: Vec<ZkMissingLibrary>,
+    already_deployed_libraries: &[ContractInfo],
+) -> eyre::Result<Vec<Vec<ContractInfo>>> {
+    trace!(?missing_libraries, ?already_deployed_libraries, "filtering out missing libraries");
+    missing_libraries.retain(|lib| {
+        !already_deployed_libraries.contains(&ContractInfo {
+            path: Some(lib.contract_path.to_string()),
+            name: lib.contract_name.to_string(),
+        })
+    });
+
+    let mut batches = Vec::new();
+    loop {
+        if missing_libraries.is_empty() {
+            break Ok(batches);
         }
 
-        Ok(serde_json::from_reader(fs::File::open(&library_paths)?)?)
-    }
-
-    /// Performs cleanup of cached missing libraries
-    pub fn cleanup_detected_missing_libraries(project_root: impl AsRef<Path>) -> eyre::Result<()> {
-        fs::remove_file(Self::get_missing_libraries_cache_path(project_root))?;
-        Ok(())
-    }
-
-    /// Retrieve ordered list of libraries to deploy
-    ///
-    /// Libraries are grouped in batches, where the next batch
-    /// may have dependencies on the previous one, thus
-    /// it's recommended to build & deploy one batch before moving onto the next
-    pub fn resolve_libraries(
-        mut missing_libraries: Vec<ZkMissingLibrary>,
-        already_deployed_libraries: &[ContractInfo],
-    ) -> eyre::Result<Vec<Vec<ContractInfo>>> {
-        trace!(?missing_libraries, ?already_deployed_libraries, "filtering out missing libraries");
-        missing_libraries.retain(|lib| {
-            !already_deployed_libraries.iter().any(|dep| {
-                dep.name == lib.contract_name &&
-                    dep.path.as_ref().map(|path| path == &lib.contract_path).unwrap_or(true)
-            })
-        });
-
-        let mut batches = Vec::new();
+        let mut batch = Vec::new();
         loop {
-            if missing_libraries.is_empty() {
-                break Ok(batches);
-            }
+            // find library with no further dependencies
+            let Some(next_lib) = missing_libraries
+                .iter()
+                .enumerate()
+                .find(|(_, lib)| lib.missing_libraries.is_empty())
+                .map(|(i, _)| i)
+                .map(|i| missing_libraries.remove(i))
+            else {
+                // no such library, and we didn't collect any library already
+                if batch.is_empty() {
+                    warn!(
+                        ?missing_libraries,
+                        ?batches,
+                        "unable to find library ready to be deployed"
+                    );
+                    //TODO: determine if this error message is accurate
+                    eyre::bail!("Library dependency cycle detected");
+                }
 
-            let mut batch = Vec::new();
-            loop {
-                // find library with no further dependencies
-                let Some(next_lib) = missing_libraries
-                    .iter()
-                    .enumerate()
-                    .find(|(_, lib)| lib.missing_libraries.is_empty())
-                    .map(|(i, _)| i)
-                    .map(|i| missing_libraries.remove(i))
-                else {
-                    // no such library, and we didn't collect any library already
-                    if batch.is_empty() {
-                        warn!(
-                            ?missing_libraries,
-                            ?batches,
-                            "unable to find library ready to be deployed"
-                        );
-                        //TODO: determine if this error message is accurate
-                        eyre::bail!("Library dependency cycle detected");
-                    }
+                break;
+            };
 
-                    break;
-                };
-
-                let info = ContractInfo {
-                    path: Some(next_lib.contract_path),
-                    name: next_lib.contract_name,
-                };
-                batch.push(info);
-            }
-
-            // remove this batch from each library's missing_library if listed as dependency
-            // this potentailly allows more libraries to be included in the next batch
-            for lib in &mut missing_libraries {
-                lib.missing_libraries.retain(|maybe_missing_lib| {
-                    let mut split = maybe_missing_lib.split(':');
-                    let lib_path = split.next().unwrap();
-                    let lib_name = split.next().unwrap();
-
-                    !batch.iter().any(|lib| {
-                        lib.path.as_deref() == Some(lib_path) && lib.name.as_str() == lib_name
-                    })
-                })
-            }
-
-            batches.push(batch);
+            let info =
+                ContractInfo { path: Some(next_lib.contract_path), name: next_lib.contract_name };
+            batch.push(info);
         }
+
+        // remove this batch from each library's missing_library if listed as dependency
+        // this potentailly allows more libraries to be included in the next batch
+        for lib in &mut missing_libraries {
+            lib.missing_libraries.retain(|maybe_missing_lib| {
+                let mut split = maybe_missing_lib.split(':');
+                let lib_path = split.next().unwrap();
+                let lib_name = split.next().unwrap();
+
+                !batch.contains(&ContractInfo {
+                    path: Some(lib_path.to_string()),
+                    name: lib_name.to_string(),
+                })
+            })
+        }
+
+        batches.push(batch);
     }
 }

--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -860,14 +860,15 @@ impl ZkSolc {
 
         // Patch the libraries to be relative to the project root
         // NOTE: This is a temporary fix until zksolc supports relative paths
-        let mut patched_libraries: BTreeMap<PathBuf, BTreeMap<String, String>> = BTreeMap::new();
-        for (path, details) in std_zk_json.settings.libraries.libs.iter() {
-            patched_libraries.insert(
-                path.strip_prefix(&self.project.paths.root).unwrap().into(),
-                details.clone(),
-            );
+        for (mut path, details) in
+            std::mem::take(&mut std_zk_json.settings.libraries.libs).into_iter()
+        {
+            if let Ok(patched) = path.strip_prefix(&self.project.paths.root) {
+                path = patched.to_owned();
+            }
+
+            std_zk_json.settings.libraries.libs.insert(path, details);
         }
-        std_zk_json.settings.libraries.libs = patched_libraries;
 
         // Store the generated standard JSON input in the ZkSolc instance
         self.standard_json = Some(std_zk_json.to_owned());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
With #357 we added support to `forge create` to deploy missing libraries found from a previous compilation.
We correctly sequence the libraries to be deployed in order, but as we compile all libraries together, we would find that nested libraried needed to be deployed, necessitating us to restart the cycle.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
We organize the libraries in batches, where batch n+1 has dependencies in batch n. 
By compiling and deploying each batch in sequence, we are able to deploy all libraries in the same invocation.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
This PR also brings some refactors to the compilation process:
* `--detect-missing-libraries` flag is not passed to the compiler unless compilation fails and it's detected to be due to missing libraries
* sources filtering happens ahead of time, skipping ignored files and providing slightly better UX
* minor refactors aimed at increasing performance
