### PR TITLE
chore: add assert for bytecode word-size in etch

### DIFF
--- a/crates/zksync/core/src/cheatcodes.rs
+++ b/crates/zksync/core/src/cheatcodes.rs
@@ -150,6 +150,13 @@ pub fn etch<'a, DB>(
     <DB as Database>::Error: Debug,
 {
     info!(?address, bytecode = hex::encode(bytecode), "cheatcode etch");
+    let len = bytecode.len();
+    if len % 32 != 0 {
+        panic!(
+            "etch bytecode length must be divisible by 32, found '{}' with length {len}",
+            hex::encode(&bytecode)
+        );
+    }
 
     let bytecode_hash = hash_bytecode(bytecode).to_ru256();
     let bytecode = Bytecode::new_raw(Bytes::copy_from_slice(bytecode));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently a user can etch a bytecode that isn't aligned on a 32-byte word boundary. This causes panic in zkEVM.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Assert the etched bytecode and panic earlier with a meaningful message and the bytecode value.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
