### PR TITLE
feat(verify): zksync contract verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.2.3"
-source = "git+https://github.com/Moonsong-Labs/block-explorers?branch=zksync-v0.2.3-verify-zksyncio#5cd84407330773f0ded19a52ac5c01a049f202c0"
+source = "git+https://github.com/Moonsong-Labs/block-explorers?branch=zksync-v0.2.3#b442f11077f30584cda7621311ee36a322135b86"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.3.9"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#83a16b319f6f5e25908758a64f90634f58fb7b14"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#0123f4007edd6fbfc74199e9fe85fd885035478f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.2.3"
-source = "git+https://github.com/Moonsong-Labs/block-explorers?branch=zksync-v0.2.3#b442f11077f30584cda7621311ee36a322135b86"
+source = "git+https://github.com/Moonsong-Labs/block-explorers?branch=zksync-v0.2.3-verify-zksyncio#5cd84407330773f0ded19a52ac5c01a049f202c0"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ foundry-zksync-core = { path = "crates/zksync/core" }
 foundry-zksync-compiler = { path = "crates/zksync/compiler" }
 
 # solc & compilation utilities
-foundry-block-explorers = { git = "https://github.com/Moonsong-Labs/block-explorers", branch = "zksync-v0.2.3", default-features = false }
+foundry-block-explorers = { git = "https://github.com/Moonsong-Labs/block-explorers", branch = "zksync-v0.2.3-verify-zksyncio", default-features = false }
 foundry-compilers = { git = "https://github.com/Moonsong-Labs/compilers", branch = "zksync-v0.3.9" }
 
 ## revm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ foundry-zksync-core = { path = "crates/zksync/core" }
 foundry-zksync-compiler = { path = "crates/zksync/compiler" }
 
 # solc & compilation utilities
-foundry-block-explorers = { git = "https://github.com/Moonsong-Labs/block-explorers", branch = "zksync-v0.2.3-verify-zksyncio", default-features = false }
+foundry-block-explorers = { git = "https://github.com/Moonsong-Labs/block-explorers", branch = "zksync-v0.2.3", default-features = false }
 foundry-compilers = { git = "https://github.com/Moonsong-Labs/compilers", branch = "zksync-v0.3.9" }
 
 ## revm

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -392,7 +392,7 @@ impl CreateArgs {
             via_ir: self.opts.via_ir,
             evm_version: self.opts.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
-            zksync: self.opts.compiler.zk.enable,
+            zksync: self.opts.compiler.zk.enabled(),
         };
 
         // Check config for Etherscan API Keys to avoid preflight check failing if no
@@ -588,7 +588,7 @@ impl CreateArgs {
             via_ir: self.opts.via_ir,
             evm_version: self.opts.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
-            zksync: self.opts.compiler.zk.enable,
+            zksync: self.opts.compiler.zk.enabled(),
         };
         println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
         verify.run().await.map(|_| address)

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -392,7 +392,7 @@ impl CreateArgs {
             via_ir: self.opts.via_ir,
             evm_version: self.opts.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
-            zksync: self.opts.compiler.zk.enable
+            zksync: self.opts.compiler.zk.enable,
         };
 
         // Check config for Etherscan API Keys to avoid preflight check failing if no
@@ -588,7 +588,7 @@ impl CreateArgs {
             via_ir: self.opts.via_ir,
             evm_version: self.opts.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
-            zksync: self.opts.compiler.zk.enable
+            zksync: self.opts.compiler.zk.enable,
         };
         println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
         verify.run().await.map(|_| address)

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -392,6 +392,7 @@ impl CreateArgs {
             via_ir: self.opts.via_ir,
             evm_version: self.opts.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
+            zksync: self.opts.compiler.zk.enable
         };
 
         // Check config for Etherscan API Keys to avoid preflight check failing if no
@@ -587,6 +588,7 @@ impl CreateArgs {
             via_ir: self.opts.via_ir,
             evm_version: self.opts.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
+            zksync: self.opts.compiler.zk.enable
         };
         println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
         verify.run().await.map(|_| address)

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -538,7 +538,7 @@ impl CreateArgs {
                     .constructor()
                     .ok_or_else(|| eyre::eyre!("could not find constructor"))?
                     .abi_encode_input(&args)?;
-                constructor_args = Some(hex::encode(encoded_args));
+                constructor_args = Some(hex::encode_prefixed(encoded_args));
             }
 
             self.verify_preflight_check(contract, constructor_args.clone(), chain).await?;

--- a/crates/forge/bin/cmd/script/verify.rs
+++ b/crates/forge/bin/cmd/script/verify.rs
@@ -19,6 +19,7 @@ pub struct VerifyBundle {
     pub retry: RetryArgs,
     pub verifier: VerifierArgs,
     pub via_ir: bool,
+    pub zksync: bool,
 }
 
 impl VerifyBundle {
@@ -46,6 +47,7 @@ impl VerifyBundle {
         };
 
         let via_ir = config.via_ir;
+        let zksync = config.zksync.enable;
 
         VerifyBundle {
             num_of_optimizations,
@@ -55,6 +57,7 @@ impl VerifyBundle {
             retry,
             verifier,
             via_ir,
+            zksync,
         }
     }
 
@@ -116,6 +119,7 @@ impl VerifyBundle {
                     via_ir: self.via_ir,
                     evm_version: None,
                     show_standard_json_input: false,
+                    zksync: self.zksync,
                 };
 
                 return Some(verify)

--- a/crates/forge/bin/cmd/script/verify.rs
+++ b/crates/forge/bin/cmd/script/verify.rs
@@ -47,7 +47,7 @@ impl VerifyBundle {
         };
 
         let via_ir = config.via_ir;
-        let zksync = config.zksync.enable;
+        let zksync = config.zksync.should_compile();
 
         VerifyBundle {
             num_of_optimizations,

--- a/crates/forge/bin/cmd/verify/etherscan/flatten.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/flatten.rs
@@ -10,6 +10,7 @@ use foundry_compilers::{
     AggregatedCompilerOutput, CompilerInput, Project, Solc,
 };
 use semver::{BuildMetadata, Version};
+use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
 #[derive(Debug)]
@@ -21,7 +22,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(String, String, CodeFormat)> {
+    ) -> Result<(Value, String, CodeFormat)> {
         let metadata = project.solc_config.settings.metadata.as_ref();
         let bch = metadata.and_then(|m| m.bytecode_hash).unwrap_or_default();
 
@@ -45,7 +46,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         }
 
         let name = args.contract.name.clone();
-        Ok((source, name, CodeFormat::SingleFile))
+        Ok((Value::from(source), name, CodeFormat::SingleFile))
     }
 
     fn zk_source(
@@ -54,7 +55,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(String, String, CodeFormat)> {
+    ) -> Result<(Value, String, CodeFormat)> {
         let metadata = project.zksync_zksolc_config.settings.metadata.as_ref();
         let bch = metadata.and_then(|m| m.bytecode_hash).unwrap_or_default();
 
@@ -78,7 +79,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         }
 
         let name = args.contract.name.clone();
-        Ok((source, name, CodeFormat::SingleFile))
+        Ok((Value::from(source), name, CodeFormat::SingleFile))
     }
 }
 

--- a/crates/forge/bin/cmd/verify/etherscan/flatten.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/flatten.rs
@@ -10,7 +10,7 @@ use foundry_compilers::{
     AggregatedCompilerOutput, CompilerInput, Project, Solc,
 };
 use semver::{BuildMetadata, Version};
-use serde_json::Value;
+
 use std::{collections::BTreeMap, path::Path};
 
 #[derive(Debug)]

--- a/crates/forge/bin/cmd/verify/etherscan/flatten.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/flatten.rs
@@ -22,7 +22,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(Value, String, CodeFormat)> {
+    ) -> Result<(String, String, CodeFormat)> {
         let metadata = project.solc_config.settings.metadata.as_ref();
         let bch = metadata.and_then(|m| m.bytecode_hash).unwrap_or_default();
 
@@ -46,7 +46,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         }
 
         let name = args.contract.name.clone();
-        Ok((Value::from(source), name, CodeFormat::SingleFile))
+        Ok((source, name, CodeFormat::SingleFile))
     }
 
     fn zk_source(
@@ -55,7 +55,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(Value, String, CodeFormat)> {
+    ) -> Result<(String, String, CodeFormat)> {
         let metadata = project.zksync_zksolc_config.settings.metadata.as_ref();
         let bch = metadata.and_then(|m| m.bytecode_hash).unwrap_or_default();
 
@@ -79,7 +79,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         }
 
         let name = args.contract.name.clone();
-        Ok((Value::from(source), name, CodeFormat::SingleFile))
+        Ok((source, name, CodeFormat::SingleFile))
     }
 }
 

--- a/crates/forge/bin/cmd/verify/etherscan/flatten.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/flatten.rs
@@ -3,6 +3,10 @@ use eyre::{Context, Result};
 use foundry_block_explorers::verify::CodeFormat;
 use foundry_compilers::{
     artifacts::{BytecodeHash, Source},
+    zksync::{
+        artifacts::{BytecodeHash as ZkBytecodeHash, CompilerInput as ZkCompilerInput},
+        compile::{output::AggregatedCompilerOutput as ZkAggregatedCompilerOutput, ZkSolc},
+    },
     AggregatedCompilerOutput, CompilerInput, Project, Solc,
 };
 use semver::{BuildMetadata, Version};
@@ -32,6 +36,39 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         if !args.force {
             // solc dry run of flattened code
             self.check_flattened(source.clone(), version, target).map_err(|err| {
+                eyre::eyre!(
+                    "Failed to compile the flattened code locally: `{}`\
+            To skip this solc dry, have a look at the `--force` flag of this command.",
+                    err
+                )
+            })?;
+        }
+
+        let name = args.contract.name.clone();
+        Ok((source, name, CodeFormat::SingleFile))
+    }
+
+    fn zk_source(
+        &self,
+        args: &VerifyArgs,
+        project: &Project,
+        target: &Path,
+        version: &Version,
+    ) -> Result<(String, String, CodeFormat)> {
+        let metadata = project.zksync_zksolc_config.settings.metadata.as_ref();
+        let bch = metadata.and_then(|m| m.bytecode_hash).unwrap_or_default();
+
+        eyre::ensure!(
+            bch == ZkBytecodeHash::Keccak256,
+            "When using flattened source with zksync, bytecodeHash must be set to keccak256 because Etherscan uses Keccak256 in its Compiler Settings when re-compiling your code. BytecodeHash is currently: {}. Hint: Set the bytecodeHash key in your foundry.toml :)",
+            bch,
+        );
+
+        let source = project.flatten(target).wrap_err("Failed to flatten contract")?;
+
+        if !args.force {
+            // solc dry run of flattened code
+            self.zk_check_flattened(source.clone(), version, target).map_err(|err| {
                 eyre::eyre!(
                     "Failed to compile the flattened code locally: `{}`\
             To skip this solc dry, have a look at the `--force` flag of this command.",
@@ -87,6 +124,55 @@ impl EtherscanFlattenedSource {
 Failed to compile the flattened code locally.
 This could be a bug, please inspect the output of `forge flatten {}` and report an issue.
 To skip this solc dry, pass `--force`.
+Diagnostics: {diags}",
+                contract_path.display()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Attempts to compile the flattened content locally with the zksolc compiler version.
+    ///
+    /// This expects the completely flattened `content´ and will try to compile it using the
+    /// provided compiler. If the compiler is missing it will be installed.
+    ///
+    /// # Errors
+    ///
+    /// If it failed to install a missing solc compiler
+    ///
+    /// # Exits
+    ///
+    /// If the solc compiler output contains errors, this could either be due to a bug in the
+    /// flattening code or could to conflict in the flattened code, for example if there are
+    /// multiple interfaces with the same name.
+    fn zk_check_flattened(
+        &self,
+        content: impl Into<String>,
+        version: &Version,
+        contract_path: &Path,
+    ) -> Result<()> {
+        let version = strip_build_meta(version.clone());
+        let zksolc = ZkSolc::find_installed_version(&version)?
+            .unwrap_or(ZkSolc::blocking_install(&version)?);
+
+        let input = ZkCompilerInput {
+            language: "Solidity".to_string(),
+            sources: BTreeMap::from([("contract.sol".into(), Source::new(content))]),
+            settings: Default::default(),
+        };
+
+        let (out, _) = zksolc.compile(&input)?;
+        if out.has_error() {
+            let mut o = ZkAggregatedCompilerOutput::default();
+            o.extend(version, out);
+            let diags = o.diagnostics(&[], &[], Default::default());
+
+            eyre::bail!(
+                "\
+Failed to compile the flattened code locally.
+This could be a bug, please inspect the output of `forge flatten {}` and report an issue.
+To skip this zksolc dry, pass `--force`.
 Diagnostics: {diags}",
                 contract_path.display()
             );

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -19,7 +19,7 @@ use futures::FutureExt;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use semver::{BuildMetadata, Version};
-use serde_json::Value;
+
 use std::{
     fmt::Debug,
     path::{Path, PathBuf},

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -21,7 +21,8 @@ use regex::Regex;
 use semver::{BuildMetadata, Version};
 use std::{
     fmt::Debug,
-    path::{Path, PathBuf}, str::FromStr,
+    path::{Path, PathBuf},
+    str::FromStr,
 };
 
 mod flatten;
@@ -393,6 +394,7 @@ impl EtherscanVerificationProvider {
             };
         }
 
+        dbg!(&verify_args);
         Ok(verify_args)
     }
 
@@ -452,8 +454,8 @@ impl EtherscanVerificationProvider {
                         .trim_start_matches('v'),
                 )?)
             } else {
-                return Err(eyre!("zkSolc error: {}", String::from_utf8_lossy(&output.stderr)))
-                    .wrap_err("Error retrieving zksolc version with --version");
+                Err(eyre!("zkSolc error: {}", String::from_utf8_lossy(&output.stderr)))
+                    .wrap_err("Error retrieving zksolc version with --version")
             }
         };
 

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -359,10 +359,10 @@ impl EtherscanVerificationProvider {
                     compiler_version = Version::new(solc.major, solc.minor, solc.patch);
                 }
 
-                let compilermode = if zk.is_zksync_solc { "zksync" } else { "solc" }.to_string();
+                let compiler_mode = if zk.is_zksync_solc { "zksync" } else { "solc" }.to_string();
 
                 vec![
-                    ("compilermode".to_string(), compilermode),
+                    ("compilermode".to_string(), compiler_mode),
                     ("zksolcVersion".to_string(), format!("v{}", zk.zksolc)),
                 ]
             }

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -359,14 +359,23 @@ impl EtherscanVerificationProvider {
                 //FIXME: avoid strip metadata
                 if let Some(solc) = zk.solc {
                     compiler_version = Version::new(solc.major, solc.minor, solc.patch);
-                } else  {
-                    compiler_version = Version::new(compiler_version.major, compiler_version.minor, compiler_version.patch);
+                } else {
+                    compiler_version = Version::new(
+                        compiler_version.major,
+                        compiler_version.minor,
+                        compiler_version.patch,
+                    );
                 }
+
+                let compilermode = if zk.is_zksync_solc { "zksync" } else { "solc" }.to_string();
 
                 (
                     //FIXME: allow `v` before solc compiler version
                     format!("{compiler_version}"),
-                    vec![("zkCompilerVersion".to_string(), format!("v{}", zk.zksolc))],
+                    vec![
+                        ("compilermode".to_string(), compilermode),
+                        ("zkCompilerVersion".to_string(), format!("v{}", zk.zksolc)),
+                    ],
                 )
             }
         };

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -394,7 +394,6 @@ impl EtherscanVerificationProvider {
             };
         }
 
-        dbg!(&verify_args);
         Ok(verify_args)
     }
 

--- a/crates/forge/bin/cmd/verify/etherscan/standard_json.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/standard_json.rs
@@ -3,6 +3,7 @@ use eyre::{Context, Result};
 use foundry_block_explorers::verify::CodeFormat;
 use foundry_compilers::{artifacts::StandardJsonCompilerInput, Project};
 use semver::Version;
+use serde_json::Value;
 use std::path::Path;
 
 #[derive(Debug)]
@@ -14,7 +15,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(String, String, CodeFormat)> {
+    ) -> Result<(Value, String, CodeFormat)> {
         let mut input: StandardJsonCompilerInput = project
             .standard_json_input(target)
             .wrap_err("Failed to get standard json input")?
@@ -32,9 +33,9 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         input.settings.sanitize(version);
 
         let source =
-            serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?;
+            serde_json::to_value(&input).wrap_err("Failed to parse standard json input")?;
 
-        trace!(target: "forge::verify", standard_json=source, "determined standard json input");
+        trace!(target: "forge::verify", standard_json=?source, "determined standard json input");
 
         let name = format!(
             "{}:{}",
@@ -50,7 +51,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(String, String, CodeFormat)> {
+    ) -> Result<(Value, String, CodeFormat)> {
         let mut input = project
             .zksync_standard_json_input(target)
             .wrap_err("Failed to get standard json input")?
@@ -65,9 +66,9 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
             .collect();
 
         let source =
-            serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?;
+            serde_json::to_value(&input).wrap_err("Failed to parse standard json input")?;
 
-        trace!(target: "forge::verify", standard_json=source, "determined standard json input");
+        trace!(target: "forge::verify", standard_json=?source, "determined zksync standard json input");
 
         let name = format!(
             "{}:{}",

--- a/crates/forge/bin/cmd/verify/etherscan/standard_json.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/standard_json.rs
@@ -3,7 +3,7 @@ use eyre::{Context, Result};
 use foundry_block_explorers::verify::CodeFormat;
 use foundry_compilers::{artifacts::StandardJsonCompilerInput, Project};
 use semver::Version;
-use serde_json::Value;
+
 use std::path::Path;
 
 #[derive(Debug)]

--- a/crates/forge/bin/cmd/verify/etherscan/standard_json.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/standard_json.rs
@@ -15,7 +15,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(Value, String, CodeFormat)> {
+    ) -> Result<(String, String, CodeFormat)> {
         let mut input: StandardJsonCompilerInput = project
             .standard_json_input(target)
             .wrap_err("Failed to get standard json input")?
@@ -33,7 +33,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         input.settings.sanitize(version);
 
         let source =
-            serde_json::to_value(&input).wrap_err("Failed to parse standard json input")?;
+            serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?;
 
         trace!(target: "forge::verify", standard_json=?source, "determined standard json input");
 
@@ -51,7 +51,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> Result<(Value, String, CodeFormat)> {
+    ) -> Result<(String, String, CodeFormat)> {
         let mut input = project
             .zksync_standard_json_input(target)
             .wrap_err("Failed to get standard json input")?
@@ -66,7 +66,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
             .collect();
 
         let source =
-            serde_json::to_value(&input).wrap_err("Failed to parse standard json input")?;
+            serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?;
 
         trace!(target: "forge::verify", standard_json=?source, "determined zksync standard json input");
 

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -4,7 +4,9 @@ use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::{opts::EtherscanOpts, utils::LoadConfig};
 use foundry_compilers::{info::ContractInfo, EvmVersion};
-use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config, ZkSyncConfig};
+use foundry_config::{
+    figment, impl_figment_convert, impl_figment_convert_cast, Config,
+};
 use provider::VerificationProviderType;
 use reqwest::Url;
 use std::path::PathBuf;

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -4,7 +4,7 @@ use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::{opts::EtherscanOpts, utils::LoadConfig};
 use foundry_compilers::{info::ContractInfo, EvmVersion};
-use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config};
+use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config, ZkSyncConfig};
 use provider::VerificationProviderType;
 use reqwest::Url;
 use std::path::PathBuf;
@@ -117,6 +117,10 @@ pub struct VerifyArgs {
 
     #[clap(flatten)]
     pub verifier: VerifierArgs,
+
+    /// Verify for zksync
+    #[clap(long)]
+    pub zksync: bool,
 }
 
 impl_figment_convert!(VerifyArgs);
@@ -146,6 +150,11 @@ impl figment::Provider for VerifyArgs {
         if self.via_ir {
             dict.insert("via_ir".to_string(), figment::value::Value::serialize(self.via_ir)?);
         }
+
+        if self.zksync {
+            dict.insert("zksync".to_string(), figment::value::Value::serialize(ZkSyncConfig{ enable: self.zksync, ..Default::default() })?);
+        }
+
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -4,9 +4,7 @@ use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::{opts::EtherscanOpts, utils::LoadConfig};
 use foundry_compilers::{info::ContractInfo, EvmVersion};
-use foundry_config::{
-    figment, impl_figment_convert, impl_figment_convert_cast, Config,
-};
+use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config};
 use provider::VerificationProviderType;
 use reqwest::Url;
 use std::path::PathBuf;

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -151,10 +151,6 @@ impl figment::Provider for VerifyArgs {
             dict.insert("via_ir".to_string(), figment::value::Value::serialize(self.via_ir)?);
         }
 
-        if self.zksync {
-            dict.insert("zksync".to_string(), figment::value::Value::serialize(ZkSyncConfig{ enable: self.zksync, ..Default::default() })?);
-        }
-
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/zk-tests/foundry.toml
+++ b/zk-tests/foundry.toml
@@ -12,3 +12,6 @@ local = "${ERA_TEST_NODE_RPC_URL}"
 mainnet = "https://mainnet.era.zksync.io:443"
 testnet = "https://testnet.era.zksync.dev:443"
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
+
+[etherscan]
+testnet = { key = "IGNOREME", chain = "300", url = "https://block-explorer-api.sepolia.zksync.dev/api" }

--- a/zk-tests/foundry.toml
+++ b/zk-tests/foundry.toml
@@ -14,4 +14,4 @@ testnet = "https://testnet.era.zksync.dev:443"
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 
 [etherscan]
-testnet = { key = "IGNOREME", chain = "300", url = "https://block-explorer-api.sepolia.zksync.dev/api" }
+testnet = { key = "PLACEHOLDER", chain = "300", url = "https://api-sepolia-era.zksync.network/api" }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #102 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
We need to add 2 fields to the Etherscan request to make it compatible with their API for ZkSync:
* `compilermode` to indicate wheter to use `zksync-solc` or just `solc` with `zksolc`
* `zksolcVersion` to indicate the version of `zksolc` in use

We also have to provide the zksolc settings instead of the solc ones.

~~### Warning
The current version of the branch most likely breaks compatibility with Etherscan, instead focusing on https://explorer.zksync.io compatibility.
Please use the API endpoints listed [in the docs](https://docs.zksync.io/build/tooling/zksync-block-explorers#block-explorer-api). An API key is **_not_** required by these endpoints, but `forge` still requires the value to be present, which can be anything.~~