### PR TITLE
refactor: only `build` evm or zksync

### DIFF
--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -75,7 +75,7 @@ pub struct BuildArgs {
 }
 
 impl BuildArgs {
-    pub fn run(self) -> Result<ProjectCompileOutput> {
+    pub fn run(self) -> Result<()> {
         let mut config = self.try_load_config_emit_warnings()?;
         let mut project = config.project()?;
 
@@ -87,35 +87,36 @@ impl BuildArgs {
             project = config.project()?;
         }
 
-        let mut compiler = ProjectCompiler::new()
-            .print_names(self.names)
-            .print_sizes(self.sizes)
-            .quiet(self.format_json)
-            .bail(!self.format_json);
-        if let Some(skip) = self.skip {
-            if !skip.is_empty() {
-                compiler = compiler.filter(Box::new(SkipBuildFilters::new(skip)?));
+        if !config.zksync {
+            let mut compiler = ProjectCompiler::new()
+                .print_names(self.names)
+                .print_sizes(self.sizes)
+                .quiet(self.format_json)
+                .bail(!self.format_json);
+            if let Some(skip) = self.skip {
+                if !skip.is_empty() {
+                    compiler = compiler.filter(Box::new(SkipBuildFilters::new(skip)?));
+                }
             }
-        }
-        let output = compiler.compile(&project)?;
 
-        if self.format_json {
-            println!("{}", serde_json::to_string_pretty(&output.clone().output())?);
-        }
-
-        if config.zksync {
+            let output = compiler.compile(&project)?;
+            if self.format_json {
+                println!("{}", serde_json::to_string_pretty(&output.output())?);
+            }
+        } else {
             let zk_compiler = ProjectCompiler::new()
                 .print_names(self.names)
                 .print_sizes(self.sizes)
                 .quiet(self.format_json)
                 .bail(!self.format_json);
-            let zk_output = zk_compiler.zksync_compile(&project)?;
+
+            let output = zk_compiler.zksync_compile(&project)?;
             if self.format_json {
-                println!("{}", serde_json::to_string_pretty(&zk_output.clone().output())?);
+                println!("{}", serde_json::to_string_pretty(&output.output())?);
             }
         }
 
-        Ok(output)
+        Ok(())
     }
 
     /// Returns the `Project` for the current workspace

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
             if cmd.is_watch() {
                 utils::block_on(watch::watch_build(cmd))
             } else {
-                cmd.run().map(|_| ())
+                cmd.run()
             }
         }
         ForgeSubcommand::Debug(cmd) => utils::block_on(cmd.run()),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
As outlined in #335  & #379, not using `--zksync` shouldn't trigger compilation with zksolc, as this can be quite confusing for users.
Additionally, using `--zksync` shouldn't trigger compilation with solc, as some contracts aren't compatible with it (like contracts with era extensions #380)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Only `build` with the appropriate compiler.
Future PRs will apply a similar fix for `create` and for `script` subcommands.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
