### PR TITLE
feat: always get logs after zkvm execution

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1241,35 +1241,29 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
                 accesses: self.accesses.as_mut(),
                 persisted_factory_deps,
             };
-            if let Ok(result) = foundry_zksync_core::vm::call::<_, DatabaseError>(
+            if let Ok((logs, result)) = foundry_zksync_core::vm::call::<_, DatabaseError>(
                 call,
                 data.env,
                 data.db,
                 &mut data.journaled_state,
                 ccx,
             ) {
+                self.combined_logs.extend(logs.clone().into_iter().map(|log| {
+                    Some(Log {
+                        address: log.address,
+                        data: LogData::new_unchecked(log.topics, log.data),
+                    })
+                }));
+                //for each log in cloned logs call handle_expect_emit
+                if !self.expected_emits.is_empty() {
+                    for log in logs {
+                        expect::handle_expect_emit(self, &log.address, &log.topics, &log.data);
+                    }
+                }
+
                 return match result {
-                    ExecutionResult::Success { output, logs, .. } => match output {
-                        Output::Call(bytes) => {
-                            self.combined_logs.extend(logs.clone().into_iter().map(|log| {
-                                Some(Log {
-                                    address: log.address,
-                                    data: LogData::new_unchecked(log.topics, log.data),
-                                })
-                            }));
-                            //for each log in cloned logs call handle_expect_emit
-                            if !self.expected_emits.is_empty() {
-                                for log in logs {
-                                    expect::handle_expect_emit(
-                                        self,
-                                        &log.address,
-                                        &log.topics,
-                                        &log.data,
-                                    );
-                                }
-                            }
-                            (InstructionResult::Return, gas, bytes)
-                        }
+                    ExecutionResult::Success { output, .. } => match output {
+                        Output::Call(bytes) => (InstructionResult::Return, gas, bytes),
                         _ => (InstructionResult::Revert, gas, Bytes::new()),
                     },
                     ExecutionResult::Revert { output, .. } => {
@@ -1726,7 +1720,7 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
                 accesses: self.accesses.as_mut(),
                 persisted_factory_deps,
             };
-            if let Ok(result) = foundry_zksync_core::vm::create::<_, DatabaseError>(
+            if let Ok((logs, result)) = foundry_zksync_core::vm::create::<_, DatabaseError>(
                 call,
                 zk_contract,
                 factory_deps,
@@ -1735,15 +1729,16 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
                 &mut data.journaled_state,
                 ccx,
             ) {
+                self.combined_logs.extend(logs.into_iter().map(|log| {
+                    Some(Log {
+                        address: log.address,
+                        data: LogData::new_unchecked(log.topics, log.data),
+                    })
+                }));
+
                 return match result {
-                    ExecutionResult::Success { output, logs, .. } => match output {
+                    ExecutionResult::Success { output, .. } => match output {
                         Output::Create(bytes, address) => {
-                            self.combined_logs.extend(logs.into_iter().map(|log| {
-                                Some(Log {
-                                    address: log.address,
-                                    data: LogData::new_unchecked(log.topics, log.data),
-                                })
-                            }));
                             (InstructionResult::Return, address, gas, bytes)
                         }
                         _ => (InstructionResult::Revert, None, gas, Bytes::new()),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
During tests or scripts execution, logs that happen inside of the zk VM are collected and returned once a given call has succeeded.
This makes it particularly hard to debug reverts and similar failures, where the logs are not retrieved and thus are not able to be displayed to the user.
This makes use cases such as print debugging via `console.log` useless, as it becomes impossible to bisect a function execution thru it.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Logs are stored separtely from the execution result of the zkVM, thus they can be retrieved even during reverts or panics.
The `revm::ExecutionResult` type only stores logs when execution succeeds, therefore it's necessary to store the logs alongside it (and not inside) if we want to be able to retrieve them for all executions.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
