### PR TITLE
fix: fuzz test failure on create address

### DIFF
--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -35,7 +35,12 @@ interface IMyProxyCaller {
 }
 
 contract MyProxyCaller {
-    function transact(address inner) public {
+    address inner;
+    constructor(address _inner) {
+        inner = _inner;
+    }
+
+    function transact() public {
         IMyProxyCaller(inner).transact(10);
     }
 }
@@ -157,6 +162,7 @@ contract ZkCheatcodesTest is Test {
 
     function testZkCheatcodesCanMockCallTestContract() public {
         address thisAddress = address(this);
+        MyProxyCaller transactor = new MyProxyCaller(thisAddress);
 
         vm.mockCall(
             thisAddress,
@@ -164,8 +170,7 @@ contract ZkCheatcodesTest is Test {
             abi.encode()
         );
 
-        MyProxyCaller transactor = new MyProxyCaller();
-        transactor.transact(thisAddress);
+        transactor.transact();
     }
 
     function testZkCheatcodesCanMockCall(address mockMe) public {
@@ -174,14 +179,7 @@ contract ZkCheatcodesTest is Test {
         //zkVM currently doesn't support mocking the transaction sender
         vm.assume(mockMe != tx.origin);
 
-        // Exclude next create address in EVM (to deploy MyProxyCaller)
-        vm.assume(
-            mockMe != address(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f)
-        );
-        // Exclude next create address in zkVM (to deploy MyProxyCaller)
-        vm.assume(
-            mockMe != address(0xB5c1DF089600415B21FB76bf89900Adb575947c8)
-        );
+        MyProxyCaller transactor = new MyProxyCaller(mockMe);
 
         vm.mockCall(
             mockMe,
@@ -189,7 +187,6 @@ contract ZkCheatcodesTest is Test {
             abi.encode()
         );
 
-        MyProxyCaller transactor = new MyProxyCaller();
-        transactor.transact(mockMe);
+        transactor.transact();
     }
 }

--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -174,6 +174,15 @@ contract ZkCheatcodesTest is Test {
         //zkVM currently doesn't support mocking the transaction sender
         vm.assume(mockMe != tx.origin);
 
+        // Exclude next create address in EVM (to deploy MyProxyCaller)
+        vm.assume(
+            mockMe != address(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f)
+        );
+        // Exclude next create address in zkVM (to deploy MyProxyCaller)
+        vm.assume(
+            mockMe != address(0xB5c1DF089600415B21FB76bf89900Adb575947c8)
+        );
+
         vm.mockCall(
             mockMe,
             abi.encodeWithSelector(IMyProxyCaller.transact.selector),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The current fuzz test to assert special addresses can be mocked fails if the input address is the next create address. This is not a failure in mocking the call but rather the contract cannot deploy as the `mockCall` inserts an empty bytecode in it for mocking purposes.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Deploy the contract before mocking, to avoid the empty bytecode insertion.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
