### PR TITLE
chore: add .zksolc-libraries-cache to .gitignore

### DIFF
--- a/zk-tests/.gitignore
+++ b/zk-tests/.gitignore
@@ -7,3 +7,4 @@ solc-v*
 era_test_node
 cache/
 broadcast/
+.zksolc-libraries-cache/


### PR DESCRIPTION
## Motivation

When running zk-tests locally, `.zksolc-libraries-cache` directory was being created and was part of the git tracked files.

## Solution

Add the directory to `.gitignore` .