### PR TITLE
fix: use project's solc when specified

### DIFF
--- a/crates/zksync/compiler/src/zksolc/compile.rs
+++ b/crates/zksync/compiler/src/zksolc/compile.rs
@@ -995,13 +995,23 @@ impl ZkSolc {
         let graph = Graph::resolve_sources(&self.project.paths, sources)
             .wrap_err("Could not resolve sources")?;
 
-        // Step 3: Extract Versions and Edges
-        let (versions, _edges) = graph
-            .into_sources_by_version(self.project.offline)
-            .wrap_err("Could not match solc versions to files")?;
+        if self.project.auto_detect {
+            // Step 3: Extract Versions and Edges
+            let (versions, _edges) = graph
+                .into_sources_by_version(self.project.offline)
+                .wrap_err("Could not match solc versions to files")?;
 
-        // Step 4: Retrieve Solc Version
-        versions.get(&self.project).wrap_err("Could not get solc")
+            // Step 4: Retrieve Solc Version
+            versions.get(&self.project).wrap_err("Could not get solc")
+        } else {
+            // Step 3: Extract sources
+            let (sources, _) = graph.into_sources();
+
+            // Step 4: Retrieve Solc Version
+            let version = self.project.solc.version()?;
+
+            Ok(BTreeMap::from([(self.project.solc.clone(), (version, sources))]))
+        }
     }
 
     /// Builds the path for saving the artifacts (compiler output) of a contract based on the


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
[Previously](https://github.com/matter-labs/foundry-zksync/pull/304) we had changed the used `solc` compiler to reflect the one detected by foundry for version resolution, but lost the ability to use a manually specified version of `solc`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
When appropriate (if `auto_detect` is not set), the manually specified version is used for all project sources
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
Braches still to port feature to:
- [x] `elfedy-foundry-compilers` (included)
- [ ]  `refactor/compiler-perf`