### PR TITLE
refactor: improve compilation performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
  "semver 1.0.22",
  "serde",
  "serde_json",
+ "spinoff",
  "tokio",
  "tracing",
  "url",
@@ -10610,6 +10611,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spinoff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20aa2ed67fbb202e7b716ff8bfc6571dd9301617767380197d701c31124e88f6"
+dependencies = [
+ "colored",
+ "once_cell",
+ "paste",
 ]
 
 [[package]]

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -162,13 +162,6 @@ impl CreateArgs {
                     contracts_batch
                         .iter()
                         .map(|lib| lib.path.clone().expect("libraries must specify path"))
-                        .map(|path| {
-                            PathBuf::from(path)
-                                .file_name()
-                                .expect("contract path to have filename")
-                                .to_string_lossy()
-                                .to_string()
-                        })
                         // respect passed in --contracts-to-compile but don't deploy them
                         .chain(input_contracts_to_compile.take().into_iter().flatten())
                         .collect(),

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -242,7 +242,7 @@ pub async fn runner_with_config_and_zk(mut config: Config) -> MultiContractRunne
                     name: contract_name,
                     zk_bytecode_hash: packed_bytecode.bytecode_hash(),
                     zk_deployed_bytecode: packed_bytecode.bytecode(),
-                    zk_factory_deps: packed_bytecode.factory_deps(),
+                    zk_factory_deps: packed_bytecode.factory_deps().to_vec(),
                     evm_bytecode_hash: keccak256(solc_deployed_bytecode),
                     evm_bytecode: solc_bytecode.to_vec(),
                     evm_deployed_bytecode: solc_deployed_bytecode.to_vec(),

--- a/crates/zksync/compiler/Cargo.toml
+++ b/crates/zksync/compiler/Cargo.toml
@@ -35,3 +35,4 @@ dirs = { version = "5.0.0" }
 tokio = "1"
 reqwest = { version = "0.11", default-features = false }
 xxhash-rust = { version = "0.8.7", features = ["const_xxh3"] }
+spinoff = { version = "0.8", features = ["dots8bit"] }

--- a/crates/zksync/compiler/src/lib.rs
+++ b/crates/zksync/compiler/src/lib.rs
@@ -8,5 +8,4 @@ mod zksolc;
 
 pub use zksolc::*;
 
-mod libraries;
-pub use libraries::*;
+pub mod libraries;

--- a/crates/zksync/compiler/src/libraries.rs
+++ b/crates/zksync/compiler/src/libraries.rs
@@ -24,8 +24,7 @@ pub(crate) fn add_dependencies_to_missing_libraries_cache(
 ) -> eyre::Result<()> {
     let file_path = get_missing_libraries_cache_path(project_root);
     fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-    fs::File::create(file_path)?
-        .write_all(serde_json::to_string_pretty(libraries).unwrap().as_bytes())?;
+    fs::File::create(file_path)?.write_all(serde_json::to_string(libraries).unwrap().as_bytes())?;
     Ok(())
 }
 

--- a/crates/zksync/compiler/src/libraries.rs
+++ b/crates/zksync/compiler/src/libraries.rs
@@ -1,3 +1,5 @@
+//! Handles resolution and storage of missing libraries emitted by zksolc
+
 use std::{
     fs,
     io::Write,
@@ -10,64 +12,67 @@ use foundry_compilers::info::ContractInfo;
 
 use crate::ZkMissingLibrary;
 
-/// Manages non-inlineable libraries for zkSolc
-pub struct ZkLibrariesManager;
+/// Return the missing libraries cache path
+pub(crate) fn get_missing_libraries_cache_path(project_root: impl AsRef<Path>) -> PathBuf {
+    project_root.as_ref().join(".zksolc-libraries-cache/missing_library_dependencies.json")
+}
 
-impl ZkLibrariesManager {
-    /// Return the missing libraries cache path
-    pub(crate) fn get_missing_libraries_cache_path(project_root: &Path) -> PathBuf {
-        project_root.join(".zksolc-libraries-cache/missing_library_dependencies.json")
+/// Add libraries to missing libraries cache
+pub(crate) fn add_dependencies_to_missing_libraries_cache(
+    project_root: impl AsRef<Path>,
+    libraries: &[ZkMissingLibrary],
+) -> eyre::Result<()> {
+    let file_path = get_missing_libraries_cache_path(project_root);
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    fs::File::create(file_path)?
+        .write_all(serde_json::to_string_pretty(libraries).unwrap().as_bytes())?;
+    Ok(())
+}
+
+/// Returns the detected missing libraries from previous compilation
+pub fn get_detected_missing_libraries(
+    project_root: impl AsRef<Path>,
+) -> eyre::Result<Vec<ZkMissingLibrary>> {
+    let library_paths = get_missing_libraries_cache_path(project_root);
+    if !library_paths.exists() {
+        eyre::bail!("No missing libraries found");
     }
 
-    /// Add libraries to missing libraries cache
-    pub(crate) fn add_dependencies_to_missing_libraries_cache(
-        project_root: &Path,
-        libraries: &[ZkMissingLibrary],
-    ) -> eyre::Result<()> {
-        let file_path = Self::get_missing_libraries_cache_path(project_root);
-        fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-        fs::File::create(file_path)?
-            .write_all(serde_json::to_string_pretty(libraries).unwrap().as_bytes())?;
-        Ok(())
-    }
+    Ok(serde_json::from_reader(fs::File::open(&library_paths)?)?)
+}
 
-    /// Returns the detected missing libraries from previous compilation
-    pub fn get_detected_missing_libraries(
-        project_root: &Path,
-    ) -> eyre::Result<Vec<ZkMissingLibrary>> {
-        let library_paths = Self::get_missing_libraries_cache_path(project_root);
-        if !library_paths.exists() {
-            eyre::bail!("No missing libraries found");
+/// Performs cleanup of cached missing libraries
+pub fn cleanup_detected_missing_libraries(project_root: impl AsRef<Path>) -> eyre::Result<()> {
+    fs::remove_file(get_missing_libraries_cache_path(project_root))?;
+    Ok(())
+}
+
+/// Retrieve ordered list of libraries to deploy
+///
+/// Libraries are grouped in batches, where the next batch
+/// may have dependencies on the previous one, thus
+/// it's recommended to build & deploy one batch before moving onto the next
+pub fn resolve_libraries(
+    mut missing_libraries: Vec<ZkMissingLibrary>,
+    already_deployed_libraries: &[ContractInfo],
+) -> eyre::Result<Vec<Vec<ContractInfo>>> {
+    trace!(?missing_libraries, ?already_deployed_libraries, "filtering out missing libraries");
+    missing_libraries.retain(|lib| {
+        !already_deployed_libraries.contains(&ContractInfo {
+            path: Some(lib.contract_path.to_string()),
+            name: lib.contract_name.to_string(),
+        })
+    });
+
+    let mut batches = Vec::new();
+    loop {
+        if missing_libraries.is_empty() {
+            break Ok(batches);
         }
 
-        Ok(serde_json::from_reader(fs::File::open(&library_paths)?)?)
-    }
-
-    /// Performs cleanup of cached missing libraries
-    pub fn cleanup_detected_missing_libraries(project_root: &Path) -> eyre::Result<()> {
-        fs::remove_file(Self::get_missing_libraries_cache_path(project_root))?;
-        Ok(())
-    }
-
-    /// Retrieve ordered list of libraries to deploy
-    pub fn resolve_libraries(
-        mut missing_libraries: Vec<ZkMissingLibrary>,
-        already_deployed_libraries: &[ContractInfo],
-    ) -> eyre::Result<Vec<ContractInfo>> {
-        trace!(?missing_libraries, ?already_deployed_libraries, "filtering out missing libraries");
-        missing_libraries.retain(|lib| {
-            !already_deployed_libraries.iter().any(|dep| {
-                dep.name == lib.contract_name &&
-                    dep.path.as_ref().map(|path| path == &lib.contract_path).unwrap_or(true)
-            })
-        });
-
-        let mut output_contracts = Vec::with_capacity(missing_libraries.len());
+        let mut batch = Vec::new();
         loop {
-            if missing_libraries.is_empty() {
-                break Ok(output_contracts);
-            }
-
+            // find library with no further dependencies
             let Some(next_lib) = missing_libraries
                 .iter()
                 .enumerate()
@@ -75,25 +80,40 @@ impl ZkLibrariesManager {
                 .map(|(i, _)| i)
                 .map(|i| missing_libraries.remove(i))
             else {
-                warn!(?missing_libraries, "unable to find library ready to be deployed");
-                //TODO: determine if this error message is accurate
-                eyre::bail!("Library dependency cycle detected");
+                // no such library, and we didn't collect any library already
+                if batch.is_empty() {
+                    warn!(
+                        ?missing_libraries,
+                        ?batches,
+                        "unable to find library ready to be deployed"
+                    );
+                    //TODO: determine if this error message is accurate
+                    eyre::bail!("Library dependency cycle detected");
+                }
+
+                break;
             };
-
-            //remove this lib from each missing_library if listed as dependency
-            for lib in &mut missing_libraries {
-                lib.missing_libraries.retain(|maybe_missing_lib| {
-                    let mut split = maybe_missing_lib.split(':');
-                    let lib_path = split.next().unwrap();
-                    let lib_name = split.next().unwrap();
-
-                    !(next_lib.contract_path == lib_path && next_lib.contract_name == lib_name)
-                })
-            }
 
             let info =
                 ContractInfo { path: Some(next_lib.contract_path), name: next_lib.contract_name };
-            output_contracts.push(info);
+            batch.push(info);
         }
+
+        // remove this batch from each library's missing_library if listed as dependency
+        // this potentailly allows more libraries to be included in the next batch
+        for lib in &mut missing_libraries {
+            lib.missing_libraries.retain(|maybe_missing_lib| {
+                let mut split = maybe_missing_lib.split(':');
+                let lib_path = split.next().unwrap();
+                let lib_name = split.next().unwrap();
+
+                !batch.contains(&ContractInfo {
+                    path: Some(lib_path.to_string()),
+                    name: lib_name.to_string(),
+                })
+            })
+        }
+
+        batches.push(batch);
     }
 }

--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -1,8 +1,8 @@
 #![allow(missing_docs)]
 //! This module provides the implementation of the ZkSolc compiler for Solidity contracts.
 use crate::{
+    libraries,
     zksolc::config::{Settings, ZkSolcConfig, ZkStandardJsonCompilerInput},
-    ZkLibrariesManager,
 };
 /// ZkSolc is a specialized compiler that supports zero-knowledge (ZK) proofs for smart
 /// contracts.
@@ -61,6 +61,11 @@ use tracing::{error, info, trace, warn};
 
 use crate::zksolc::PackedEraBytecode;
 
+/// It is observed that when there's a missing library without
+/// `--detect-missing-libraries` an error is thrown that contains
+/// this message fragment
+const MISSING_LIBS_ERROR: &[u8] = b"not found in the project".as_slice();
+
 /// Mapping of bytecode hash (without "0x" prefix) to the respective contract name.
 pub type ContractBytecodes = BTreeMap<String, String>;
 
@@ -73,7 +78,7 @@ pub struct ZkSolcArtifactPaths {
 impl ZkSolcArtifactPaths {
     pub fn new(filename: PathBuf) -> Self {
         Self {
-            artifact: filename.clone().join("artifacts.json"),
+            artifact: filename.join("artifacts.json"),
             contract_hash: filename.join("contract_hash"),
         }
     }
@@ -284,12 +289,19 @@ impl ZkSolc {
     /// versioned sources. These modified values can be accessed after the compilation process
     /// for further processing or analysis.
     pub fn compile(&mut self) -> Result<(ProjectCompileOutput, ContractBytecodes)> {
-        //TODO: understand how to set are_libaries_missing flag or if it should be set always
-        self.config.settings.are_libraries_missing = true;
         let mut displayed_warnings = HashSet::new();
         let mut data = BTreeMap::new();
         // Step 1: Collect Source Files
-        let sources = self.get_versioned_sources().wrap_err("Cannot get source files")?;
+        let mut sources = self.get_versioned_sources().wrap_err("Cannot get source files")?;
+        sources.retain(|_, (_, sources)| {
+            sources.retain(|path, _| {
+                let relative_path = path.strip_prefix(self.project.root()).unwrap_or(path.as_ref());
+                // prune ignored contracts
+                !self.is_contract_ignored_in_config(relative_path)
+            });
+            // and prune any group that is now empty
+            !sources.is_empty()
+        });
         let mut contract_bytecodes = BTreeMap::new();
 
         // Step 2: Check missing libraries
@@ -298,33 +310,25 @@ impl ZkSolc {
 
         // Step 3: Proceed with contract compilation
         for (solc, version) in sources {
-            info!("\nCompiling {} files...", version.1.len());
+            info!(solc = ?solc.solc, "\nCompiling {} files...", version.1.len());
             // Configure project solc for each solc version
             for (contract_path, _) in version.1 {
-                // Check if contract has been ignored by user
-                let relative_path = contract_path.strip_prefix(self.project.root())?;
-
-                if self.is_contract_ignored_in_config(relative_path) {
-                    continue
-                }
-
                 let filename = contract_path
                     .file_name()
                     .wrap_err(format!("Could not get filename from {:?}", contract_path))?
                     .to_str()
-                    .unwrap()
-                    .to_string();
+                    .expect("Invalid Contract filename");
 
                 // Run Compiler (or use cached) and Handle Output
                 let artifact_paths =
-                    ZkSolcArtifactPaths::new(self.project.paths.artifacts.join(&filename));
+                    ZkSolcArtifactPaths::new(self.project.paths.artifacts.join(filename));
 
                 info!("Compiling {:?}...", contract_path);
                 let (output, contract_hash) = self.check_contract_is_cached(&contract_path)?;
                 let (output, maybe_artifact_paths) = match output {
                     Some(output) => {
                         info!("Using hashed artifact for {:?}", filename);
-                        (output.to_owned(), None)
+                        (output, None)
                     }
                     None => {
                         self.prepare_compiler_input(&contract_path).wrap_err(format!(
@@ -332,45 +336,35 @@ impl ZkSolc {
                             contract_path
                         ))?;
 
-                        // do a first run to detect if there are missing libraries
-                        if self.config.settings.are_libraries_missing {
-                            let Some(output) = self.run_compiler(&contract_path, true, &solc)?
-                            else {
-                                continue
-                            };
-
-                            let missing_libraries =
-                                Self::get_missing_libraries_from_output(&output.stdout)?;
-                            tracing::trace!(path = ?contract_path, ?missing_libraries);
-                            let has_missing_libraries = !missing_libraries.is_empty();
-
-                            // collect missing libraries
-                            for missing_library in missing_libraries {
-                                all_missing_libraries
-                                    .entry((
-                                        missing_library.contract_path.clone(),
-                                        missing_library.contract_name.clone(),
-                                    ))
-                                    .and_modify(|missing_dependencies| {
-                                        missing_dependencies
-                                            .extend(missing_library.missing_libraries.clone())
-                                    })
-                                    .or_insert_with(|| {
-                                        HashSet::from_iter(
-                                            missing_library.missing_libraries.clone(),
-                                        )
-                                    });
-                            }
-
-                            if has_missing_libraries {
-                                //skip current contract output from processing
-                                continue;
-                            }
-                        }
-
-                        let Some(output) = self.run_compiler(&contract_path, false, &solc)? else {
+                        let Some(output) = self.run_compiler(&contract_path, &solc)? else {
                             continue
                         };
+
+                        let missing_libraries =
+                            Self::get_missing_libraries_from_output(&output.stdout)?;
+                        tracing::trace!(path = ?contract_path, ?missing_libraries);
+                        let has_missing_libraries = !missing_libraries.is_empty();
+
+                        // collect missing libraries
+                        for missing_library in missing_libraries {
+                            all_missing_libraries
+                                .entry((
+                                    missing_library.contract_path.clone(),
+                                    missing_library.contract_name.clone(),
+                                ))
+                                .and_modify(|missing_dependencies| {
+                                    missing_dependencies
+                                        .extend(missing_library.missing_libraries.clone())
+                                })
+                                .or_insert_with(|| {
+                                    HashSet::from_iter(missing_library.missing_libraries.clone())
+                                });
+                        }
+
+                        if has_missing_libraries {
+                            //skip current contract output from processing
+                            continue;
+                        }
 
                         (output.stdout, Some(artifact_paths))
                     }
@@ -379,12 +373,12 @@ impl ZkSolc {
                 // Step 6: Handle Output (Errors and Warnings)
                 let (artifacts, bytecodes) = ZkSolc::handle_output(
                     output,
-                    &filename,
+                    filename,
                     &mut displayed_warnings,
                     &contract_hash,
                     maybe_artifact_paths,
                 );
-                data.insert(filename.clone(), artifacts);
+                data.insert(filename.to_string(), artifacts);
                 contract_bytecodes.extend(bytecodes);
             }
         }
@@ -392,14 +386,14 @@ impl ZkSolc {
         // Step 4: If missing library dependencies, save them to a file and return an error
         if !all_missing_libraries.is_empty() {
             let dependencies: Vec<ZkMissingLibrary> = all_missing_libraries
-                .iter()
+                .into_iter()
                 .map(|((contract_path, contract_name), missing_libraries)| ZkMissingLibrary {
-                    contract_path: contract_path.clone(),
-                    contract_name: contract_name.clone(),
-                    missing_libraries: missing_libraries.iter().cloned().collect(),
+                    contract_path,
+                    contract_name,
+                    missing_libraries: missing_libraries.into_iter().collect(),
                 })
                 .collect();
-            ZkLibrariesManager::add_dependencies_to_missing_libraries_cache(
+            libraries::add_dependencies_to_missing_libraries_cache(
                 &self.project.paths.root,
                 dependencies.as_slice(),
             )?;
@@ -457,31 +451,36 @@ impl ZkSolc {
     /// # Returns
     ///
     /// A vector of strings representing the compiler arguments.
-    fn build_compiler_args(
-        &self,
-        contract_path: &Path,
-        solc: &Solc,
+    fn build_compiler_args<'s>(
+        &'s self,
+        contract_path: &'s Path,
+        solc: &'s Solc,
         detect_missing_libraries: bool,
-    ) -> Vec<String> {
+    ) -> Vec<&'s str> {
         // Get the solc compiler path as a string
-        let solc_path = solc.solc.to_str().expect("Error configuring solc compiler.").to_string();
+        let solc_path = solc.solc.to_str().expect("Given solc compiler path wasn't valid.");
 
         // Build compiler arguments
-        let mut comp_args = vec!["--standard-json".to_string(), "--solc".to_string(), solc_path];
+        let mut comp_args = vec!["--standard-json", "--solc", solc_path];
 
         // Check if system mode is enabled or if the source path contains "is-system"
-        if self.config.settings.is_system || contract_path.to_str().unwrap().contains("is-system") {
-            comp_args.push("--system-mode".to_string());
+        if self.config.settings.is_system ||
+            contract_path
+                .to_str()
+                .expect("Given contract path wasn't valid.")
+                .contains("is-system")
+        {
+            comp_args.push("--system-mode");
         }
 
         // Check if force-evmla is enabled
         if self.config.settings.force_evmla {
-            comp_args.push("--force-evmla".to_string());
+            comp_args.push("--force-evmla");
         }
 
         // Check if should detect missing libraries
         if detect_missing_libraries {
-            comp_args.push("--detect-missing-libraries".to_string());
+            comp_args.push("--detect-missing-libraries");
         }
 
         comp_args
@@ -866,14 +865,15 @@ impl ZkSolc {
 
         // Patch the libraries to be relative to the project root
         // NOTE: This is a temporary fix until zksolc supports relative paths
-        let mut patched_libraries: BTreeMap<PathBuf, BTreeMap<String, String>> = BTreeMap::new();
-        for (path, details) in std_zk_json.settings.libraries.libs.iter() {
-            patched_libraries.insert(
-                path.strip_prefix(&self.project.paths.root).unwrap().into(),
-                details.clone(),
-            );
+        for (mut path, details) in
+            std::mem::take(&mut std_zk_json.settings.libraries.libs).into_iter()
+        {
+            if let Ok(patched) = path.strip_prefix(&self.project.paths.root) {
+                path = patched.to_owned();
+            }
+
+            std_zk_json.settings.libraries.libs.insert(path, details);
         }
-        std_zk_json.settings.libraries.libs = patched_libraries;
 
         // Store the generated standard JSON input in the ZkSolc instance
         self.standard_json = Some(std_zk_json.to_owned());
@@ -883,11 +883,13 @@ impl ZkSolc {
 
         // Step 6: Save JSON Input
         let json_input_path = artifact_path.join("json_input.json");
-        let stdjson =
-            serde_json::to_value(&std_zk_json).wrap_err("Could not serialize JSON input")?;
 
-        std::fs::write(json_input_path, serde_json::to_string_pretty(&stdjson)?)
-            .wrap_err("Could not write JSON input file")?;
+        std::fs::write(
+            json_input_path,
+            serde_json::to_string_pretty(&std_zk_json)
+                .wrap_err("Could not serialize JSON input")?,
+        )
+        .wrap_err("Could not write JSON input file")?;
 
         Ok(())
     }
@@ -1047,8 +1049,11 @@ impl ZkSolc {
 
     /// Checks if the contract has been ignored by the user in the configuration file.
     fn is_contract_ignored_in_config(&self, relative_path: &Path) -> bool {
-        let filename =
-            relative_path.file_name().expect("Failed to get Contract filename.").to_str().unwrap();
+        let filename = relative_path
+            .file_name()
+            .expect("Failed to get Contract filename.")
+            .to_str()
+            .expect("Invalid Contract filename.");
         let mut should_compile = match self.config.contracts_to_compile {
             Some(ref contracts_to_compile) => {
                 //compare if there is some member of the vector contracts_to_compile
@@ -1076,7 +1081,8 @@ impl ZkSolc {
         contract_path: impl AsRef<Path>,
     ) -> Result<(Option<Vec<u8>>, String)> {
         let contract_path = contract_path.as_ref();
-        let contract_hash = Self::hash_contract(contract_path)?;
+        let contract_hash =
+            Self::hash_contract(contract_path).wrap_err("Trying to hash contract contents")?;
         let artifact_paths = ZkSolcArtifactPaths::new(
             self.project.paths.artifacts.join(
                 contract_path
@@ -1141,27 +1147,32 @@ impl ZkSolc {
     fn run_compiler(
         &self,
         contract_path: &Path,
-        detect_missing_libraries: bool,
         solc: &Solc,
     ) -> Result<Option<std::process::Output>> {
-        let comp_args = self.build_compiler_args(contract_path, solc, detect_missing_libraries);
+        let get_compiler = |args| {
+            let mut command = Command::new(&self.config.compiler_path);
+            command.args(&args).stdin(Stdio::piped()).stderr(Stdio::piped()).stdout(Stdio::piped());
+            command
+        };
 
-        let mut command = Command::new(&self.config.compiler_path);
-        command
-            .args(&comp_args)
-            .stdin(Stdio::piped())
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped());
-
+        let mut command = get_compiler(self.build_compiler_args(contract_path, solc, false));
         trace!(compiler_path = ?command.get_program(), args = ?command.get_args(), "Running compiler");
 
-        let mut child = command.spawn().wrap_err("Failed to start the compiler")?;
-        let stdin = child.stdin.take().expect("Stdin exists.");
-        let stdjson = serde_json::to_value(&self.standard_json.clone().unwrap())
-            .wrap_err("Could not serialize JSON input")?;
-        serde_json::to_writer(stdin, &stdjson)
-            .wrap_err("Could not assign standard_json to writer")?;
-        let output = child.wait_with_output().wrap_err("Could not run compiler cmd")?;
+        let exec_compiler = |command: &mut Command| -> Result<std::process::Output> {
+            let mut child = command.spawn().wrap_err("Failed to start the compiler")?;
+            let stdin = child.stdin.take().expect("Stdin exists.");
+            serde_json::to_writer(stdin, self.standard_json.as_ref().unwrap())
+                .wrap_err("Could not assign standard_json to writer")?;
+            child.wait_with_output().wrap_err("Could not run compiler cmd")
+        };
+        let mut output = exec_compiler(&mut command)?;
+
+        // retry but detect missing libraries this time
+        if !output.status.success() && Self::maybe_missing_libraries(&output.stderr) {
+            command = get_compiler(self.build_compiler_args(contract_path, solc, true));
+            trace!("Running compiler with missing libraries detection");
+            output = exec_compiler(&mut command)?;
+        }
 
         // Skip this file if the compiler output is empty
         // currently zksolc returns false for success if output is empty
@@ -1183,6 +1194,10 @@ impl ZkSolc {
         }
 
         Ok(Some(output))
+    }
+
+    fn maybe_missing_libraries(stderr: &[u8]) -> bool {
+        stderr.windows(MISSING_LIBS_ERROR.len()).any(|window| window == MISSING_LIBS_ERROR)
     }
 }
 

--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -341,6 +341,11 @@ impl ZkSolc {
                 format!("Compiling {total} files..."),
                 None,
             );
+            let ci = std::env::var_os("CI").map(|ci| ci == "true").unwrap_or_default();
+
+            if ci {
+                sp.stop_with_message("Spinner hidden in CI");
+            }
 
             let input = self
                 .prepare_compiler_input(sources)
@@ -364,7 +369,9 @@ impl ZkSolc {
                 &mut contract_bytecodes,
             );
 
-            sp.success(&format!("Compiled {total} files!"));
+            if !ci {
+                sp.success(&format!("Compiled {total} files!"));
+            }
         }
 
         // Step 4: If missing library dependencies, save them to a file and return an error

--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -1124,7 +1124,7 @@ impl ZkSolc {
             let cached =
                 Self::check_contract_is_cached(artifacts_paths, path).ok().and_then(|r| r.0);
 
-            // prune ignored or cached contractacs
+            // prune ignored or cached contracts
             match (is_ignored, cached) {
                 (false, None) => true,
                 (true, _) => false,

--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -621,7 +621,7 @@ impl ZkSolc {
 
                 let artifact = ArtifactFile {
                     artifact: art,
-                    file: filename.into(),
+                    file: format!("{name}.sol").into(),
                     version: Version::parse(&compiler_output.version).unwrap(),
                 };
                 // each contract is only supposed to have 1 artifact

--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -1204,11 +1204,7 @@ impl ZkSolc {
             .iter()
             .flat_map(|(path, ccs)| ccs.iter().map(move |c| (path, c)))
             .filter(|(_, (_, contract))| {
-                !contract
-                    .missing_libraries
-                    .as_ref()
-                    .map(|libs| !libs.is_empty())
-                    .unwrap_or_default()
+                contract.missing_libraries.as_ref().map(|libs| !libs.is_empty()).unwrap_or_default()
             })
             .map(|(p, (_, c))| (p, c))
             .peekable();

--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -1077,16 +1077,11 @@ impl ZkSolc {
 
     /// Checks if the contract has been ignored by the user in the configuration file.
     fn is_contract_ignored_in_config(&self, relative_path: &Path) -> bool {
-        let filename = relative_path
-            .file_name()
-            .expect("Failed to get Contract filename.")
-            .to_str()
-            .expect("Invalid Contract filename.");
         let mut should_compile = match self.config.contracts_to_compile {
             Some(ref contracts_to_compile) => {
                 //compare if there is some member of the vector contracts_to_compile
                 // present in the filename
-                contracts_to_compile.iter().any(|c| c.is_match(filename))
+                contracts_to_compile.iter().any(|c| c.is_match(relative_path))
             }
             None => true,
         };
@@ -1095,7 +1090,7 @@ impl ZkSolc {
             Some(ref avoid_contracts) => {
                 //compare if there is some member of the vector avoid_contracts
                 // present in the filename
-                !avoid_contracts.iter().any(|c| c.is_match(filename))
+                !avoid_contracts.iter().any(|c| c.is_match(relative_path))
             }
             None => should_compile,
         };

--- a/crates/zksync/compiler/src/zksolc/factory_deps.rs
+++ b/crates/zksync/compiler/src/zksolc/factory_deps.rs
@@ -16,14 +16,13 @@ use zksync_utils::bytecode::hash_bytecode;
 pub struct PackedEraBytecode<'s> {
     hash: &'s str,
     bytecode: &'s str,
-    #[serde(borrow)]
-    factory_deps: Vec<&'s str>,
+    factory_deps: Vec<H256>,
 }
 
 impl<'s> PackedEraBytecode<'s> {
     /// Create a new instance of the `PackedEraBytecode`.
-    pub fn new(hash: &'s str, bytecode: &'s str, factory_deps: &[&'s str]) -> Self {
-        Self { hash, bytecode, factory_deps: factory_deps.to_vec() }
+    pub fn new(hash: &'s str, bytecode: &'s str, factory_deps: Vec<H256>) -> Self {
+        Self { hash, bytecode, factory_deps }
     }
 
     /// Convert the `PackedEraBytecode` into a `Vec<u8>`.
@@ -49,12 +48,8 @@ impl<'s> PackedEraBytecode<'s> {
     }
 
     /// Get the factory deps.
-    pub fn factory_deps(&self) -> Vec<Vec<u8>> {
-        self.factory_deps
-            .iter()
-            .chain([&self.bytecode])
-            .map(|entry| hex::decode(entry).unwrap())
-            .collect()
+    pub fn factory_deps(&self) -> &[H256] {
+        &self.factory_deps
     }
 }
 

--- a/crates/zksync/compiler/src/zksolc/factory_deps.rs
+++ b/crates/zksync/compiler/src/zksolc/factory_deps.rs
@@ -13,16 +13,17 @@ use zksync_utils::bytecode::hash_bytecode;
 
 /// Struct with the contract bytecode, and all the other factory deps.
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
-pub struct PackedEraBytecode {
-    hash: String,
-    bytecode: String,
-    factory_deps: Vec<String>,
+pub struct PackedEraBytecode<'s> {
+    hash: &'s str,
+    bytecode: &'s str,
+    #[serde(borrow)]
+    factory_deps: Vec<&'s str>,
 }
 
-impl PackedEraBytecode {
+impl<'s> PackedEraBytecode<'s> {
     /// Create a new instance of the `PackedEraBytecode`.
-    pub fn new(hash: String, bytecode: String, factory_deps: Vec<String>) -> Self {
-        Self { hash, bytecode, factory_deps }
+    pub fn new(hash: &'s str, bytecode: &'s str, factory_deps: &[&'s str]) -> Self {
+        Self { hash, bytecode, factory_deps: factory_deps.to_vec() }
     }
 
     /// Convert the `PackedEraBytecode` into a `Vec<u8>`.
@@ -31,19 +32,19 @@ impl PackedEraBytecode {
     }
 
     /// Convert a `Vec<u8>` into a `PackedEraBytecode`.
-    pub fn from_vec(input: &[u8]) -> Self {
+    pub fn from_vec(input: &'s [u8]) -> Self {
         serde_json::from_slice(input).unwrap()
     }
 
     /// Convert the `PackedEraBytecode` into a `Vec<u8>`.
     pub fn bytecode(&self) -> Vec<u8> {
-        hex::decode(self.bytecode.clone()).unwrap()
+        hex::decode(self.bytecode).unwrap()
     }
 
     /// Get the bytecode hash.
     pub fn bytecode_hash(&self) -> H256 {
         let h = hash_bytecode(&self.bytecode());
-        assert_eq!(h, H256::from_str(&self.hash).unwrap());
+        assert_eq!(h, H256::from_str(self.hash).unwrap());
         h
     }
 

--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -35,7 +35,12 @@ interface IMyProxyCaller {
 }
 
 contract MyProxyCaller {
-    function transact(address inner) public {
+    address inner;
+    constructor(address _inner) {
+        inner = _inner;
+    }
+
+    function transact() public {
         IMyProxyCaller(inner).transact(10);
     }
 }
@@ -157,6 +162,7 @@ contract ZkCheatcodesTest is Test {
 
     function testZkCheatcodesCanMockCallTestContract() public {
         address thisAddress = address(this);
+        MyProxyCaller transactor = new MyProxyCaller(thisAddress);
 
         vm.mockCall(
             thisAddress,
@@ -164,8 +170,7 @@ contract ZkCheatcodesTest is Test {
             abi.encode()
         );
 
-        MyProxyCaller transactor = new MyProxyCaller();
-        transactor.transact(thisAddress);
+        transactor.transact();
     }
 
     function testZkCheatcodesCanMockCall(address mockMe) public {
@@ -174,13 +179,14 @@ contract ZkCheatcodesTest is Test {
         //zkVM currently doesn't support mocking the transaction sender
         vm.assume(mockMe != tx.origin);
 
+        MyProxyCaller transactor = new MyProxyCaller(mockMe);
+
         vm.mockCall(
             mockMe,
             abi.encodeWithSelector(IMyProxyCaller.transact.selector),
             abi.encode()
         );
 
-        MyProxyCaller transactor = new MyProxyCaller();
-        transactor.transact(mockMe);
+        transactor.transact();
     }
 }

--- a/zk-tests/src/MissingLibraries.sol
+++ b/zk-tests/src/MissingLibraries.sol
@@ -2,9 +2,14 @@
 pragma solidity ^0.8.13;
 
 import {Maths} from "./Maths.sol";
+import 'forge-std/Test.sol';
 
 contract Mathematician {
     uint256 public number;
+
+    constructor(uint256 _number) {
+        number = _number;
+    }
 
     function square() public view returns (uint256) {
         return Maths.square(number);
@@ -13,7 +18,8 @@ contract Mathematician {
 
 contract MathematicianTest is Test {
     function testLibraries() external {
-        Mathematician maths = new Mathematician();
-        assertEq(maths.square(2), 4);
+        Mathematician maths = new Mathematician(2);
+
+        assertEq(maths.square(), 4);
     }
 }

--- a/zk-tests/src/MissingLibraries.sol
+++ b/zk-tests/src/MissingLibraries.sol
@@ -10,3 +10,10 @@ contract Mathematician {
         return Maths.square(number);
     }
 }
+
+contract MathematicianTest is Test {
+    function testLibraries() external {
+        Mathematician maths = new Mathematician();
+        assertEq(maths.square(2), 4);
+    }
+}

--- a/zk-tests/src/MissingLibraries.sol
+++ b/zk-tests/src/MissingLibraries.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Maths} from "./Maths.sol";
-import 'forge-std/Test.sol';
+import 'forge-std/Script.sol';
 
 contract Mathematician {
     uint256 public number;
@@ -16,10 +16,10 @@ contract Mathematician {
     }
 }
 
-contract MathematicianTest is Test {
-    function testLibraries() external {
+contract MathematicianScript is Script {
+    function run() external {
         Mathematician maths = new Mathematician(2);
 
-        assertEq(maths.square(), 4);
+        assert(maths.square() == 4);
     }
 }

--- a/zk-tests/src/NestedMaths.sol
+++ b/zk-tests/src/NestedMaths.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Maths} from './Maths.sol';
+
+library NestedMaths {
+    function square(uint256 x) public pure returns (uint256) {
+        return Maths.square(x);
+    }
+}

--- a/zk-tests/src/NestedMissingLibraries.sol
+++ b/zk-tests/src/NestedMissingLibraries.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {NestedMaths} from "./NestedMaths.sol";
-import 'forge-std/Test.sol';
+import 'forge-std/Script.sol';
 
 contract NestedMathematician {
     uint256 public number;
@@ -16,10 +16,10 @@ contract NestedMathematician {
     }
 }
 
-contract NestedMathematicianTest is Test {
-    function testNestedLibraries() external {
+contract NestedMathematicianScript is Script {
+    function run() external {
         NestedMathematician maths = new NestedMathematician(2);
 
-        assertEq(maths.square(), 4);
+        assert(maths.square() == 4);
     }
 }

--- a/zk-tests/src/NestedMissingLibraries.sol
+++ b/zk-tests/src/NestedMissingLibraries.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {NestedMaths} from "./NestedMaths.sol";
+import 'forge-std/Test.sol';
+
+contract NestedMathematician {
+    uint256 public number;
+
+    function square() public view returns (uint256) {
+        return NestedMaths.square(number);
+    }
+}
+
+contract NestedMathematicianTest is Test {
+    function testNestedLibraries() external {
+        NestedMathematician maths = new NestedMathematician();
+        assertEq(maths.square(2), 4);
+    }
+}

--- a/zk-tests/src/NestedMissingLibraries.sol
+++ b/zk-tests/src/NestedMissingLibraries.sol
@@ -7,6 +7,10 @@ import 'forge-std/Test.sol';
 contract NestedMathematician {
     uint256 public number;
 
+    constructor(uint256 _number) {
+        number = _number;
+    }
+
     function square() public view returns (uint256) {
         return NestedMaths.square(number);
     }
@@ -14,7 +18,8 @@ contract NestedMathematician {
 
 contract NestedMathematicianTest is Test {
     function testNestedLibraries() external {
-        NestedMathematician maths = new NestedMathematician();
-        assertEq(maths.square(2), 4);
+        NestedMathematician maths = new NestedMathematician(2);
+
+        assertEq(maths.square(), 4);
     }
 }

--- a/zk-tests/test.sh
+++ b/zk-tests/test.sh
@@ -132,6 +132,8 @@ output=$(RUST_LOG=warn "${FORGE}" build --zksync 2>&1 || true)
 
 if echo "$output" | grep -q "Missing libraries detected"; then
     RUST_LOG=warn "${FORGE}" create --deploy-missing-libraries --rpc-url $RPC_URL --private-key $PRIVATE_KEY --zksync
+    RUST_LOG=warn "${FORGE}" script ./src/MissingLibraries.sol:MathematicianScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --zksync --chain 260 --use "./${SOLC}" -vvv || fail "forge script with libs failed"
+    RUST_LOG=warn "${FORGE}" script ./src/NestedMissingLibraries.sol:NestedMathematicianScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --zksync --chain 260 --use "./${SOLC}" -vvv || fail "forge script with nested libs failed"
 else
     echo "No missing libraries detected."
 fi


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently compiling projects can be quite slow, especially for bigger and more complicated projects.
The PR aims to improve the compilation speed for zk contracts substantially.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
The main change proposed in the PR regards the way we invoke the compiler - where as before we'd invoke the compiler separately for each contract (with its own set of dependencies), we now call the compiler a limited number of times (typically 1) with all the files in the project and the dependencies, drastically reducing compile time and avoiding recompilation of shared dependencies.

Other improvements aim at decreasing memory usage and improving the speed of processing the compiler's output and preparing its input.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
This PR is still work in progress as the compilation process has been overhauled greatly - there might still be a few bugs and regressions introduced, but before merging these will be resolved