### PR TITLE
feat: add zk-solc-path option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.3.9"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#2f1fac2502d4a81f58f8d232c3fc4f2454c2a964"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#b21def4c09e519cad02ca57ed7d9d6b001d54df8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.3.9"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#b21def4c09e519cad02ca57ed7d9d6b001d54df8"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#463c09c40f828a93ce8a2766f164e72d395829f7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/README.md
+++ b/README.md
@@ -80,21 +80,14 @@ Follow these steps to quickly install the binaries for `foundry-zksync`:
    cd foundry-zksync
    ```
 
-3. **Make the Installer Executable**:
-   Before running the installation script, ensure it is executable. This step is crucial for allowing the script to run without permission issues.
-
-   ```bash
-   chmod +x ./install-foundry-zksync
-   ```
-
-4. **Run the Installer**:
+3. **Run the Installer**:
    Now, you're ready to execute the installation script. This command initializes the setup and installs `foundry-zksync` binaries `forge` and `cast`.
 
    ```bash
    ./install-foundry-zksync
    ```
 
-5. **Verify the Installation** (Recommended):
+4. **Verify the Installation** (Recommended):
    After installation, it's good practice to verify that the binaries have been installed correctly. Run the following command to check the installed version:
 
    ```bash

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -60,7 +60,7 @@ pub struct CompilerArgs {
 
     #[clap(
         help_heading = "zkSync Compiler options",
-        help = "Solc compiler path to when compiling with zksolc",
+        help = "Solc compiler path to use when compiling with zksolc",
         long = "zk-solc-path",
         value_name = "ZK_SOLC_PATH"
     )]

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -60,9 +60,9 @@ pub struct CompilerArgs {
 
     #[clap(
         help_heading = "zkSync Compiler options",
-        help = "Solc compiler path to when when compiling with zksolc",
+        help = "Solc compiler path to when compiling with zksolc",
         long = "zk-solc-path",
-        value_name = "SYSTEM_MODE"
+        value_name = "ZK_SOLC_PATH"
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zk_solc_path: Option<PathBuf>,

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, EvmVersion};
 use serde::Serialize;
@@ -55,6 +57,15 @@ pub struct CompilerArgs {
     /// Use ZKSync era vm.
     #[clap(help_heading = "Use ZKSync era vm", long)]
     pub zksync: bool,
+
+    #[clap(
+        help_heading = "zkSync Compiler options",
+        help = "Solc compiler path to when when compiling with zksolc",
+        long = "zk-solc-path",
+        value_name = "SYSTEM_MODE"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zk_solc_path: Option<PathBuf>,
 
     /// A flag indicating whether to enable the system contract compilation mode.
     #[clap(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -419,6 +419,8 @@ pub struct Config {
     pub zksync: bool,
     /// The zkSolc instance to use if any.
     pub zksolc: Option<SolcReq>,
+    /// solc path to use along the zksolc compiler
+    pub zk_solc_path: Option<PathBuf>,
     /// Optimizer settings for zkSync
     pub zk_optimizer: bool,
     /// The optimization mode string.
@@ -1238,6 +1240,7 @@ impl Config {
             force_evmla: self.force_evmla,
             // TODO: See if we need to set this from here
             output_selection: Default::default(),
+            solc: self.zk_solc_path.clone(),
         };
 
         Ok(settings)
@@ -2073,6 +2076,7 @@ impl Default for Config {
             zk_optimizer: true,
             mode: '3',
             zksync: false,
+            zk_solc_path: None,
             zk_optimizer_details: None,
             fallback_oz: false,
             force_evmla: false,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -133,6 +133,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         force_evmla: Default::default(),
         detect_missing_libraries: Default::default(),
         zksolc: Default::default(),
+        zk_solc_path: None,
         zk_bytecode_hash: Default::default(),
         avoid_contracts: Default::default(),
     };


### PR DESCRIPTION
## Motivation

[This PR ](https://github.com/Moonsong-Labs/compilers/pull/4) in zksync's fork of foundry compilers adds a new setting for zksolc's `--solc` option.

## Solution

Add `zk_solc_path` config value that allows the user to set the option