### PR TITLE
chore: remove contracts_to_compile from CompilerArgs

### DIFF
--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -105,12 +105,12 @@ pub struct CompilerArgs {
     #[serde(skip)]
     pub zk_optimizer: bool,
 
-    /// Contracts to compile
-    #[clap(long, help_heading = "Contracts to compile", value_delimiter = ',')]
-    pub contracts_to_compile: Option<Vec<String>>,
-
-    /// Contracts to avoid compiling
-    #[clap(long, help_heading = "Contracts to avoid compilation", value_delimiter = ',')]
+    /// Contracts to avoid compiling on zkSync
+    #[clap(
+        long,
+        help_heading = "Contracts to avoid during zkSync compilation",
+        value_delimiter = ','
+    )]
     pub avoid_contracts: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
## Motivation

Contracts to compile is not supported anymore but it is currently shown as an option to the user (e.g: when running `forge build --help`)

## Solution

Remove `contracts_to_compile` from `CompilerArgs`. Also clarify that avoid contracts is zksync specific (it has no effect in `solc` compilation)