### PR TITLE
refactor(config): split zk-related configuration

### DIFF
--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use clap::Parser;
 use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, EvmVersion};
 use serde::Serialize;
@@ -9,6 +7,9 @@ pub use self::core::CoreBuildArgs;
 
 mod paths;
 pub use self::paths::ProjectPathsArgs;
+
+mod zksync;
+pub use self::zksync::ZkSyncArgs;
 
 // A set of solc compiler settings that can be set via command line arguments, which are intended
 // to be merged into an existing `foundry_config::Config`.
@@ -53,76 +54,8 @@ pub struct CompilerArgs {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extra_output_files: Vec<ContractOutputSelection>,
 
-    // @zksync
-    /// Use ZKSync era vm.
-    #[clap(help_heading = "Use ZKSync era vm", long)]
-    pub zksync: bool,
-
-    #[clap(
-        help_heading = "zkSync Compiler options",
-        help = "Solc compiler path to use when compiling with zksolc",
-        long = "zk-solc-path",
-        value_name = "ZK_SOLC_PATH"
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub zk_solc_path: Option<PathBuf>,
-
-    /// A flag indicating whether to enable the system contract compilation mode.
-    #[clap(
-        help_heading = "zkSync Compiler options",
-        help = "Enable the system contract compilation mode.",
-        long = "enable-eravm-extensions",
-        value_name = "ENABLE_ERAVM_EXTENSIONS"
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_eravm_extensions: Option<bool>,
-
-    /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
-    #[clap(
-        help_heading = "zkSync Compiler options",
-        help = "Forcibly switch to the EVM legacy assembly pipeline.",
-        long = "force-evmla",
-        value_name = "FORCE_EVMLA"
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub force_evmla: Option<bool>,
-
-    /// Try to recompile with -Oz if the bytecode is too large.
-    #[clap(
-        help_heading = "zkSync Compiler options",
-        long = "fallback-oz",
-        value_name = "FALLBACK_OZ"
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fallback_oz: Option<bool>,
-
-    /// Path to cache missing library dependencies, used for compiling and deploying libraries.
-    #[clap(help_heading = "zkSync Compiler options", long = "detect-missing-libraries")]
-    pub detect_missing_libraries: bool,
-
-    /// Set the LLVM optimization parameter `-O[0 | 1 | 2 | 3 | s | z]`.
-    /// Use `3` for best performance and `z` for minimal size.
-    #[clap(
-        help_heading = "zkSync Compiler options",
-        short = 'O',
-        long = "zk-optimization",
-        value_name = "LEVEL"
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub zk_optimizer_mode: Option<String>,
-
-    /// Enables optimizations
-    #[clap(help_heading = "zkSync Compiler options", long = "zk-optimizer")]
-    #[serde(skip)]
-    pub zk_optimizer: bool,
-
-    /// Contracts to avoid compiling on zkSync
-    #[clap(
-        long,
-        help_heading = "Contracts to avoid during zkSync compilation",
-        value_delimiter = ','
-    )]
-    pub avoid_contracts: Option<Vec<String>>,
+    #[clap(flatten)]
+    pub zk: ZkSyncArgs,
 }
 
 #[cfg(test)]

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -55,6 +55,7 @@ pub struct CompilerArgs {
     pub extra_output_files: Vec<ContractOutputSelection>,
 
     #[clap(flatten)]
+    #[serde(skip)]
     pub zk: ZkSyncArgs,
 }
 

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -71,11 +71,11 @@ pub struct CompilerArgs {
     #[clap(
         help_heading = "zkSync Compiler options",
         help = "Enable the system contract compilation mode.",
-        long = "is-system",
-        value_name = "SYSTEM_MODE"
+        long = "enable-eravm-extensions",
+        value_name = "ENABLE_ERAVM_EXTENSIONS"
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_system: Option<bool>,
+    pub enable_eravm_extensions: Option<bool>,
 
     /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
     #[clap(
@@ -105,11 +105,11 @@ pub struct CompilerArgs {
     #[clap(
         help_heading = "zkSync Compiler options",
         short = 'O',
-        long = "optimization",
+        long = "zk-optimization",
         value_name = "LEVEL"
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<String>,
+    pub zk_optimizer_mode: Option<String>,
 
     /// Enables optimizations
     #[clap(help_heading = "zkSync Compiler options", long = "zk-optimizer")]

--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -1,0 +1,105 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use foundry_config::ZkSyncConfig;
+use serde::Serialize;
+
+#[derive(Clone, Debug, Default, Serialize, Parser)]
+#[clap(next_help_heading = "ZKSync configuration")]
+pub struct ZkSyncArgs {
+    /// Use ZKSync era vm.
+    #[clap(long = "zksync", visible_alias = "zk")]
+    pub enable: bool,
+
+    #[clap(
+        help = "Solc compiler path to use when compiling with zksolc",
+        long = "zk-solc-path",
+        value_name = "ZK_SOLC_PATH"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub solc_path: Option<PathBuf>,
+
+    /// A flag indicating whether to enable the system contract compilation mode.
+    #[clap(
+        help = "Enable the system contract compilation mode.",
+        long = "zk-eravm-extensions",
+        visible_alias = "enable-eravm-extensions",
+        visible_alias = "system-mode",
+        value_name = "ENABLE_ERAVM_EXTENSIONS"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eravm_extensions: Option<bool>,
+
+    /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
+    #[clap(
+        help = "Forcibly switch to the EVM legacy assembly pipeline.",
+        long = "zk-force-evmla",
+        visible_alias = "force-evmla",
+        value_name = "FORCE_EVMLA"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_evmla: Option<bool>,
+
+    /// Try to recompile with -Oz if the bytecode is too large.
+    #[clap(long = "zk-fallback-oz", visible_alias = "fallback-oz", value_name = "FALLBACK_OZ")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_oz: Option<bool>,
+
+    /// Detect missing libraries, instead of erroring
+    ///
+    /// Currently unused
+    #[clap(long = "zk-detect-missing-libraries")]
+    pub detect_missing_libraries: bool,
+
+    /// Set the LLVM optimization parameter `-O[0 | 1 | 2 | 3 | s | z]`.
+    /// Use `3` for best performance and `z` for minimal size.
+    #[clap(
+        short = 'O',
+        long = "zk-optimizer-mode",
+        visible_alias = "zk-optimization",
+        value_name = "LEVEL"
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optimizer_mode: Option<String>,
+
+    /// Enables optimizations
+    #[clap(long = "zk-optimizer")]
+    #[serde(skip)]
+    pub optimizer: bool,
+
+    /// Contracts to avoid compiling on zkSync
+    #[clap(long = "zk-avoid-contracts", visible_alias = "avoid-contracts", value_delimiter = ',')]
+    pub avoid_contracts: Option<Vec<String>>,
+}
+
+impl ZkSyncArgs {
+    /// Merge the current cli arguments into the specified zksync configuration
+    pub(crate) fn apply_overrides(&self, mut zksync: ZkSyncConfig) -> ZkSyncConfig {
+        macro_rules! set_if_some {
+            ($src:expr, $dst:expr) => {
+                if let Some(src) = $src {
+                    $dst = src.into();
+                }
+            };
+        }
+
+        set_if_some!(self.enable.then_some(true), zksync.enable);
+        set_if_some!(self.solc_path.clone(), zksync.solc_path);
+        set_if_some!(self.eravm_extensions, zksync.eravm_extensions);
+        set_if_some!(self.force_evmla, zksync.force_evmla);
+        set_if_some!(self.fallback_oz, zksync.fallback_oz);
+        set_if_some!(
+            self.detect_missing_libraries.then_some(true),
+            zksync.detect_missing_libraries
+        );
+        set_if_some!(self.avoid_contracts.clone(), zksync.avoid_contracts);
+
+        set_if_some!(self.optimizer.then_some(true), zksync.optimizer);
+        set_if_some!(
+            self.optimizer_mode.as_ref().and_then(|mode| mode.parse::<char>().ok()),
+            zksync.optimizer_mode
+        );
+
+        zksync
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,15 +22,7 @@ use foundry_compilers::{
     cache::SOLIDITY_FILES_CACHE_FILENAME,
     error::SolcError,
     remappings::{RelativeRemapping, Remapping},
-    zksync::{
-        artifacts::{
-            BytecodeHash as ZkSolcBytecodeHash, Optimizer as ZkSolcOptimizer,
-            OptimizerDetails as ZkSolcOptimizerDetails, Settings as ZkSolcSettings,
-            SettingsMetadata as ZkSolcSettingsMetadata,
-        },
-        compile::ZkSolc,
-        config::ZkSolcConfig,
-    },
+    zksync::{artifacts::Settings as ZkSolcSettings, compile::ZkSolc, config::ZkSolcConfig},
     ConfigurableArtifacts, EvmVersion, Project, ProjectPathsConfig, Solc, SolcConfig,
 };
 use inflector::Inflector;
@@ -105,6 +97,9 @@ use providers::remappings::RemappingsProvider;
 mod inline;
 use crate::etherscan::EtherscanEnvProvider;
 pub use inline::{validate_profiles, InlineConfig, InlineConfigError, InlineConfigParser, NatSpec};
+
+mod zksync;
+use zksync::ZkSyncConfig;
 
 /// Foundry configuration
 ///
@@ -414,31 +409,7 @@ pub struct Config {
     pub __warnings: Vec<Warning>,
 
     /// @zkSync zkSolc configuration and settings
-    ///
-    /// Use zksync era
-    pub zksync: bool,
-    /// The zkSolc instance to use if any.
-    pub zksolc: Option<SolcReq>,
-    /// solc path to use along the zksolc compiler
-    pub zk_solc_path: Option<PathBuf>,
-    /// Optimizer settings for zkSync
-    pub zk_optimizer: bool,
-    /// The optimization mode string.
-    pub mode: char,
-    /// zksolc optimizer details remain the same
-    pub zk_optimizer_details: Option<ZkSolcOptimizerDetails>,
-    /// Whether to include the metadata hash for zksolc compiled bytecode.
-    pub zk_bytecode_hash: ZkSolcBytecodeHash,
-    /// Whether to try to recompile with -Oz if the bytecode is too large.
-    pub fallback_oz: bool,
-    /// Whether to support compilation of zkSync-specific simulations
-    pub is_system: bool,
-    /// Force evmla for zkSync
-    pub force_evmla: bool,
-    /// Path to cache missing library dependencies, used for compiling and deploying libraries.
-    pub detect_missing_libraries: bool,
-    /// Source files to avoid compiling on zksolc
-    pub avoid_contracts: Option<Vec<String>>,
+    pub zksync: ZkSyncConfig,
 }
 
 /// Mapping of fallback standalone sections. See [`FallbackProfileProvider`]
@@ -461,7 +432,7 @@ impl Config {
 
     /// Standalone sections in the config which get integrated into the selected profile
     pub const STANDALONE_SECTIONS: &'static [&'static str] =
-        &["rpc_endpoints", "etherscan", "fmt", "doc", "fuzz", "invariant", "labels"];
+        &["rpc_endpoints", "etherscan", "fmt", "doc", "fuzz", "invariant", "labels", "zksync"];
 
     /// File name of config toml file
     pub const FILE_NAME: &'static str = "foundry.toml";
@@ -728,12 +699,13 @@ impl Config {
         // when setting up the builder for the sake of consistency (requires dedicated
         // builder methods)
         project.zksync_zksolc_config = ZkSolcConfig { settings: self.zksync_zksolc_settings()? };
-        project.zksync_avoid_contracts = self.avoid_contracts.clone().map(|patterns| {
-            patterns
-                .into_iter()
-                .map(|pat| globset::Glob::new(&pat).expect("invalid pattern").compile_matcher())
-                .collect::<Vec<_>>()
-        });
+        project.zksync_avoid_contracts =
+            self.zksync.compiler.avoid_contracts.clone().map(|patterns| {
+                patterns
+                    .into_iter()
+                    .map(|pat| globset::Glob::new(&pat).expect("invalid pattern").compile_matcher())
+                    .collect::<Vec<_>>()
+            });
 
         if let Some(zksolc) = self.zksync_ensure_zksolc()? {
             project.zksync_zksolc = zksolc;
@@ -802,7 +774,7 @@ impl Config {
     ///
     /// If `zksolc` is [`SolcReq::Local`] then this will ensure that the path exists.
     fn zksync_ensure_zksolc(&self) -> Result<Option<ZkSolc>, SolcError> {
-        if let Some(ref zksolc) = self.zksolc {
+        if let Some(ref zksolc) = self.zksync.compiler.zksolc {
             let zksolc = match zksolc {
                 SolcReq::Version(version) => {
                     let mut zksolc = ZkSolc::find_installed_version(version)?;
@@ -1218,32 +1190,7 @@ impl Config {
             Err(e) => return Err(SolcError::msg(format!("Failed to parse libraries: {}", e))),
         };
 
-        let optimizer = ZkSolcOptimizer {
-            enabled: Some(self.zk_optimizer),
-            mode: Some(self.mode),
-            fallback_to_optimizing_for_size: Some(self.fallback_oz),
-            disable_system_request_memoization: Some(true),
-            details: self.zk_optimizer_details.clone(),
-            jump_table_density_threshold: None,
-        };
-
-        let settings = ZkSolcSettings {
-            libraries,
-            optimizer,
-            evm_version: Some(self.evm_version),
-            metadata: Some(ZkSolcSettingsMetadata { bytecode_hash: Some(self.zk_bytecode_hash) }),
-            via_ir: Some(self.via_ir),
-            // Set in project paths.
-            remappings: Vec::new(),
-            detect_missing_libraries: self.detect_missing_libraries,
-            system_mode: self.is_system,
-            force_evmla: self.force_evmla,
-            // TODO: See if we need to set this from here
-            output_selection: Default::default(),
-            solc: self.zk_solc_path.clone(),
-        };
-
-        Ok(settings)
+        Ok(self.zksync.compiler.settings(libraries, self.evm_version, self.via_ir))
     }
 
     /// Returns the default figment
@@ -2070,19 +2017,7 @@ impl Default for Config {
             labels: Default::default(),
             __non_exhaustive: (),
             __warnings: vec![],
-            // @zkSync
-            zksolc: None,
-            zk_bytecode_hash: ZkSolcBytecodeHash::None,
-            zk_optimizer: true,
-            mode: '3',
-            zksync: false,
-            zk_solc_path: None,
-            zk_optimizer_details: None,
-            fallback_oz: false,
-            force_evmla: false,
-            is_system: false,
-            detect_missing_libraries: false,
-            avoid_contracts: None,
+            zksync: Default::default(),
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -699,13 +699,12 @@ impl Config {
         // when setting up the builder for the sake of consistency (requires dedicated
         // builder methods)
         project.zksync_zksolc_config = ZkSolcConfig { settings: self.zksync_zksolc_settings()? };
-        project.zksync_avoid_contracts =
-            self.zksync.compiler.avoid_contracts.clone().map(|patterns| {
-                patterns
-                    .into_iter()
-                    .map(|pat| globset::Glob::new(&pat).expect("invalid pattern").compile_matcher())
-                    .collect::<Vec<_>>()
-            });
+        project.zksync_avoid_contracts = self.zksync.avoid_contracts.clone().map(|patterns| {
+            patterns
+                .into_iter()
+                .map(|pat| globset::Glob::new(&pat).expect("invalid pattern").compile_matcher())
+                .collect::<Vec<_>>()
+        });
 
         if let Some(zksolc) = self.zksync_ensure_zksolc()? {
             project.zksync_zksolc = zksolc;
@@ -774,7 +773,7 @@ impl Config {
     ///
     /// If `zksolc` is [`SolcReq::Local`] then this will ensure that the path exists.
     fn zksync_ensure_zksolc(&self) -> Result<Option<ZkSolc>, SolcError> {
-        if let Some(ref zksolc) = self.zksync.compiler.zksolc {
+        if let Some(ref zksolc) = self.zksync.zksolc {
             let zksolc = match zksolc {
                 SolcReq::Version(version) => {
                     let mut zksolc = ZkSolc::find_installed_version(version)?;
@@ -1190,7 +1189,7 @@ impl Config {
             Err(e) => return Err(SolcError::msg(format!("Failed to parse libraries: {}", e))),
         };
 
-        Ok(self.zksync.compiler.settings(libraries, self.evm_version, self.via_ir))
+        Ok(self.zksync.settings(libraries, self.evm_version, self.via_ir))
     }
 
     /// Returns the default figment

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -99,7 +99,7 @@ use crate::etherscan::EtherscanEnvProvider;
 pub use inline::{validate_profiles, InlineConfig, InlineConfigError, InlineConfigParser, NatSpec};
 
 mod zksync;
-use zksync::ZkSyncConfig;
+pub use zksync::*;
 
 /// Foundry configuration
 ///

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -13,56 +13,41 @@ use crate::SolcReq;
 /// ZkSync configuration
 pub struct ZkSyncConfig {
     /// Enable zksync mode
-    #[serde(alias = "zk", alias = "zksync")]
     pub enable: bool,
 
     /// The zkSolc instance to use if any.
     pub zksolc: Option<SolcReq>,
 
     /// solc path to use along the zksolc compiler
-    #[serde(alias = "zk-solc-path", alias = "solc")]
     pub solc_path: Option<PathBuf>,
 
     /// Whether to include the metadata hash for zksolc compiled bytecode.
-    #[serde(alias = "zk-bytecode-hash")]
     pub bytecode_hash: BytecodeHash,
 
     /// Whether to try to recompile with -Oz if the bytecode is too large.
-    #[serde(alias = "zk-fallback-oz")]
     pub fallback_oz: bool,
 
     /// Whether to support compilation of zkSync-specific simulations
-    #[serde(
-        alias = "system-mode",
-        alias = "enable-eravm-extensions",
-        alias = "zk-eravm-extensions"
-    )]
     pub eravm_extensions: bool,
 
     /// Force evmla for zkSync
-    #[serde(alias = "zk-force-evmla")]
     pub force_evmla: bool,
 
     /// Detect missing libraries, instead of erroring
     ///
     /// Currently unused
-    #[serde(alias = "zk-detect-missing-libraries")]
     pub detect_missing_libraries: bool,
 
     /// Source files to avoid compiling on zksolc
-    #[serde(alias = "zk-avoid-contracts")]
     pub avoid_contracts: Option<Vec<String>>,
 
     /// Enable optimizer for zkSync
-    #[serde(alias = "zk-optimizer", alias = "enable-optimizer")]
     pub optimizer: bool,
 
     /// The optimization mode string for zkSync
-    #[serde(alias = "zk-optimizer-mode")]
     pub optimizer_mode: char,
 
     /// zkSolc optimizer details
-    #[serde(alias = "zk-optimizer-details")]
     pub optimizer_details: Option<OptimizerDetails>,
 }
 

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -63,7 +63,7 @@ impl Default for ZkSyncConfig {
             force_evmla: Default::default(),
             detect_missing_libraries: Default::default(),
             avoid_contracts: Default::default(),
-            optimizer: Default::default(),
+            optimizer: true,
             optimizer_mode: '3',
             optimizer_details: Default::default(),
         }

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -1,0 +1,108 @@
+use foundry_compilers::{
+    artifacts::Libraries,
+    zksync::artifacts::{BytecodeHash, Optimizer, OptimizerDetails, Settings, SettingsMetadata},
+    EvmVersion,
+};
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::SolcReq;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkOptimizerConfig {
+    /// Optimizer settings for zkSync
+    pub enable: bool,
+
+    /// The optimization mode string.
+    pub mode: char,
+
+    /// zksolc optimizer details remain the same
+    pub details: Option<OptimizerDetails>,
+}
+
+impl Default for ZkOptimizerConfig {
+    fn default() -> Self {
+        Self { enable: Default::default(), mode: '3', details: Default::default() }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkCompilerConfig {
+    /// The zkSolc instance to use if any.
+    pub zksolc: Option<SolcReq>,
+
+    /// solc path to use along the zksolc compiler
+    pub solc: Option<PathBuf>,
+
+    /// Whether to include the metadata hash for zksolc compiled bytecode.
+    pub bytecode_hash: BytecodeHash,
+
+    /// Optimizer configuration
+    pub optimizer: ZkOptimizerConfig,
+
+    /// Whether to try to recompile with -Oz if the bytecode is too large.
+    pub fallback_oz: bool,
+
+    /// Whether to support compilation of zkSync-specific simulations
+    pub enable_eravm_extensions: bool,
+
+    /// Force evmla for zkSync
+    pub force_evmla: bool,
+
+    /// Path to cache missing library dependencies, used for compiling and deploying libraries.
+    pub detect_missing_libraries: bool,
+
+    /// Source files to avoid compiling on zksolc
+    pub avoid_contracts: Option<Vec<String>>,
+}
+
+impl ZkCompilerConfig {
+    pub fn settings(
+        &self,
+        libraries: Libraries,
+        evm_version: EvmVersion,
+        via_ir: bool,
+    ) -> Settings {
+        let optimizer = Optimizer {
+            enabled: Some(self.optimizer.enable),
+            mode: Some(self.optimizer.mode),
+            fallback_to_optimizing_for_size: Some(self.fallback_oz),
+            disable_system_request_memoization: Some(true),
+            details: self.optimizer.details.clone(),
+            jump_table_density_threshold: None,
+        };
+
+        Settings {
+            libraries,
+            optimizer,
+            evm_version: Some(evm_version),
+            metadata: Some(SettingsMetadata { bytecode_hash: Some(self.bytecode_hash) }),
+            via_ir: Some(via_ir),
+            // Set in project paths.
+            remappings: Vec::new(),
+            detect_missing_libraries: self.detect_missing_libraries,
+            system_mode: self.enable_eravm_extensions,
+            force_evmla: self.force_evmla,
+            // TODO: See if we need to set this from here
+            output_selection: Default::default(),
+            solc: self.solc.clone(),
+        }
+    }
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkSyncConfig {
+    /// Enable zksync mode
+    pub enable: bool,
+
+    /// zkSync compiler
+    pub compiler: ZkCompilerConfig,
+}
+
+impl ZkSyncConfig {
+    /// Returns true if zk mode is enabled and it if tests should be run in zk mode
+    pub fn run_in_zk_mode(&self) -> bool {
+        self.enable
+    }
+}

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use crate::SolcReq;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// ZkSolc optimizer configuration
 pub struct ZkOptimizerConfig {
     /// Optimizer settings for zkSync
     pub enable: bool,
@@ -28,6 +29,7 @@ impl Default for ZkOptimizerConfig {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// ZkSolc compiler configuration
 pub struct ZkCompilerConfig {
     /// The zkSolc instance to use if any.
     pub zksolc: Option<SolcReq>,
@@ -58,6 +60,7 @@ pub struct ZkCompilerConfig {
 }
 
 impl ZkCompilerConfig {
+    /// Convert the compiler config to a foundry_compilers zksync Settings
     pub fn settings(
         &self,
         libraries: Libraries,
@@ -92,6 +95,7 @@ impl ZkCompilerConfig {
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// ZkSync configuration
 pub struct ZkSyncConfig {
     /// Enable zksync mode
     pub enable: bool,

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -13,39 +13,56 @@ use crate::SolcReq;
 /// ZkSync configuration
 pub struct ZkSyncConfig {
     /// Enable zksync mode
+    #[serde(alias = "zk", alias = "zksync")]
     pub enable: bool,
 
     /// The zkSolc instance to use if any.
     pub zksolc: Option<SolcReq>,
 
     /// solc path to use along the zksolc compiler
-    pub solc: Option<PathBuf>,
+    #[serde(alias = "zk-solc-path", alias = "solc")]
+    pub solc_path: Option<PathBuf>,
 
     /// Whether to include the metadata hash for zksolc compiled bytecode.
+    #[serde(alias = "zk-bytecode-hash")]
     pub bytecode_hash: BytecodeHash,
 
     /// Whether to try to recompile with -Oz if the bytecode is too large.
+    #[serde(alias = "zk-fallback-oz")]
     pub fallback_oz: bool,
 
     /// Whether to support compilation of zkSync-specific simulations
-    pub enable_eravm_extensions: bool,
+    #[serde(
+        alias = "system-mode",
+        alias = "enable-eravm-extensions",
+        alias = "zk-eravm-extensions"
+    )]
+    pub eravm_extensions: bool,
 
     /// Force evmla for zkSync
+    #[serde(alias = "zk-force-evmla")]
     pub force_evmla: bool,
 
-    /// Path to cache missing library dependencies, used for compiling and deploying libraries.
+    /// Detect missing libraries, instead of erroring
+    ///
+    /// Currently unused
+    #[serde(alias = "zk-detect-missing-libraries")]
     pub detect_missing_libraries: bool,
 
     /// Source files to avoid compiling on zksolc
+    #[serde(alias = "zk-avoid-contracts")]
     pub avoid_contracts: Option<Vec<String>>,
 
-    /// Optimizer settings for zkSync
-    pub enable_optimizer: bool,
+    /// Enable optimizer for zkSync
+    #[serde(alias = "zk-optimizer", alias = "enable-optimizer")]
+    pub optimizer: bool,
 
-    /// The optimization mode string.
+    /// The optimization mode string for zkSync
+    #[serde(alias = "zk-optimizer-mode")]
     pub optimizer_mode: char,
 
-    /// zksolc optimizer details remain the same
+    /// zkSolc optimizer details
+    #[serde(alias = "zk-optimizer-details")]
     pub optimizer_details: Option<OptimizerDetails>,
 }
 
@@ -54,14 +71,14 @@ impl Default for ZkSyncConfig {
         Self {
             enable: Default::default(),
             zksolc: Default::default(),
-            solc: Default::default(),
+            solc_path: Default::default(),
             bytecode_hash: Default::default(),
             fallback_oz: Default::default(),
-            enable_eravm_extensions: Default::default(),
+            eravm_extensions: Default::default(),
             force_evmla: Default::default(),
             detect_missing_libraries: Default::default(),
             avoid_contracts: Default::default(),
-            enable_optimizer: Default::default(),
+            optimizer: Default::default(),
             optimizer_mode: '3',
             optimizer_details: Default::default(),
         }
@@ -82,7 +99,7 @@ impl ZkSyncConfig {
         via_ir: bool,
     ) -> Settings {
         let optimizer = Optimizer {
-            enabled: Some(self.enable_optimizer),
+            enabled: Some(self.optimizer),
             mode: Some(self.optimizer_mode),
             fallback_to_optimizing_for_size: Some(self.fallback_oz),
             disable_system_request_memoization: Some(true),
@@ -99,11 +116,11 @@ impl ZkSyncConfig {
             // Set in project paths.
             remappings: Vec::new(),
             detect_missing_libraries: self.detect_missing_libraries,
-            system_mode: self.enable_eravm_extensions,
+            system_mode: self.eravm_extensions,
             force_evmla: self.force_evmla,
             // TODO: See if we need to set this from here
             output_selection: Default::default(),
-            solc: self.solc.clone(),
+            solc: self.solc_path.clone(),
         }
     }
 }

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -103,7 +103,7 @@ impl BuildArgs {
             println!("{}", serde_json::to_string_pretty(&output.clone().output())?);
         }
 
-        if config.zksync {
+        if config.zksync.enable {
             let zk_compiler = ProjectCompiler::new()
                 .print_names(self.names)
                 .print_sizes(self.sizes)

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -162,6 +162,21 @@ impl Provider for BuildArgs {
             dict.insert("sizes".to_string(), true.into());
         }
 
+        // these are handled in CoreBuildArgs -> Figment impl
+        for zksync_flag in [
+            "zksync",
+            "zk_solc_path",
+            "enable_eravm_extensions",
+            "force_evmla",
+            "fallback_oz",
+            "detect_missing_libraries",
+            "avoid_contracts",
+            "zk_optimizer",
+            "zk_optimizer_mode",
+        ] {
+            dict.remove(zksync_flag);
+        }
+
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -163,21 +163,6 @@ impl Provider for BuildArgs {
             dict.insert("sizes".to_string(), true.into());
         }
 
-        // these are handled in CoreBuildArgs -> Figment impl
-        for zksync_flag in [
-            "zksync",
-            "zk_solc_path",
-            "enable_eravm_extensions",
-            "force_evmla",
-            "fallback_oz",
-            "detect_missing_libraries",
-            "avoid_contracts",
-            "zk_optimizer",
-            "zk_optimizer_mode",
-        ] {
-            dict.remove(zksync_flag);
-        }
-
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -117,7 +117,7 @@ impl CreateArgs {
     pub async fn run(self) -> Result<()> {
         let mut config = self.eth.try_load_config_emit_warnings()?;
         let project_root = config.project_paths().root;
-        let zksync = self.opts.compiler.zksync;
+        let zksync = self.opts.compiler.zk.enable;
 
         // Resolve missing libraries
         let libs_batches = if zksync && self.deploy_missing_libraries {

--- a/crates/forge/bin/cmd/script/executor.rs
+++ b/crates/forge/bin/cmd/script/executor.rs
@@ -159,7 +159,7 @@ impl ScriptArgs {
                         tx.to,
                         tx.input.clone().into_input(),
                         tx.value,
-                        (script_config.config.zksync, zk.clone()),
+                        (script_config.config.zksync.run_in_zk_mode(), zk.clone()),
                     )
                     .wrap_err("Internal EVM error during simulation")?;
 
@@ -323,6 +323,7 @@ impl ScriptArgs {
             .spec(script_config.config.evm_spec_id())
             .gas_limit(script_config.evm_opts.gas_limit());
 
+        let use_zk = script_config.config.zksync.run_in_zk_mode();
         if let SimulationStage::Local = stage {
             builder = builder.inspectors(|stack| {
                 stack
@@ -333,7 +334,7 @@ impl ScriptArgs {
                             script_config.evm_opts.clone(),
                             script_wallets,
                             dual_compiled_contracts.unwrap_or_default(),
-                            script_config.config.zksync,
+                            use_zk,
                         )
                         .into(),
                     )
@@ -342,7 +343,7 @@ impl ScriptArgs {
         }
 
         let mut executor = builder.build(env, db);
-        executor.use_zk = script_config.config.zksync;
+        executor.use_zk = use_zk;
         Ok(ScriptRunner::new(executor, script_config.evm_opts.initial_balance, sender))
     }
 }

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -210,7 +210,7 @@ impl TestArgs {
                 evm_opts.clone(),
                 None,
                 dual_compiled_contracts,
-                config.zksync,
+                config.zksync.run_in_zk_mode(),
             ))
             .with_test_options(test_options.clone())
             .enable_isolation(evm_opts.isolate)
@@ -226,7 +226,7 @@ impl TestArgs {
             }
             *test_pattern = Some(debug_test_pattern.clone());
         }
-        runner.use_zk = config.zksync;
+        runner.use_zk = config.zksync.run_in_zk_mode();
 
         let outcome = self.run_tests(runner, config, verbosity, &filter, test_options).await?;
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -124,18 +124,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         isolate: true,
         __non_exhaustive: (),
         __warnings: vec![],
-        zk_optimizer: Default::default(),
-        mode: Default::default(),
-        zksync: false,
-        zk_optimizer_details: Default::default(),
-        fallback_oz: Default::default(),
-        is_system: Default::default(),
-        force_evmla: Default::default(),
-        detect_missing_libraries: Default::default(),
-        zksolc: Default::default(),
-        zk_solc_path: None,
-        zk_bytecode_hash: Default::default(),
-        avoid_contracts: Default::default(),
+        zksync: Default::default(),
     };
     prj.write_config(input.clone());
     let config = cmd.config();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
All zksync related configurations are flattened into the top level `Config` struct, having to deal with duplicated names and need to keep relatively simplified values to encode wanted behavior.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Encapsulate zksync related configuration as to not pollute the top level `Config` struct, allowing a more structured approach to configuration.

This is how `foundry.toml` _can_ look like, with the changes:
```
[zksync] #all configuration below lives inside the `zksync` item
enable = false # can still be enabled from the cli
zksolc = "1.5.0"
force_evmla = true
fallback_oz = true
solc_path = "./solc-0.8.23-1.0.1"
optimizer = true
optimizer_mode = 'z'
```
before:
```
# no section
zksync = true
zksolc = "1.5.0"
force_evmla = true
fallback_oz = true
zk_solc_path = "./solc-0.8.23-1.0.1"
zk_optimizer = true
mode = 'z'
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
