### PR TITLE
fix: Add handle expect emit on create

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1745,7 +1745,7 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
                     })
                 }));
 
-                //for each log in cloned logs call handle_expect_emit
+                // for each log in cloned logs call handle_expect_emit
                 if !self.expected_emits.is_empty() {
                     for log in result.logs {
                         expect::handle_expect_emit(self, &log.address, &log.topics, &log.data);

--- a/zk-tests/src/Cheatcodes.t.sol
+++ b/zk-tests/src/Cheatcodes.t.sol
@@ -36,6 +36,7 @@ interface IMyProxyCaller {
 
 contract MyProxyCaller {
     address inner;
+
     constructor(address _inner) {
         inner = _inner;
     }
@@ -45,7 +46,22 @@ contract MyProxyCaller {
     }
 }
 
+contract Emitter {
+    event EventConstructor(string message);
+    event EventFunction(string message);
+
+    constructor() {
+        emit EventConstructor("constructor");
+    }
+
+    function functionEmit() public {
+        emit EventFunction("function");
+    }
+}
+
 contract ZkCheatcodesTest is Test {
+    event EventConstructor(string message);
+    event EventFunction(string message);
     uint256 testSlot = 0; //0x000000000000000000000000000000000000000000000000000000000000001e slot
     uint256 constant ERA_FORK_BLOCK = 19579636;
     uint256 constant ERA_FORK_BLOCK_TS = 1700601590;
@@ -141,6 +157,19 @@ contract ZkCheatcodesTest is Test {
         bytes32 keySlot0 = bytes32(uint256(0));
         assertEq(reads[0], keySlot0);
         assertEq(writes[0], keySlot0);
+    }
+
+    function testExpectEmit() public {
+        vm.expectEmit(true, true, true, true);
+        emit EventFunction("function");
+        Emitter emitter = new Emitter();
+        emitter.functionEmit();
+    }
+
+    function testExpectEmitOnCreate() public {
+        vm.expectEmit(true, true, true, true);
+        emit EventConstructor("constructor");
+        new Emitter();
     }
 
     function testZkCheatcodesValueFunctionMockReturn() public {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The logs emitted in a create function are not going through the logic to handle the expected emits. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Replicate the way to handle expect emits from call to create function
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
