### PR TITLE
fix: use journaled state to read storage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,6 @@ jobs:
               with:
                   name: ${{ needs.prepare.outputs.release_name }}
                   tag_name: ${{ needs.prepare.outputs.tag_name }}
-                  draft: true
                   prerelease: true
                   body: ${{ needs.prepare.outputs.changelog }}
                   files: |

--- a/crates/zksync/core/src/cheatcodes.rs
+++ b/crates/zksync/core/src/cheatcodes.rs
@@ -222,11 +222,11 @@ pub fn set_mocked_account<'a, DB>(
         .expect("failed storing value");
 
     let hash_key = empty_code_hash.to_ru256();
-    let has_key = journaled_state
+    let has_hash = journaled_state
         .sload(known_code_addr, hash_key, db)
         .map(|(v, _)| !v.is_zero())
         .unwrap_or_default();
-    if !has_key {
+    if !has_hash {
         journaled_state.touch(&known_code_addr);
         journaled_state
             .sstore(known_code_addr, hash_key, rU256::from(1u32), db)

--- a/crates/zksync/core/src/cheatcodes.rs
+++ b/crates/zksync/core/src/cheatcodes.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use alloy_primitives::{Bytes, B256};
 use revm::{
-    primitives::{Address, Bytecode, Env, StorageSlot, U256 as rU256},
+    primitives::{Address, Bytecode, Env, U256 as rU256},
     Database, JournaledState,
 };
 use tracing::info;
@@ -195,36 +195,41 @@ pub fn set_mocked_account<'a, DB>(
     let account_code_addr = zksync_types::ACCOUNT_CODE_STORAGE_ADDRESS.to_address();
     let known_code_addr = zksync_types::KNOWN_CODES_STORAGE_ADDRESS.to_address();
     {
-        let (account_code_acc, _) = journaled_state
+        journaled_state
             .load_account(account_code_addr, db)
-            .expect("account could not be loaded");
-
-        let key = address.to_h256().to_ru256();
-
-        // Apply only if the address doesn't have any associated bytecode entry
-        let has_code = account_code_acc
-            .storage
-            .get(&key)
-            .map(|v| !v.present_value.is_zero())
-            .unwrap_or_default();
-        if has_code {
-            return;
-        }
-
-        let hash = zksync_utils::bytecode::hash_bytecode(&EMPTY_CODE);
-        let value: StorageSlot = StorageSlot::new(hash.to_ru256());
-
-        if !account_code_acc.storage.contains_key(&key) {
-            account_code_acc.storage.insert(key, value);
-        }
+            .expect("account 'ACCOUNT_CODE_STORAGE_ADDRESS' could not be loaded");
+        journaled_state
+            .load_account(known_code_addr, db)
+            .expect("account 'KNOWN_CODES_STORAGE_ADDRESS' could not be loaded");
     }
-    {
-        let (known_codes_acc, _) =
-            journaled_state.load_account(known_code_addr, db).expect("account could not be loaded");
-        let hash = zksync_utils::bytecode::hash_bytecode(&EMPTY_CODE);
-        let key = hash.to_ru256();
-        if !known_codes_acc.storage.contains_key(&key) {
-            known_codes_acc.storage.insert(key, StorageSlot::new(rU256::from(1u32)));
-        }
+
+    let empty_code_hash = zksync_utils::bytecode::hash_bytecode(&EMPTY_CODE);
+
+    // update account code storage for empty code
+    let account_key = address.to_h256().to_ru256();
+    let has_code = journaled_state
+        .sload(account_code_addr, account_key, db)
+        .map(|(v, _)| !v.is_zero())
+        .unwrap_or_default();
+    if has_code {
+        return;
+    }
+
+    // update known code storage for empty code
+    journaled_state.touch(&account_code_addr);
+    journaled_state
+        .sstore(account_code_addr, account_key, empty_code_hash.to_ru256(), db)
+        .expect("failed storing value");
+
+    let hash_key = empty_code_hash.to_ru256();
+    let has_key = journaled_state
+        .sload(known_code_addr, hash_key, db)
+        .map(|(v, _)| !v.is_zero())
+        .unwrap_or_default();
+    if !has_key {
+        journaled_state.touch(&known_code_addr);
+        journaled_state
+            .sstore(known_code_addr, hash_key, rU256::from(1u32), db)
+            .expect("failed storing value");
     }
 }

--- a/crates/zksync/core/src/vm/db.rs
+++ b/crates/zksync/core/src/vm/db.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, fmt::Debug};
 
 use alloy_primitives::{Address, U256 as rU256};
 use foundry_cheatcodes_common::record::RecordAccess;
-use revm::{Database, JournaledState};
+use revm::{primitives::Account, Database, JournaledState};
 use zksync_basic_types::{L2ChainId, H160, H256, U256};
 use zksync_state::ReadStorage;
 use zksync_types::{
@@ -170,8 +170,18 @@ where
         h256_to_u256(balance_storage)
     }
 
+    /// Load an account into the journaled state.
+    pub fn load_account(&mut self, address: Address) -> &mut Account {
+        let (account, _) = self
+            .journaled_state
+            .load_account(address, self.db)
+            .expect("account could not be loaded");
+        account
+    }
+
+    /// Load an storage slot into the journaled state.
+    /// The account must be already loaded else this function panics.
     pub fn sload(&mut self, address: Address, key: rU256) -> rU256 {
-        self.journaled_state.load_account(address, self.db).expect("account could not be loaded");
         let (value, _) = self.journaled_state.sload(address, key, self.db).unwrap_or_default();
         value
     }

--- a/crates/zksync/core/src/vm/db.rs
+++ b/crates/zksync/core/src/vm/db.rs
@@ -6,9 +6,9 @@
 /// is usually collecing all the diffs - and applies them to database itself.
 use std::{collections::HashMap, fmt::Debug};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, U256 as rU256};
 use foundry_cheatcodes_common::record::RecordAccess;
-use revm::{primitives::Account, Database, JournaledState};
+use revm::{Database, JournaledState};
 use zksync_basic_types::{L2ChainId, H160, H256, U256};
 use zksync_state::ReadStorage;
 use zksync_types::{
@@ -170,12 +170,10 @@ where
         h256_to_u256(balance_storage)
     }
 
-    pub fn load_account(&mut self, address: Address) -> &mut Account {
-        let (account, _) = self
-            .journaled_state
-            .load_account(address, self.db)
-            .expect("account could not be loaded");
-        account
+    pub fn sload(&mut self, address: Address, key: rU256) -> rU256 {
+        self.journaled_state.load_account(address, self.db).expect("account could not be loaded");
+        let (value, _) = self.journaled_state.sload(address, key, self.db).unwrap_or_default();
+        value
     }
 
     fn read_db(&mut self, address: H160, idx: U256) -> H256 {

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -404,8 +404,7 @@ where
     for (k, v) in &modified_storage {
         let address = k.address().to_address();
         let index = k.key().to_ru256();
-        let account = era_db.load_account(address);
-        let previous = account.storage.get(&index).map(|v| v.present_value).unwrap_or_default();
+        let previous = era_db.sload(address, index);
         let entry = storage.entry(address).or_default();
         entry.insert(index, StorageSlot::new_changed(previous, v.to_ru256()));
 

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -404,6 +404,7 @@ where
     for (k, v) in &modified_storage {
         let address = k.address().to_address();
         let index = k.key().to_ru256();
+        era_db.load_account(address);
         let previous = era_db.sload(address, index);
         let entry = storage.entry(address).or_default();
         entry.insert(index, StorageSlot::new_changed(previous, v.to_ru256()));

--- a/zk-tests/src/Contracts.t.sol
+++ b/zk-tests/src/Contracts.t.sol
@@ -32,6 +32,16 @@ contract FixedGreeter {
     }
 }
 
+contract MultiNumber {
+    function one() public pure returns (uint8) {
+        return 1;
+    }
+
+    function two() public pure returns (uint8) {
+        return 2;
+    }
+}
+
 contract PayableFixedNumber {
     address sender;
     uint256 value;
@@ -80,6 +90,7 @@ contract CustomStorage {
 contract ZkContractsTest is Test {
     Number number;
     CustomNumber customNumber;
+    MultiNumber multiNumber;
 
     uint256 constant ERA_FORK_BLOCK = 19579636;
     uint256 constant ERA_FORK_BLOCK_TS = 1700601590;
@@ -93,6 +104,7 @@ contract ZkContractsTest is Test {
     function setUp() public {
         number = new Number();
         customNumber = new CustomNumber(20);
+        multiNumber = new MultiNumber();
         vm.makePersistent(address(number));
         vm.makePersistent(address(customNumber));
 
@@ -258,5 +270,16 @@ contract ZkContractsTest is Test {
         );
 
         assertEq(address(0x46efB6258A2A539f7C8b44e2EF659D778fb5BAAd), addr);
+    }
+
+    function testZkContractsDeployedInSetupAreMockable() public {
+        vm.mockCall(
+            address(multiNumber),
+            abi.encodeWithSelector(MultiNumber.one.selector),
+            abi.encode(42)
+        );
+
+        assertEq(42, multiNumber.one());
+        assertEq(2, multiNumber.two());
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The storage was being read from journaled accounts directly. `load_account` does not populate the storage and thus storage needs to be read via `sload`. This would cause issues in mocking contracts deployed during setup (as the journaled state would be empty, triggering this behavior).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Correctly read from journaled state, instead of reading from partially loaded account.

## Notes
Storage writes can still be performed on loaded accounts.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
