### PR TITLE
feat(create): empty constructor args warning

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -620,7 +620,7 @@ impl CreateArgs {
             tracing::warn!(
                 given = actual_params,
                 expected = expected_params,
-                "not enough or too many constructor args"
+               "Constructor argument mismatch: expected {expected} arguments, but received {given}. Ensure that the number of arguments provided matches the constructor definition."
             );
         }
 

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -620,7 +620,7 @@ impl CreateArgs {
             tracing::warn!(
                 given = actual_params,
                 expected = expected_params,
-               "Constructor argument mismatch: expected {expected} arguments, but received {given}. Ensure that the number of arguments provided matches the constructor definition."
+               "Constructor argument mismatch: expected {expected_params} arguments, but received {actual_params}. Ensure that the number of arguments provided matches the constructor definition."
             );
         }
 

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -66,6 +66,7 @@ pub struct CreateArgs {
         long,
         value_hint = ValueHint::FilePath,
         value_name = "PATH",
+        conflicts_with = "constructor_args",
     )]
     constructor_args_path: Option<PathBuf>,
 
@@ -73,7 +74,8 @@ pub struct CreateArgs {
     #[clap(
         long,
         help = "Deploy the missing dependency libraries from last build.",
-        default_value_t = false
+        default_value_t = false,
+        conflicts_with = "contract"
     )]
     deploy_missing_libraries: bool,
 
@@ -601,7 +603,9 @@ impl CreateArgs {
         constructor: &Constructor,
         constructor_args: &[String],
     ) -> Result<Vec<DynSolValue>> {
-        let mut params = Vec::with_capacity(constructor.inputs.len());
+        let expected_params = constructor.inputs.len();
+
+        let mut params = Vec::with_capacity(expected_params);
         for (input, arg) in constructor.inputs.iter().zip(constructor_args) {
             // resolve the input type directly
             let ty = input
@@ -609,6 +613,17 @@ impl CreateArgs {
                 .wrap_err_with(|| format!("Could not resolve constructor arg: input={input}"))?;
             params.push((ty, arg));
         }
+
+        let actual_params = params.len();
+
+        if actual_params != expected_params {
+            tracing::warn!(
+                given = actual_params,
+                expected = expected_params,
+                "not enough or too many constructor args"
+            );
+        }
+
         let params = params.iter().map(|(ty, arg)| (ty, arg.as_str()));
         parse_tokens(params)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
In an [issue's comment](https://github.com/matter-labs/foundry-zksync/issues/434#issuecomment-2181219499) it was outlined that when creating a contract that expects arguments but none were passed a non-helpful error is thrown.

>Seems like the error code is wrong. It should say like "forgot constructor arguments."

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add a warning when the number of constructor arguments passed doesn't match the expected inputs indicated by the contract's ABI.

This PR also changes the CLI for `create` in 2 ways:
* error if both `--constructor-args` and `--constructor-args-path` are specified, as only the latter would be used
* error if both `--deploy-missing-libraries` and a target contract are specified, as only the former would be used
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
