### PR TITLE
fix: use consistent chainId in zkEVM

### DIFF
--- a/crates/zksync/core/src/vm/db.rs
+++ b/crates/zksync/core/src/vm/db.rs
@@ -82,11 +82,11 @@ where
     pub fn new_with_system_contracts(
         db: &'a mut DB,
         journaled_state: &'a mut JournaledState,
+        chain_id: L2ChainId,
     ) -> Self {
         let contracts = era_test_node::system_contracts::get_deployed_contracts(
             &era_test_node::system_contracts::Options::BuiltInWithoutSecurity,
         );
-        let chain_id = L2ChainId::from(DEFAULT_CHAIN_ID);
         let system_context_init_log = get_system_context_init_logs(chain_id);
 
         let mut override_keys = HashMap::default();

--- a/zk-tests/src/Basic.t.sol
+++ b/zk-tests/src/Basic.t.sol
@@ -7,11 +7,13 @@ contract BlockEnv {
     uint256 public number;
     uint256 public timestamp;
     uint256 public basefee;
+    uint256 public chainid;
 
     constructor() {
         number = block.number;
         timestamp = block.timestamp;
         basefee = block.basefee;
+        chainid = block.chainid;
     }
 }
 
@@ -82,6 +84,10 @@ contract ZkBasicTest is Test {
             be.basefee() == block.basefee,
             "propagated block basefee is the same as current"
         );
+        require(
+            be.chainid() == block.chainid,
+            "propagated block chainid is the same as current"
+        );
 
         be = new BlockEnv();
         require(
@@ -95,6 +101,10 @@ contract ZkBasicTest is Test {
         require(
             be.basefee() == block.basefee,
             "propagated block basefee stays constant"
+        );
+        require(
+            be.chainid() == block.chainid,
+            "propagated block chainid stays constant"
         );
 
         vm.roll(42);

--- a/zk-tests/test.sh
+++ b/zk-tests/test.sh
@@ -139,10 +139,10 @@ else
 fi
 
 echo "Running tests..."
-RUST_LOG=warn "${FORGE}" test --use "./${SOLC}" -vvv  || fail "forge test failed"
+RUST_LOG=warn "${FORGE}" test --use "./${SOLC}" --chain 300 -vvv  || fail "forge test failed"
 
 echo "Running tests with '--zksync'..."
-RUST_LOG=warn "${FORGE}" test --use "./${SOLC}" -vvv --zksync  || fail "forge test --zksync failed"
+RUST_LOG=warn "${FORGE}" test --use "./${SOLC}" --chain 300 -vvv --zksync  || fail "forge test --zksync failed"
 
 echo "Running script..."
 RUST_LOG=warn "${FORGE}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "$PRIVATE_KEY" --chain 260 --gas-estimate-multiplier 310 --rpc-url "$RPC_URL" --use "./${SOLC}" --slow  -vvv  || fail "forge script failed"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ChainId was not being respected when system contracts were being created, leading to an inconsistency if tests were run with a custom `--chain`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* Consistently handle the passed in chainId.
* Run tests with `--chain` to catch this case.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Notes
Fixes #390 