### PR TITLE
feat: implement changes for zksolc 1.5.1 (compilers-3.9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.3.9"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#1fe3c55220272edfcc2dcda7e2ff659064b34e7e"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.3.9#470e9610ef5eed5a34224b7e25a7d60cd9d2d10b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -40,7 +40,7 @@ pub struct ZkSyncArgs {
     /// A flag indicating whether to enable the system contract compilation mode.
     #[clap(
         help = "Enable the system contract compilation mode.",
-        long = "zk-eravm-extensions",
+        long = "zk-enable-eravm-extensions",
         visible_alias = "enable-eravm-extensions",
         visible_alias = "system-mode",
         value_name = "ENABLE_ERAVM_EXTENSIONS",
@@ -49,7 +49,7 @@ pub struct ZkSyncArgs {
         default_missing_value = "true"
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eravm_extensions: Option<bool>,
+    pub enable_eravm_extensions: Option<bool>,
 
     /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
     #[clap(
@@ -63,6 +63,11 @@ pub struct ZkSyncArgs {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force_evmla: Option<bool>,
+
+    /// ZkSolc extra LLVM options
+    #[clap(help = "ZkSolc extra LLVM options", long = "zk-llvm-options")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llvm_options: Option<Vec<String>>,
 
     /// Try to recompile with -Oz if the bytecode is too large.
     #[clap(
@@ -120,7 +125,8 @@ impl ZkSyncArgs {
         set_if_some!(self.compile, zksync.compile);
         set_if_some!(self.startup, zksync.startup);
         set_if_some!(self.solc_path.clone(), zksync.solc_path);
-        set_if_some!(self.eravm_extensions, zksync.eravm_extensions);
+        set_if_some!(self.enable_eravm_extensions, zksync.enable_eravm_extensions);
+        set_if_some!(self.llvm_options.clone(), zksync.llvm_options);
         set_if_some!(self.force_evmla, zksync.force_evmla);
         set_if_some!(self.fallback_oz, zksync.fallback_oz);
         set_if_some!(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -713,7 +713,7 @@ impl Config {
             // if none is found, but maybe we should mirror auto detect settings
             // as done with solc
             if !self.offline {
-                let default_version = Version::new(1, 4, 1);
+                let default_version = Version::new(1, 5, 1);
                 let mut zksolc = ZkSolc::find_installed_version(&default_version)?;
                 if zksolc.is_none() {
                     ZkSolc::blocking_install(&default_version)?;

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -36,10 +36,10 @@ pub struct ZkSyncConfig {
     /// Force evmla for zkSync
     pub force_evmla: bool,
 
+    /// The extra LLVM options.
     pub llvm_options: Vec<String>,
+
     /// Detect missing libraries, instead of erroring
-    ///
-    /// Currently unused
     pub detect_missing_libraries: bool,
 
     /// Source files to avoid compiling on zksolc

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -31,11 +31,12 @@ pub struct ZkSyncConfig {
     pub fallback_oz: bool,
 
     /// Whether to support compilation of zkSync-specific simulations
-    pub eravm_extensions: bool,
+    pub enable_eravm_extensions: bool,
 
     /// Force evmla for zkSync
     pub force_evmla: bool,
 
+    pub llvm_options: Vec<String>,
     /// Detect missing libraries, instead of erroring
     ///
     /// Currently unused
@@ -63,9 +64,10 @@ impl Default for ZkSyncConfig {
             solc_path: Default::default(),
             bytecode_hash: Default::default(),
             fallback_oz: Default::default(),
-            eravm_extensions: Default::default(),
+            enable_eravm_extensions: Default::default(),
             force_evmla: Default::default(),
             detect_missing_libraries: Default::default(),
+            llvm_options: Default::default(),
             avoid_contracts: Default::default(),
             optimizer: true,
             optimizer_mode: '3',
@@ -110,8 +112,9 @@ impl ZkSyncConfig {
             // Set in project paths.
             remappings: Vec::new(),
             detect_missing_libraries: self.detect_missing_libraries,
-            system_mode: self.eravm_extensions,
+            enable_eravm_extensions: self.enable_eravm_extensions,
             force_evmla: self.force_evmla,
+            llvm_options: self.llvm_options.clone(),
             // TODO: See if we need to set this from here
             output_selection: Default::default(),
             solc: self.solc_path.clone(),


### PR DESCRIPTION
https://github.com/matter-labs/foundry-zksync/pull/460 adapted to before the dependency update so `1.5.1` can be used before merging those changes.