### PR TITLE
fix: script [upstream merge]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4705,6 +4705,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "yansi 1.0.1",
+ "zksync-web3-rs",
 ]
 
 [[package]]
@@ -5346,6 +5347,7 @@ dependencies = [
 name = "foundry-zksync-core"
 version = "0.0.2"
 dependencies = [
+ "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-sol-types",
  "ansi_term",
@@ -5359,6 +5361,7 @@ dependencies = [
  "multivm",
  "once_cell",
  "revm",
+ "serde_json",
  "tracing",
  "url",
  "zksync-web3-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5347,6 +5347,7 @@ dependencies = [
 name = "foundry-zksync-core"
 version = "0.0.2"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-sol-types",

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -57,5 +57,8 @@ alloy-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-transport.workspace = true
 
+# zksync
+zksync-web3-rs.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -143,6 +143,7 @@ impl LinkedBuildData {
             Some(&libraries),
         )?;
 
+        //TODO: zk contracts?
         let known_contracts =
             ContractsByArtifact::new(build_data.get_linker().get_linked_artifacts(&libraries)?);
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -63,6 +63,7 @@ impl LinkedState {
 
         let target_contract = build_data.get_target_contract()?;
 
+        //TODO: zk bytecode? factory deps?
         let bytecode = target_contract.bytecode().ok_or_eyre("target contract has no bytecode")?;
 
         let (func, calldata) = args.get_method_and_calldata(&target_contract.abi)?;

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -2,7 +2,7 @@ use alloy_chains::Chain;
 use alloy_primitives::{utils::format_units, TxHash, U256};
 use alloy_provider::{PendingTransactionBuilder, Provider};
 use alloy_rpc_types::AnyTransactionReceipt;
-use eyre::Result;
+use eyre::{Context, Result};
 use foundry_common::provider::RetryProvider;
 use std::time::Duration;
 

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -10,6 +10,7 @@ use crate::{
     build::LinkedBuildData,
     execute::{ExecutionArtifacts, ExecutionData},
     sequence::get_commit_hash,
+    transaction::ZkTransaction,
     ScriptArgs, ScriptConfig, ScriptResult,
 };
 use alloy_network::TransactionBuilder;
@@ -135,7 +136,7 @@ impl PreSimulationState {
                         tx.gas = Some(gas as u128);
                     }
                 }
-                let tx = TransactionWithMetadata::new(
+                let tx = TransactionWithMetadata::new_with_zk(
                     tx,
                     rpc,
                     &result,
@@ -143,6 +144,7 @@ impl PreSimulationState {
                     &self.execution_artifacts.decoder,
                     created_contracts,
                     is_fixed_gas_limit,
+                    zk.map(|zk_tx| ZkTransaction { factory_deps: zk_tx.factory_deps }),
                 )?;
 
                 eyre::Ok((Some(tx), result.traces))

--- a/crates/zksync/core/Cargo.toml
+++ b/crates/zksync/core/Cargo.toml
@@ -17,6 +17,7 @@ foundry-cheatcodes-common.workspace = true
 foundry-zksync-compiler.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
+alloy-dyn-abi.workspace = true
 hex.workspace = true
 itertools.workspace = true
 revm = { workspace = true, default-features = false, features = [
@@ -30,6 +31,7 @@ revm = { workspace = true, default-features = false, features = [
     "optimism",
 ] }
 tracing.workspace = true
+serde_json.workspace = true
 
 # zk
 multivm.workspace = true

--- a/crates/zksync/core/Cargo.toml
+++ b/crates/zksync/core/Cargo.toml
@@ -18,6 +18,7 @@ foundry-zksync-compiler.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 alloy-dyn-abi.workspace = true
+alloy-consensus.workspace = true
 hex.workspace = true
 itertools.workspace = true
 revm = { workspace = true, default-features = false, features = [

--- a/crates/zksync/core/src/convert.rs
+++ b/crates/zksync/core/src/convert.rs
@@ -156,7 +156,12 @@ impl ConvertSignature for ZkSignature {
 
 impl ConvertSignature for AlloySignature {
     fn to_ethers(self) -> ZkSignature {
-        ZkSignature { r: self.r().to_u256(), s: self.s().to_u256(), v: self.v().to_u64() }
+        let v = self.v();
+        ZkSignature {
+            r: self.r().to_u256(),
+            s: self.s().to_u256(),
+            v: v.y_parity_byte_non_eip155().unwrap_or(v.y_parity_byte()) as u64,
+        }
     }
 
     fn to_alloy(self) -> AlloySignature {

--- a/crates/zksync/core/src/convert.rs
+++ b/crates/zksync/core/src/convert.rs
@@ -5,6 +5,12 @@ use revm::primitives::{Address, B256};
 use zksync_basic_types::{H160, H256, U256};
 use zksync_utils::{address_to_h256, h256_to_u256, u256_to_h256};
 
+use alloy_primitives::{Bytes as AlloyBytes, Signature as AlloySignature};
+use zksync_web3_rs::types::{Bytes as ZkBytes, Signature as ZkSignature};
+
+mod eip712;
+pub use eip712::*;
+
 /// Conversions from [U256]
 pub trait ConvertU256 {
     /// Convert to [rU256]
@@ -127,6 +133,62 @@ impl ConvertAddress for Address {
 
     fn to_h160(self) -> H160 {
         H160::from(self.0 .0)
+    }
+}
+
+/// Conversions to/from [`ZkSignature`] & [`AlloySignature`]
+pub trait ConvertSignature {
+    /// Cast to [`ZkSignature`]
+    fn to_ethers(self) -> ZkSignature;
+    /// Cast to [`AlloySignature`]
+    fn to_alloy(self) -> AlloySignature;
+}
+
+impl ConvertSignature for ZkSignature {
+    fn to_ethers(self) -> ZkSignature {
+        self
+    }
+
+    fn to_alloy(self) -> AlloySignature {
+        AlloySignature::from_rs_and_parity(self.r.to_ru256(), self.s.to_ru256(), self.v).unwrap()
+    }
+}
+
+impl ConvertSignature for AlloySignature {
+    fn to_ethers(self) -> ZkSignature {
+        ZkSignature { r: self.r().to_u256(), s: self.s().to_u256(), v: self.v().to_u64() }
+    }
+
+    fn to_alloy(self) -> AlloySignature {
+        self
+    }
+}
+
+/// Convert to/from [`AlloyBytes`] & [`ZkBytes`]
+pub trait ConvertBytes {
+    /// Convert to [`AlloyBytes`]
+    fn to_alloy(self) -> AlloyBytes;
+    /// Convert to [`ZkBytes`]
+    fn to_ethers(self) -> ZkBytes;
+}
+
+impl ConvertBytes for AlloyBytes {
+    fn to_alloy(self) -> AlloyBytes {
+        self
+    }
+
+    fn to_ethers(self) -> ZkBytes {
+        ZkBytes(self.0)
+    }
+}
+
+impl ConvertBytes for ZkBytes {
+    fn to_alloy(self) -> AlloyBytes {
+        AlloyBytes(self.0)
+    }
+
+    fn to_ethers(self) -> ZkBytes {
+        self
     }
 }
 

--- a/crates/zksync/core/src/convert/eip712.rs
+++ b/crates/zksync/core/src/convert/eip712.rs
@@ -1,0 +1,114 @@
+
+use alloy_dyn_abi::TypedData;
+/// Conversion between ethers and alloy for EIP712 items
+use alloy_sol_types::{Eip712Domain as AlloyEip712Domain};
+use zksync_web3_rs::{
+    eip712::Eip712Transaction,
+    types::transaction::eip712::{
+        encode_type, EIP712Domain as EthersEip712Domain, Eip712 as EthersEip712, Eip712DomainType,
+        Types,
+    },
+};
+
+use super::{ConvertAddress, ConvertH160, ConvertRU256, ConvertU256};
+
+/// Convert between Eip712Domain types
+pub trait ConvertEIP712Domain {
+    /// Cast to ethers-rs's Eip712Domain
+    fn to_ethers(self) -> EthersEip712Domain;
+
+    /// Cast to alloy-rs's Eip712Domain
+    fn to_alloy(self) -> AlloyEip712Domain;
+}
+
+impl ConvertEIP712Domain for AlloyEip712Domain {
+    fn to_ethers(self) -> EthersEip712Domain {
+        EthersEip712Domain {
+            name: self.name.map(Into::into),
+            version: self.version.map(Into::into),
+            chain_id: self.chain_id.map(ConvertRU256::to_u256),
+            verifying_contract: self.verifying_contract.map(ConvertAddress::to_h160),
+            salt: self.salt.map(Into::into),
+        }
+    }
+
+    fn to_alloy(self) -> AlloyEip712Domain {
+        self
+    }
+}
+
+impl ConvertEIP712Domain for EthersEip712Domain {
+    fn to_ethers(self) -> EthersEip712Domain {
+        self
+    }
+
+    fn to_alloy(self) -> AlloyEip712Domain {
+        AlloyEip712Domain::new(
+            self.name.map(Into::into),
+            self.version.map(Into::into),
+            self.chain_id.map(ConvertU256::to_ru256),
+            self.verifying_contract.map(ConvertH160::to_address),
+            self.salt.map(Into::into),
+        )
+    }
+}
+
+/// Convert to [`TypedData`]
+pub trait ToTypedData {
+    /// Convert item to [`TypedData`]
+    fn to_typed_data(self) -> TypedData;
+}
+
+impl ToTypedData for Eip712Transaction {
+    fn to_typed_data(self) -> TypedData {
+        use alloy_dyn_abi::*;
+
+        let types = eip712_transaction_types();
+        let primary_type = types.first_key_value().unwrap().0.clone();
+
+        let domain = EthersEip712::domain(&self).expect("Eip712Transaction has domain").to_alloy();
+
+        let message = serde_json::to_value(&self).expect("able to serialize as json");
+
+        let encode_type = encode_type(&primary_type, &types).expect("able to encodeType");
+
+        let resolver = {
+            let mut resolver = Resolver::default();
+            resolver.ingest_string(&encode_type).expect("able to ingest encodeType");
+            resolver
+        };
+
+        TypedData { domain, resolver, primary_type, message }
+    }
+}
+
+//zksync_web3_rs::eip712::transaction
+fn eip712_transaction_types() -> Types {
+    let mut types = Types::new();
+
+    types.insert(
+        "Transaction".to_owned(),
+        vec![
+            Eip712DomainType { name: "txType".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType { name: "from".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType { name: "to".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType { name: "gasLimit".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType {
+                name: "gasPerPubdataByteLimit".to_owned(),
+                r#type: "uint256".to_owned(),
+            },
+            Eip712DomainType { name: "maxFeePerGas".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType {
+                name: "maxPriorityFeePerGas".to_owned(),
+                r#type: "uint256".to_owned(),
+            },
+            Eip712DomainType { name: "paymaster".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType { name: "nonce".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType { name: "value".to_owned(), r#type: "uint256".to_owned() },
+            Eip712DomainType { name: "data".to_owned(), r#type: "bytes".to_owned() },
+            Eip712DomainType { name: "factoryDeps".to_owned(), r#type: "bytes32[]".to_owned() },
+            Eip712DomainType { name: "paymasterInput".to_owned(), r#type: "bytes".to_owned() },
+        ],
+    );
+    types
+}

--- a/crates/zksync/core/src/convert/eip712.rs
+++ b/crates/zksync/core/src/convert/eip712.rs
@@ -54,7 +54,7 @@ impl ConvertEIP712Domain for EthersEip712Domain {
     }
 }
 
-/// Wrapper around [`Eip721Transaction`] implementing [`SignableTransaction`]
+/// Wrapper around [`Eip712Transaction`] implementing [`SignableTransaction`]
 pub struct Eip712SignableTransaction(Eip712Transaction);
 
 impl Transaction for Eip712SignableTransaction {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Forward-port scripting changes to `foundry-update-4af6cfa`.
Added a few more conversion for types as more things have been moved to alloy.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Notes

Tested slightly locally but `--broadcast` fails with `era-test-node`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
