### PR TITLE
docs: add notes solc version compatibility with zksolc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ While `foundry-zksync` is **alpha stage**, there are some limitations to be awar
 - **Create2 Address Derivation**: There are differences in Create2 Address derivation compared to Ethereum. [Read the details](https://era.zksync.io/docs/reference/architecture/differences-with-ethereum.html#create-create2).
 - **Contract Verification**: Currently contract verification via the `--verify` flag do not work as expected but will be added shortly.  
 - **Specific Foundry Features**: Currently features such as `--gas-report`, `--coverage` may not work as intended. We are actively working on providing support for these feature types.
+- **Solc Compatibility**: `zksolc` requires a `solc` binary to be run as a child process. The version/path to use for each can be specified by the `zksolc` and `solc` options in `foundry.toml`. Not all `solc` versions are supported by all `zksolc` versions, compiling with a `solc` version higher than the one supported may lead to unexpected errors. [Read the docs](https://docs.zksync.io/zk-stack/components/compiler/toolchain/solidity.html#limitations) about version limitations and check the [zksolc changelog](https://github.com/matter-labs/era-compiler-solidity/blob/main/CHANGELOG.md) to see the latest supported `solc` version.
 
 For the most effective use of our library, we recommend familiarizing yourself with these features and limitations.
 


### PR DESCRIPTION
## Motivation
There are many issues reported that are due to using incompatible `zksolc` and `solc` versions.

## Solution
Add a note in limitations section about `zksolc`/`solc` compatibility. Long term solution might be enforcing compatibility automatically either downloading and using the binaries automatically and/or failing with a clear error message when incompatibility is detected due to versions derived from config.

