### PR TITLE
feat: use default EvmVersion on default Config

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2138,7 +2138,7 @@ impl Default for Config {
             allow_paths: vec![],
             include_paths: vec![],
             force: false,
-            evm_version: EvmVersion::Paris,
+            evm_version: EvmVersion::default(),
             gas_reports: vec!["*".to_string()],
             gas_reports_ignore: vec![],
             solc: None,


### PR DESCRIPTION
## Motivation

Default `evm_version` on `Config` was being hardcoded to `Paris` even though the default value was `Cancun`

## Solution

Use `Default::default()` to set `evm_version` so we keep up to date with whatever version is set upstream.
