### PR TITLE
fix: add support for SELFBALANCE opcode

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -590,9 +590,13 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
     }
 
     fn step_end(&mut self, interpreter: &mut Interpreter<'_>, data: &mut EVMData<'_, DB>) {
+        if !self.use_zk_mv {
+            return;
+        }
+
         let address = match interpreter.current_opcode() {
-            opcode::SELFBALANCE if self.use_zk_vm => interpreter.contract().address,
-            opcode::BALANCE if self.use_zk_vm => {
+            opcode::SELFBALANCE => interpreter.contract().address,
+            opcode::BALANCE => {
                 if interpreter.stack.is_empty() {
                     interpreter.instruction_result = InstructionResult::StackUnderflow;
                     return;

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -590,33 +590,32 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
     }
 
     fn step_end(&mut self, interpreter: &mut Interpreter<'_>, data: &mut EVMData<'_, DB>) {
-        if !self.use_zk_vm {
-            return;
-        }
+        // ovverride address(x).balance retrieval to make it consistent between EraVM and EVM
+        if self.use_zk_vm {
+            let address = match interpreter.current_opcode() {
+                opcode::SELFBALANCE => interpreter.contract().address,
+                opcode::BALANCE => {
+                    if interpreter.stack.is_empty() {
+                        interpreter.instruction_result = InstructionResult::StackUnderflow;
+                        return;
+                    }
 
-        let address = match interpreter.current_opcode() {
-            opcode::SELFBALANCE => interpreter.contract().address,
-            opcode::BALANCE => {
-                if interpreter.stack.is_empty() {
-                    interpreter.instruction_result = InstructionResult::StackUnderflow;
-                    return;
+                    Address::from_word(B256::from(unsafe { interpreter.stack.pop_unsafe() }))
                 }
+                _ => return,
+            };
 
-                Address::from_word(B256::from(unsafe { interpreter.stack.pop_unsafe() }))
-            }
-            _ => return,
-        };
+            // Safety: Length is checked above.
+            let balance = foundry_zksync_core::balance(address, data.db, &mut data.journaled_state);
 
-        // Safety: Length is checked above.
-        let balance = foundry_zksync_core::balance(address, data.db, &mut data.journaled_state);
-
-        // Skip the current BALANCE instruction since we've already handled it
-        match interpreter.stack.push(balance) {
-            Ok(_) => unsafe {
-                interpreter.instruction_pointer = interpreter.instruction_pointer.add(1);
-            },
-            Err(e) => {
-                interpreter.instruction_result = e;
+            // Skip the current BALANCE instruction since we've already handled it
+            match interpreter.stack.push(balance) {
+                Ok(_) => unsafe {
+                    interpreter.instruction_pointer = interpreter.instruction_pointer.add(1);
+                },
+                Err(e) => {
+                    interpreter.instruction_result = e;
+                }
             }
         }
     }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -590,7 +590,7 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
     }
 
     fn step_end(&mut self, interpreter: &mut Interpreter<'_>, data: &mut EVMData<'_, DB>) {
-        if !self.use_zk_mv {
+        if !self.use_zk_vm {
             return;
         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -590,23 +590,29 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
     }
 
     fn step_end(&mut self, interpreter: &mut Interpreter<'_>, data: &mut EVMData<'_, DB>) {
-        if self.use_zk_vm && interpreter.current_opcode() == opcode::BALANCE {
-            if interpreter.stack.is_empty() {
-                interpreter.instruction_result = InstructionResult::StackUnderflow;
-                return;
-            }
-            // Safety: Length is checked above.
-            let address = Address::from_word(B256::from(unsafe { interpreter.stack.pop_unsafe() }));
-            let balance = foundry_zksync_core::balance(address, data.db, &mut data.journaled_state);
-
-            // Skip the current BALANCE instruction since we've already handled it
-            match interpreter.stack.push(balance) {
-                Ok(_) => unsafe {
-                    interpreter.instruction_pointer = interpreter.instruction_pointer.add(1);
-                },
-                Err(e) => {
-                    interpreter.instruction_result = e;
+        let address = match interpreter.current_opcode() {
+            opcode::SELFBALANCE if self.use_zk_vm => interpreter.contract().address,
+            opcode::BALANCE if self.use_zk_vm => {
+                if interpreter.stack.is_empty() {
+                    interpreter.instruction_result = InstructionResult::StackUnderflow;
+                    return;
                 }
+
+                Address::from_word(B256::from(unsafe { interpreter.stack.pop_unsafe() }))
+            }
+            _ => return,
+        };
+
+        // Safety: Length is checked above.
+        let balance = foundry_zksync_core::balance(address, data.db, &mut data.journaled_state);
+
+        // Skip the current BALANCE instruction since we've already handled it
+        match interpreter.stack.push(balance) {
+            Ok(_) => unsafe {
+                interpreter.instruction_pointer = interpreter.instruction_pointer.add(1);
+            },
+            Err(e) => {
+                interpreter.instruction_result = e;
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
When an account balance is read, and zk mode is enabled, we intercept the `BALANCE` opcode and read the balance from the L2 Eth system contract.
When checking the test address's balance (via `address(this).balance`), any balance change seems to not be reflected, causing failures on some [tests](https://github.com/bgd-labs/aave-governance-v3/blob/0c14d60ac89d7a9f79d0a1f77de5c99c3ba1201f/tests/GovernanceCore.t.sol#L854).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
`address(this).balance` doesn't always use the `BALANCE` opcode, but the `SELFBALANCE` opcode instead (or at least, it _can_ use that opcode), as it is more gas efficient.
Adding support for this opcode ensures that this pattern reads the expected contract balance.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
