### PR TITLE
fix: batch factory deps for broadcastable tx

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1631,7 +1631,7 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
                         // the last batch is the final one that does the deployment
                         zk_tx = batched.pop();
 
-                        for factory_deps in batched.into_iter() {
+                        for factory_deps in batched {
                             self.broadcastable_transactions.push_back(BroadcastableTransaction {
                                 rpc: rpc.clone(),
                                 transaction: TransactionRequest {

--- a/crates/evm/core/src/backend/fuzz.rs
+++ b/crates/evm/core/src/backend/fuzz.rs
@@ -53,13 +53,14 @@ impl<'a> FuzzBackendWrapper<'a> {
     pub fn inspect_ref_zk(
         &mut self,
         env: &mut Env,
+        persisted_factory_deps: &mut HashMap<foundry_zksync_core::H256, Vec<u8>>,
         factory_deps: Option<Vec<Vec<u8>>>,
     ) -> eyre::Result<ResultAndState> {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
         // already, we reset the initialized state
         self.is_initialized = false;
 
-        foundry_zksync_core::vm::transact(factory_deps, env, self)
+        foundry_zksync_core::vm::transact(Some(persisted_factory_deps), factory_deps, env, self)
     }
 
     /// Executes the configured transaction of the `env` without committing state changes

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -840,11 +840,12 @@ impl Backend {
     pub fn inspect_ref_zk(
         &mut self,
         env: &mut Env,
+        persisted_factory_deps: &mut HashMap<foundry_zksync_core::H256, Vec<u8>>,
         factory_deps: Option<Vec<Vec<u8>>>,
     ) -> eyre::Result<ResultAndState> {
         self.initialize(env);
 
-        foundry_zksync_core::vm::transact(factory_deps, env, self)
+        foundry_zksync_core::vm::transact(Some(persisted_factory_deps), factory_deps, env, self)
     }
 
     /// Returns true if the address is a precompile

--- a/crates/forge/bin/cmd/script/broadcast.rs
+++ b/crates/forge/bin/cmd/script/broadcast.rs
@@ -661,7 +661,7 @@ impl ScriptArgs {
                 .nonce(legacy_or_1559.nonce().unwrap())
                 .gas_price(legacy_or_1559.gas_price().unwrap())
                 .max_fee_per_gas(legacy_or_1559.max_cost().unwrap())
-                .data(legacy_or_1559.data().cloned().unwrap())
+                .data(legacy_or_1559.data().cloned().unwrap_or_default())
                 .custom_data(custom_data);
 
             let gas_price = provider.get_gas_price().await?;

--- a/crates/forge/bin/cmd/script/executor.rs
+++ b/crates/forge/bin/cmd/script/executor.rs
@@ -106,7 +106,7 @@ impl ScriptArgs {
         contracts: &ContractsByArtifact,
         dual_compiled_contracts: Option<DualCompiledContracts>,
     ) -> Result<VecDeque<TransactionWithMetadata>> {
-        trace!(target: "script", "executing onchain simulation");
+        trace!(target: "script", ?transactions, "executing onchain simulation");
 
         let runners = Arc::new(
             self.build_runners(script_config, dual_compiled_contracts)

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -27,7 +27,7 @@ pub use vm::{balance, encode_create_params, nonce};
 use zksync_types::utils::storage_key_for_eth_balance;
 pub use zksync_types::{
     ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, L2_BASE_TOKEN_ADDRESS,
-    NONCE_HOLDER_ADDRESS,
+    NONCE_HOLDER_ADDRESS, H256,
 };
 pub use zksync_utils::bytecode::hash_bytecode;
 use zksync_web3_rs::{

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -26,8 +26,8 @@ pub use vm::{balance, encode_create_params, nonce};
 
 use zksync_types::utils::storage_key_for_eth_balance;
 pub use zksync_types::{
-    ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, L2_BASE_TOKEN_ADDRESS,
-    NONCE_HOLDER_ADDRESS, H256,
+    ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H256, L2_BASE_TOKEN_ADDRESS,
+    NONCE_HOLDER_ADDRESS,
 };
 pub use zksync_utils::bytecode::hash_bytecode;
 use zksync_web3_rs::{

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -505,7 +505,7 @@ pub const MAX_FACTORY_DEPENDENCIES_SIZE_BYTES: usize = 100000; // 100kB
 /// For large factory_deps the VM can run out of gas. To avoid this case we batch factory_deps
 /// on the basis of [MAX_FACTORY_DEPENDENCIES_SIZE_BYTES] and deploy all but the last batch
 /// via empty transactions, with the last one deployed normally via create.
-fn batch_factory_dependencies(mut factory_deps: Vec<Vec<u8>>) -> Vec<Vec<Vec<u8>>> {
+pub fn batch_factory_dependencies(mut factory_deps: Vec<Vec<u8>>) -> Vec<Vec<Vec<u8>>> {
     let factory_deps_count = factory_deps.len();
     let factory_deps_sizes = factory_deps.iter().map(|dep| dep.len()).collect_vec();
     let factory_deps_total_size = factory_deps_sizes.iter().sum::<usize>();

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -349,6 +349,7 @@ fn inspect_inner<S: ReadStorage + Send>(
             expected_calls.insert(*addr, v.clone());
         }
     }
+    let is_static = call_ctx.is_static;
     let tracers = vec![
         CallTracer::new(call_tracer_result.clone()).into_tracer_pointer(),
         CheatcodeTracer::new(
@@ -414,7 +415,13 @@ fn inspect_inner<S: ReadStorage + Send>(
         .iter()
         .map(|b| bytecode_to_factory_dep(b.original.clone()))
         .collect();
-    let modified_keys = storage.borrow().modified_storage_keys().clone();
+
+    let modified_keys = if is_static {
+        Default::default()
+    } else {
+        storage.borrow().modified_storage_keys().clone()
+    };
+
     (tx_result, bytecodes, modified_keys)
 }
 

--- a/crates/zksync/core/src/vm/mod.rs
+++ b/crates/zksync/core/src/vm/mod.rs
@@ -6,6 +6,8 @@ mod runner;
 mod storage_view;
 mod tracer;
 
-pub use inspect::{inspect, inspect_as_batch, ZKVMExecutionResult, ZKVMResult};
+pub use inspect::{
+    batch_factory_dependencies, inspect, inspect_as_batch, ZKVMExecutionResult, ZKVMResult,
+};
 pub use runner::{balance, call, code_hash, create, encode_create_params, nonce, transact};
 pub use tracer::CheatcodeTracerContext;

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -82,6 +82,7 @@ where
         block_timestamp: env.block.timestamp,
         block_basefee: min(max_fee_per_gas.to_ru256(), env.block.basefee),
         is_create,
+        is_static: false,
     };
 
     let mut cheatcode_tracer_context =
@@ -191,6 +192,7 @@ where
         block_timestamp: env.block.timestamp,
         block_basefee: min(max_fee_per_gas.to_ru256(), env.block.basefee),
         is_create: true,
+        is_static: false,
     };
 
     inspect_as_batch(tx, env, db, journaled_state, &mut ccx, call_ctx)
@@ -246,6 +248,7 @@ where
         block_timestamp: env.block.timestamp,
         block_basefee: min(max_fee_per_gas.to_ru256(), env.block.basefee),
         is_create: false,
+        is_static: call.is_static,
     };
 
     inspect(tx, env, db, journaled_state, &mut ccx, call_ctx)

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -14,7 +14,7 @@ use zksync_types::{
     U256,
 };
 
-use std::{cmp::min, fmt::Debug};
+use std::{cmp::min, collections::HashMap, fmt::Debug};
 
 use crate::{
     convert::{ConvertAddress, ConvertH160, ConvertRU256, ConvertU256},
@@ -36,7 +36,7 @@ where
     DB: Database + Send,
     <DB as Database>::Error: Debug,
 {
-    debug!("zk transact");
+    debug!(calldata = ?env.tx.data, fdeps = factory_deps.as_ref().map(|v| v.len()).unwrap_or_default(), "zk transact");
     let mut journaled_state = JournaledState::new(
         env.cfg.spec_id,
         Precompiles::new(to_precompile_id(env.cfg.spec_id))
@@ -55,7 +55,7 @@ where
     };
 
     let (gas_limit, max_fee_per_gas) = gas_params(env, db, &mut journaled_state, caller);
-    info!(?gas_limit, ?max_fee_per_gas, "tx gas parameters");
+    debug!(?gas_limit, ?max_fee_per_gas, "tx gas parameters");
     let tx = L2Tx::new(
         transact_to,
         env.tx.data.to_vec(),

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -28,6 +28,7 @@ use crate::{
 
 /// Transacts
 pub fn transact<'a, DB>(
+    persisted_factory_deps: Option<&'a mut HashMap<H256, Vec<u8>>>,
     factory_deps: Option<Vec<Vec<u8>>>,
     env: &'a mut Env,
     db: &'a mut DB,
@@ -83,12 +84,15 @@ where
         is_create,
     };
 
+    let mut cheatcode_tracer_context =
+        CheatcodeTracerContext { persisted_factory_deps, ..Default::default() };
+
     match inspect::<_, DB::Error>(
         tx,
         env,
         db,
         &mut journaled_state,
-        &mut Default::default(),
+        &mut cheatcode_tracer_context,
         call_ctx,
     ) {
         Ok(ZKVMExecutionResult { execution_result: result, .. }) => {

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -107,6 +107,8 @@ pub struct CallContext {
     pub block_basefee: rU256,
     /// Whether the current call is a create.
     pub is_create: bool,
+    /// Whether the current call is a static call.
+    pub is_static: bool,
 }
 
 /// A tracer to allow for foundry-specific functionality.

--- a/zk-tests/script/Deploy.s.sol
+++ b/zk-tests/script/Deploy.s.sol
@@ -51,9 +51,16 @@ contract DeployScript is Script {
         );
         require(success, "zkVm() call failed");
         vm.startBroadcast();
+
         greeter = new Greeter();
-        greeter.greeting("john");
         greeter.setAge(123);
+
+        uint256 age = greeter.getAge();
+
+        greeter.greeting("john");
+
         vm.stopBroadcast();
+
+        assert(age == 123);
     }
 }

--- a/zk-tests/script/Deploy.s.sol
+++ b/zk-tests/script/Deploy.s.sol
@@ -2,41 +2,7 @@
 pragma solidity ^0.8.18;
 
 import {Script} from "forge-std/Script.sol";
-import {Test} from "forge-std/Test.sol";
-import {console2 as console} from "forge-std/console2.sol";
-
-contract Greeter {
-    string name;
-    uint256 age;
-
-    event Greet(string greet);
-
-    function greeting(string memory _name) public returns (string memory) {
-        name = _name;
-        string memory greet = string(abi.encodePacked("Hello ", _name));
-        emit Greet(greet);
-        return greet;
-    }
-
-    function greeting2(
-        string memory _name,
-        uint256 n
-    ) public returns (uint256) {
-        name = _name;
-        string memory greet = string(abi.encodePacked("Hello ", _name));
-        console.log(name);
-        emit Greet(greet);
-        return n * 2;
-    }
-
-    function setAge(uint256 _age) public {
-        age = _age;
-    }
-
-    function getAge() public view returns (uint256) {
-        return age;
-    }
-}
+import {Greeter} from "../src/Greeter.sol";
 
 contract DeployScript is Script {
     // Vm constant vm = Vm(HEVM_ADDRESS);
@@ -53,8 +19,8 @@ contract DeployScript is Script {
         vm.startBroadcast();
 
         greeter = new Greeter();
-        greeter.setAge(123);
 
+        greeter.setAge(123);
         uint256 age = greeter.getAge();
 
         greeter.greeting("john");

--- a/zk-tests/src/Greeter.sol
+++ b/zk-tests/src/Greeter.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+contract Greeter {
+    string name;
+    uint256 age;
+
+    event Greet(string greet);
+
+    function greeting(string memory _name) public returns (string memory) {
+        name = _name;
+
+        string memory greet = string(abi.encodePacked("Hello ", _name));
+        emit Greet(greet);
+
+        return greet;
+    }
+
+    function greeting2(
+        string memory _name,
+        uint256 n
+    ) public returns (uint256) {
+        name = _name;
+
+        string memory greet = string(abi.encodePacked("Hello ", _name));
+        emit Greet(greet);
+
+        return n * 2;
+    }
+
+    function setAge(uint256 _age) public {
+        age = _age;
+    }
+
+    function getAge() public view returns (uint256) {
+        return age;
+    }
+}

--- a/zk-tests/src/LargeFactoryDependencies.t.sol
+++ b/zk-tests/src/LargeFactoryDependencies.t.sol
@@ -2,10 +2,18 @@
 pragma solidity ^0.8.18;
 
 import "forge-std/Test.sol";
+import "forge-std/Script.sol";
 import {LargeContract} from "./LargeContracts.sol";
 
 contract ZkLargeFactoryDependenciesTest is Test {
     function testLargeFactoryDependenciesAreDeployedInBatches() public {
+        new LargeContract();
+    }
+}
+
+contract ZkLargeFactoryDependenciesScript is Script {
+    function run() external {
+        vm.broadcast();
         new LargeContract();
     }
 }

--- a/zk-tests/test.sh
+++ b/zk-tests/test.sh
@@ -148,6 +148,9 @@ echo "Running script..."
 RUST_LOG=warn "${FORGE}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "$PRIVATE_KEY" --chain 260 --gas-estimate-multiplier 310 --rpc-url "$RPC_URL" --use "./${SOLC}" --slow  -vvv  --zk-compile || fail "forge script failed"
 RUST_LOG=warn "${FORGE}" script ./script/Deploy.s.sol:DeployScript --broadcast --private-key "$PRIVATE_KEY" --chain 260 --gas-estimate-multiplier 310 --rpc-url "$RPC_URL" --use "./${SOLC}" --slow  -vvv  --zk-compile || fail "forge script failed on 2nd deploy"
 
+echo "Running factory deps script..."
+RUST_LOG=warn "${FORGE}" script ./src/LargeFactoryDependencies.t.sol:ZkLargeFactoryDependenciesScript --broadcast --private-key "$PRIVATE_KEY" --chain 260 --gas-estimate-multiplier 310 --rpc-url "$RPC_URL" --use "./${SOLC}" --slow -vvv --zk-startup || fail "forge script failed"
+
 echo "Running NFT script"
 RUST_LOG=warn "${FORGE}" script ./script/NFT.s.sol:MyScript --broadcast --private-key $PRIVATE_KEY --rpc-url $RPC_URL --use 0.8.20 --zk-startup || fail "forge script failed"
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Batching factory deps has been added since #412, but support for broadcastable tx (and create) was never done.
After investigating #450 it became clear that the simulation issue was due to this missing feature.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
1. Batch factory deps in broadcastable txns, creating new transactions as needed
2. Add support for `persisted_factory_deps` for `transact`, used in simulation
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
