### PR TITLE
fix: resolve hashes always enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To use for zkSync environments, include `--zksync` when running `forge` or `vm.z
    - zkSync VM processes the transaction and returns state changes, which are applied to `journaled_state`. Results are relayed back.
 5. **Logging:**
    - `console.log()` outputs within zkSync VM are captured and displayed in Foundry.
+   - `ZK_DEBUG_RESOLVE_HASHES` and `ZK_DEBUG_SHOW_OUTPUTS` env variable may be set to `true` to display zkSync VM call logs with resolved selector hashes (requires Internet connection), and the call outputs, respectively.
 6. **Fuzzing**
    - Adds config option `no_zksync_reserved_addresses`. Since zkSync reserves addresses below 2^16 as system addresses, a fuzz test would've required a broad `vm.assume` and many `vm.excludeSender` calls to exclude these. This is not only cumbersome but could also trigger `proptest`'s global `max_global_rejects` failure. When this option is set to `true` the `proptest` generation itself ensures that no invalid addresses are generated, and thus need not be filtered adding up to the `max_test_rejects` count.
 

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -535,9 +535,10 @@ fn inspect_inner<S: ReadStorage + Send>(
     }
 
     let resolve_hashes = get_env_var::<bool>("ZK_DEBUG_RESOLVE_HASHES");
+    let show_outputs = get_env_var::<bool>("ZK_DEBUG_SHOW_OUTPUTS");
     tracing::info!("=== Calls: ");
     for call in call_traces.iter() {
-        formatter::print_call(call, 0, &ShowCalls::All, resolve_hashes, true);
+        formatter::print_call(call, 0, &ShowCalls::All, show_outputs, resolve_hashes);
     }
 
     tracing::info!("==== {}", format!("{} events", tx_result.logs.events.len()));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Resolve hashes functionality for the zkEVM output was always enabled owing to introduction of a new `show_output` parameter.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Handle `resolve_hashes` and `show_output` correctly based on environment variables. Update README.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
