### PR TITLE
chore(deps): bump watchexec to 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,11 +1114,11 @@ dependencies = [
 
 [[package]]
 name = "async-priority-channel"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21678992e1b21bebfe2bc53ab5f5f68c106eddab31b24e0bb06e9b715a86640"
+checksum = "acde96f444d31031f760c5c43dc786b97d3e1cb2ee49dd06898383fe9a999758"
 dependencies = [
- "event-listener 2.5.3",
+ "event-listener 4.0.3",
 ]
 
 [[package]]
@@ -2016,15 +2016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "btoi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,11 +2569,11 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clearscreen"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994"
+checksum = "2f8c93eb5f77c9050c7750e14f13ef1033a40a0aac70c6371535b6763a01438c"
 dependencies = [
- "nix 0.26.4",
+ "nix 0.28.0",
  "terminfo",
  "thiserror",
  "which",
@@ -2779,18 +2770,6 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width",
-]
-
-[[package]]
-name = "command-group"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5080df6b0f0ecb76cab30808f00d937ba725cebe266a3da8cd89dff92f2a9916"
-dependencies = [
- "async-trait",
- "nix 0.26.4",
- "tokio",
- "winapi",
 ]
 
 [[package]]
@@ -4281,6 +4260,17 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -4328,6 +4318,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 
 [[package]]
 name = "fastrand"
@@ -4575,6 +4571,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_complete_fig",
+ "clearscreen",
  "comfy-table",
  "const-hex",
  "criterion",
@@ -4608,7 +4605,7 @@ dependencies = [
  "itertools 0.13.0",
  "mockall",
  "once_cell",
- "opener 0.6.1",
+ "opener",
  "parking_lot 0.12.3",
  "paste",
  "path-slash",
@@ -4638,6 +4635,8 @@ dependencies = [
  "tracing-subscriber",
  "vergen",
  "watchexec",
+ "watchexec-events",
+ "watchexec-signals",
  "yansi 1.0.1",
  "zksync-web3-rs",
  "zksync_types",
@@ -5072,7 +5071,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "dunce",
  "fs_extra",
- "memmap2 0.9.4",
+ "memmap2",
  "once_cell",
  "path-slash",
  "regex",
@@ -5699,23 +5698,23 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "gix-actor"
-version = "0.20.0"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848efa0f1210cea8638f95691c82a46f98a74b9e3524f01d4955ebc25a8f84f3"
+checksum = "d9b8ee65074b2bbb91d9d97c15d172ea75043aefebf9869b5b329149dc76501c"
 dependencies = [
  "bstr 1.9.1",
- "btoi",
  "gix-date",
+ "gix-utils",
  "itoa",
- "nom",
  "thiserror",
+ "winnow 0.6.13",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.22.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d252a0eddb6df74600d3d8872dc9fe98835a7da43110411d705b682f49d4ac1"
+checksum = "7580e05996e893347ad04e1eaceb92e1c0e6a3ffe517171af99bf6b6df0ca6e5"
 dependencies = [
  "bstr 1.9.1",
  "gix-config-value",
@@ -5724,20 +5723,19 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "log",
  "memchr",
- "nom",
  "once_cell",
  "smallvec",
  "thiserror",
  "unicode-bom",
+ "winnow 0.6.13",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.12.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e874f41437441c02991dcea76990b9058fadfc54b02ab4dd06ab2218af43897"
+checksum = "fbd06203b1a9b33a78c88252a625031b094d9e1b647260070c25b09910c0a804"
 dependencies = [
  "bitflags 2.6.0",
  "bstr 1.9.1",
@@ -5748,9 +5746,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.5.1"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc164145670e9130a60a21670d9b6f0f4f8de04e5dd256c51fa5a0340c625902"
+checksum = "9eed6931f21491ee0aeb922751bd7ec97b4b2fe8fbfedcb678e2a2dce5f3b8c0"
 dependencies = [
  "bstr 1.9.1",
  "itoa",
@@ -5760,30 +5758,34 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.29.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf69b0f5c701cc3ae22d3204b671907668f6437ca88862d355eaf9bc47a4f897"
+checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
  "gix-hash",
+ "gix-trace",
+ "gix-utils",
  "libc",
+ "prodash",
  "sha1_smol",
  "walkdir",
 ]
 
 [[package]]
 name = "gix-fs"
-version = "0.1.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b37a1832f691fdc09910bd267f9a2e413737c1f9ec68c6e31f9e802616278a9"
+checksum = "e2184c40e7910529677831c8b481acf788ffd92427ed21fad65b6aa637e631b8"
 dependencies = [
  "gix-features",
+ "gix-utils",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.7.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07c98204529ac3f24b34754540a852593d2a4c7349008df389240266627a72a"
+checksum = "c2a29ad0990cf02c48a7aac76ed0dbddeb5a0d070034b83675cc3bbf937eace4"
 dependencies = [
  "bitflags 2.6.0",
  "bstr 1.9.1",
@@ -5793,19 +5795,19 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.11.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b422ff2ad9a0628baaad6da468cf05385bf3f5ab495ad5a33cce99b9f41092f"
+checksum = "f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e"
 dependencies = [
- "hex",
+ "faster-hex",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "5.0.1"
+version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c693d7f05730fa74a7c467150adc7cea393518410c65f0672f80226b8111555"
+checksum = "e7c359f81f01b8352063319bcb39789b7ea0887b406406381106e38c4a34d049"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -5814,28 +5816,28 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.29.2"
+version = "0.42.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d96bd620fd08accdd37f70b2183cfa0b001b4f1c6ade8b7f6e15cb3d9e261ce"
+checksum = "25da2f46b4e7c2fa7b413ce4dffb87f69eaf89c2057e386491f4c55cadbfe386"
 dependencies = [
  "bstr 1.9.1",
- "btoi",
  "gix-actor",
+ "gix-date",
  "gix-features",
  "gix-hash",
+ "gix-utils",
  "gix-validate",
- "hex",
  "itoa",
- "nom",
  "smallvec",
  "thiserror",
+ "winnow 0.6.13",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.8.4"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18609c8cbec8508ea97c64938c33cd305b75dfc04a78d0c3b78b8b3fd618a77c"
+checksum = "ca987128ffb056d732bd545db5db3d8b103d252fbf083c2567bb0796876619a4"
 dependencies = [
  "bstr 1.9.1",
  "gix-trace",
@@ -5846,11 +5848,12 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.29.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e03989e9d49954368e1b526578230fc7189d1634acdfbe79e9ba1de717e15d5"
+checksum = "fd4aba68b925101cb45d6df328979af0681364579db889098a0de75b36c77b65"
 dependencies = [
  "gix-actor",
+ "gix-date",
  "gix-features",
  "gix-fs",
  "gix-hash",
@@ -5858,29 +5861,30 @@ dependencies = [
  "gix-object",
  "gix-path",
  "gix-tempfile",
+ "gix-utils",
  "gix-validate",
- "memmap2 0.5.10",
- "nom",
+ "memmap2",
  "thiserror",
+ "winnow 0.6.13",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.8.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9615cbd6b456898aeb942cd75e5810c382fbfc48dbbff2fa23ebd2d33dcbe9c7"
+checksum = "fddc27984a643b20dd03e97790555804f98cf07404e0e552c0ad8133266a79a1"
 dependencies = [
  "bitflags 2.6.0",
  "gix-path",
  "libc",
- "windows",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "gix-tempfile"
-version = "5.0.3"
+version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71a0d32f34e71e86586124225caefd78dabc605d0486de580d717653addf182"
+checksum = "a761d76594f4443b675e85928e4902dec333273836bd386906f01e7e346a0d11"
 dependencies = [
  "gix-fs",
  "libc",
@@ -5907,9 +5911,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.7.7"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9b3737b2cef3dcd014633485f0034b0f1a931ee54aeb7d8f87f177f3c89040"
+checksum = "82c27dd34a49b1addf193c92070bcbf3beaf6e10f16a78544de6372e146a0acf"
 dependencies = [
  "bstr 1.9.1",
  "thiserror",
@@ -6424,7 +6428,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -6470,15 +6474,16 @@ dependencies = [
 
 [[package]]
 name = "ignore-files"
-version = "1.3.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4d73056a8d335492938cabeef794f38968ef43e6db9bc946638cfd6281003b"
+checksum = "99f84e7f847462c582abc4c2aef6ede285ad6e8f66aeec83b47f5481706ddeba"
 dependencies = [
  "dunce",
  "futures 0.3.30",
  "gix-config",
  "ignore",
- "miette",
+ "miette 7.2.0",
+ "normalize-path",
  "project-origins",
  "radix_trie",
  "thiserror",
@@ -7410,7 +7415,7 @@ dependencies = [
  "log",
  "memchr",
  "once_cell",
- "opener 0.7.1",
+ "opener",
  "pulldown-cmark 0.10.3",
  "regex",
  "serde",
@@ -7426,15 +7431,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memmap2"
@@ -7469,8 +7465,20 @@ version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
 dependencies = [
- "miette-derive",
+ "miette-derive 5.10.0",
  "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "miette-derive 7.2.0",
  "thiserror",
  "unicode-width",
 ]
@@ -7480,6 +7488,17 @@ name = "miette-derive"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7702,20 +7721,21 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.2.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "crossbeam-channel 0.5.13",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7978,17 +7998,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "opener"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
-dependencies = [
- "bstr 1.9.1",
- "normpath",
- "winapi",
 ]
 
 [[package]]
@@ -8910,10 +8919,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "project-origins"
-version = "1.2.0"
+name = "process-wrap"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629e0d57f265ca8238345cb616eea8847b8ecb86b5d97d155be2c8963a314379"
+checksum = "38ee68ae331824036479c84060534b18254c864fa73366c58d86db3b7b811619"
+dependencies = [
+ "futures 0.3.30",
+ "indexmap 2.2.6",
+ "nix 0.28.0",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
+name = "prodash"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
+
+[[package]]
+name = "project-origins"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735c6b4b1c67863c2211cac24badb0dca9fabfe1098209834fc5e0f92eda6c2c"
 dependencies = [
  "futures 0.3.30",
  "tokio",
@@ -9049,7 +9078,7 @@ checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
 dependencies = [
  "base64 0.21.7",
  "logos",
- "miette",
+ "miette 5.10.0",
  "once_cell",
  "prost 0.12.6",
  "prost-types",
@@ -9093,7 +9122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00bb76c5f6221de491fe2c8f39b106330bbd9762c6511119c07940e10eb9ff11"
 dependencies = [
  "bytes",
- "miette",
+ "miette 5.10.0",
  "prost 0.12.6",
  "prost-reflect",
  "prost-types",
@@ -9108,7 +9137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4581f441c58863525a3e6bec7b8de98188cf75239a56c725a3e7288450a33f"
 dependencies = [
  "logos",
- "miette",
+ "miette 5.10.0",
  "prost-types",
  "thiserror",
 ]
@@ -12759,50 +12788,65 @@ dependencies = [
 
 [[package]]
 name = "watchexec"
-version = "2.3.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5931215e14de2355a3039477138ae08a905abd7ad0265519fd79717ff1380f88"
+checksum = "c635816bdb583dcd1cf58935899df38b5c5ffb1b9d0cc89f8d3c7b33e2c005e3"
 dependencies = [
  "async-priority-channel",
  "async-recursion",
  "atomic-take",
- "clearscreen",
- "command-group",
  "futures 0.3.30",
  "ignore-files",
- "miette",
- "nix 0.26.4",
+ "miette 7.2.0",
+ "nix 0.28.0",
  "normalize-path",
  "notify",
  "once_cell",
+ "process-wrap",
  "project-origins",
  "thiserror",
  "tokio",
  "tracing",
  "watchexec-events",
  "watchexec-signals",
+ "watchexec-supervisor",
 ]
 
 [[package]]
 name = "watchexec-events"
-version = "1.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01603bbe02fd75918f010dadad456d47eda14fb8fdcab276b0b4b8362f142ae3"
+checksum = "1ce015ba32ff91a7f796cea3798e7998d3645411f03fc373ef0e7c7e564291bc"
 dependencies = [
- "nix 0.26.4",
+ "nix 0.28.0",
  "notify",
  "watchexec-signals",
 ]
 
 [[package]]
 name = "watchexec-signals"
-version = "1.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2a5df96c388901c94ca04055fcd51d4196ca3e971c5e805bd4a4b61dd6a7e5"
+checksum = "8f7ccc54db7df8cbbe3251508321e46986ce179af4c4a03b4c70bda539d72755"
 dependencies = [
- "miette",
- "nix 0.26.4",
+ "miette 7.2.0",
+ "nix 0.28.0",
  "thiserror",
+]
+
+[[package]]
+name = "watchexec-supervisor"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97efb9292bebdf72a777a0d6e400b69b32b4f3daee1ddd30214317a18ff20ab"
+dependencies = [
+ "futures 0.3.30",
+ "nix 0.28.0",
+ "process-wrap",
+ "tokio",
+ "tracing",
+ "watchexec-events",
+ "watchexec-signals",
 ]
 
 [[package]]
@@ -12832,14 +12876,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -12891,11 +12935,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12908,12 +12953,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
+name = "windows-core"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12932,21 +13011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -12982,12 +13046,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -13000,12 +13058,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -13015,12 +13067,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -13042,12 +13088,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -13057,12 +13097,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -13078,12 +13112,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -13093,12 +13121,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -13149,6 +13171,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "ws_stream_wasm"

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -97,7 +97,10 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 toml = { version = "0.8", features = ["preserve_order"] }
 toml_edit = "0.22.4"
-watchexec = "2.3.2"
+watchexec = "4.1"
+watchexec-events = "3.0"
+watchexec-signals = "3.0"
+clearscreen = "3.0"
 evm-disassembler.workspace = true
 rustc-hash.workspace = true
 
@@ -105,7 +108,7 @@ rustc-hash.workspace = true
 axum = { workspace = true, features = ["ws"] }
 hyper.workspace = true
 tower-http = { workspace = true, features = ["fs"] }
-opener = "0.6"
+opener = "0.7"
 
 # soldeer
 soldeer.workspace = true

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -19,7 +19,6 @@ use foundry_config::{
 };
 use serde::Serialize;
 use std::path::PathBuf;
-use watchexec::config::{InitConfig, RuntimeConfig};
 
 foundry_config::merge_impl_figment_convert!(BuildArgs, args);
 
@@ -142,11 +141,11 @@ impl BuildArgs {
 
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
-    pub(crate) fn watchexec_config(&self) -> Result<(InitConfig, RuntimeConfig)> {
+    pub(crate) fn watchexec_config(&self) -> Result<watchexec::Config> {
         // use the path arguments or if none where provided the `src` dir
         self.watch.watchexec_config(|| {
             let config = Config::from(self);
-            vec![config.src, config.test, config.script]
+            [config.src, config.test, config.script]
         })
     }
 }

--- a/crates/forge/bin/cmd/snapshot.rs
+++ b/crates/forge/bin/cmd/snapshot.rs
@@ -14,7 +14,6 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use watchexec::config::{InitConfig, RuntimeConfig};
 use yansi::Paint;
 
 /// A regex that matches a basic snapshot entry like
@@ -89,7 +88,7 @@ impl SnapshotArgs {
 
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
-    pub(crate) fn watchexec_config(&self) -> Result<(InitConfig, RuntimeConfig)> {
+    pub(crate) fn watchexec_config(&self) -> Result<watchexec::Config> {
         self.test.watchexec_config()
     }
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -43,7 +43,6 @@ use std::{
     sync::{mpsc::channel, Arc},
     time::Instant,
 };
-use watchexec::config::{InitConfig, RuntimeConfig};
 use yansi::Paint;
 
 mod filter;
@@ -612,10 +611,10 @@ impl TestArgs {
 
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
-    pub(crate) fn watchexec_config(&self) -> Result<(InitConfig, RuntimeConfig)> {
+    pub(crate) fn watchexec_config(&self) -> Result<watchexec::Config> {
         self.watch.watchexec_config(|| {
             let config = Config::from(self);
-            vec![config.src, config.test]
+            [config.src, config.test]
         })
     }
 }

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -3,17 +3,29 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::utils::{self, FoundryPathExt};
 use foundry_config::Config;
-use std::{collections::HashSet, convert::Infallible, path::PathBuf, sync::Arc};
+use parking_lot::Mutex;
+use std::{
+    collections::HashSet,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::process::Command as TokioCommand;
 use watchexec::{
-    action::{Action, Outcome, PreSpawn},
-    command::Command,
-    config::{InitConfig, RuntimeConfig},
-    event::{Event, Priority, ProcessEnd},
-    handler::SyncFnHandler,
+    action::ActionHandler,
+    command::{Command, Program},
+    job::{CommandState, Job},
     paths::summarise_events_to_env,
-    signal::source::MainSignal,
     Watchexec,
 };
+use watchexec_events::{Event, Priority, ProcessEnd};
+use watchexec_signals::Signal;
+use yansi::{Color, Paint};
+
+type SpawnHook = Arc<dyn Fn(&[Event], &mut TokioCommand) + Send + Sync + 'static>;
 
 #[derive(Clone, Debug, Default, Parser)]
 #[command(next_help_heading = "Watch options")]
@@ -21,12 +33,7 @@ pub struct WatchArgs {
     /// Watch the given files or directories for changes.
     ///
     /// If no paths are provided, the source and test directories of the project are watched.
-    #[arg(
-        long,
-        short,
-        num_args(0..),
-        value_name = "PATH",
-    )]
+    #[arg(long, short, num_args(0..), value_name = "PATH")]
     pub watch: Option<Vec<PathBuf>>,
 
     /// Do not restart the command while it's still running.
@@ -57,207 +64,264 @@ pub struct WatchArgs {
 }
 
 impl WatchArgs {
-    /// Returns new [InitConfig] and [RuntimeConfig] based on the [WatchArgs]
+    /// Creates a new [`watchexec::Config`].
     ///
     /// If paths were provided as arguments the these will be used as the watcher's pathset,
-    /// otherwise the path the closure returns will be used
-    pub fn watchexec_config(
+    /// otherwise the path the closure returns will be used.
+    pub fn watchexec_config<PS: IntoIterator<Item = P>, P: Into<PathBuf>>(
         &self,
-        f: impl FnOnce() -> Vec<PathBuf>,
-    ) -> Result<(InitConfig, RuntimeConfig)> {
-        let init = init()?;
-        let mut runtime = runtime(self)?;
-
-        // contains all the arguments `--watch p1, p2, p3`
-        let has_paths = self.watch.as_ref().map(|paths| !paths.is_empty()).unwrap_or_default();
-
-        if !has_paths {
-            // use alternative pathset, but only those that exists
-            runtime.pathset(f().into_iter().filter(|p| p.exists()));
-        }
-        Ok((init, runtime))
+        default_paths: impl FnOnce() -> PS,
+    ) -> Result<watchexec::Config> {
+        self.watchexec_config_generic(default_paths, None)
     }
+
+    /// Creates a new [`watchexec::Config`] with a custom command spawn hook.
+    ///
+    /// If paths were provided as arguments the these will be used as the watcher's pathset,
+    /// otherwise the path the closure returns will be used.
+    pub fn watchexec_config_with_override<PS: IntoIterator<Item = P>, P: Into<PathBuf>>(
+        &self,
+        default_paths: impl FnOnce() -> PS,
+        spawn_hook: impl Fn(&[Event], &mut TokioCommand) + Send + Sync + 'static,
+    ) -> Result<watchexec::Config> {
+        self.watchexec_config_generic(default_paths, Some(Arc::new(spawn_hook)))
+    }
+
+    fn watchexec_config_generic<PS: IntoIterator<Item = P>, P: Into<PathBuf>>(
+        &self,
+        default_paths: impl FnOnce() -> PS,
+        spawn_hook: Option<SpawnHook>,
+    ) -> Result<watchexec::Config> {
+        let mut paths = self.watch.as_deref().unwrap_or_default();
+        let storage: Vec<_>;
+        if paths.is_empty() {
+            storage = default_paths().into_iter().map(Into::into).filter(|p| p.exists()).collect();
+            paths = &storage;
+        }
+        self.watchexec_config_inner(paths, spawn_hook)
+    }
+
+    fn watchexec_config_inner(
+        &self,
+        paths: &[PathBuf],
+        spawn_hook: Option<SpawnHook>,
+    ) -> Result<watchexec::Config> {
+        let config = watchexec::Config::default();
+
+        config.on_error(|err| eprintln!("[[{err:?}]]"));
+
+        if let Some(delay) = &self.watch_delay {
+            config.throttle(utils::parse_delay(delay)?);
+        }
+
+        config.pathset(paths.iter().map(|p| p.as_path()));
+
+        let n_path_args = self.watch.as_deref().unwrap_or_default().len();
+        let base_command = Arc::new(watch_command(cmd_args(n_path_args)));
+
+        let id = watchexec::Id::default();
+        let quit_again = Arc::new(AtomicU8::new(0));
+        let stop_timeout = Duration::from_secs(5);
+        let no_restart = self.no_restart;
+        let stop_signal = Signal::Terminate;
+        config.on_action(move |mut action| {
+            let base_command = base_command.clone();
+            let job = action.get_or_create_job(id, move || base_command.clone());
+
+            let events = action.events.clone();
+            let spawn_hook = spawn_hook.clone();
+            job.set_spawn_hook(move |command, _| {
+                // https://github.com/watchexec/watchexec/blob/72f069a8477c679e45f845219276b0bfe22fed79/crates/cli/src/emits.rs#L9
+                let env = summarise_events_to_env(events.iter());
+                for (k, v) in env {
+                    command.command_mut().env(format!("WATCHEXEC_{k}_PATH"), v);
+                }
+
+                if let Some(spawn_hook) = &spawn_hook {
+                    spawn_hook(&events, command.command_mut());
+                }
+            });
+
+            let clear_screen = || {
+                let _ = clearscreen::clear();
+            };
+
+            let quit = |mut action: ActionHandler| {
+                match quit_again.fetch_add(1, Ordering::Relaxed) {
+                    0 => {
+                        eprintln!(
+                            "[Waiting {stop_timeout:?} for processes to exit before stopping... \
+                             Ctrl-C again to exit faster]"
+                        );
+                        action.quit_gracefully(stop_signal, stop_timeout);
+                    }
+                    1 => action.quit_gracefully(Signal::ForceStop, Duration::ZERO),
+                    _ => action.quit(),
+                }
+
+                action
+            };
+
+            let signals = action.signals().collect::<Vec<_>>();
+
+            if signals.contains(&Signal::Terminate) || signals.contains(&Signal::Interrupt) {
+                return quit(action);
+            }
+
+            // Only filesystem events below here (or empty synthetic events).
+            if action.paths().next().is_none() && !action.events.iter().any(|e| e.is_empty()) {
+                debug!("no filesystem or synthetic events, skip without doing more");
+                return action;
+            }
+
+            job.run({
+                let job = job.clone();
+                move |context| {
+                    if context.current.is_running() && no_restart {
+                        return;
+                    }
+                    job.restart_with_signal(stop_signal, stop_timeout);
+                    job.run({
+                        let job = job.clone();
+                        move |context| {
+                            clear_screen();
+                            setup_process(job, &context.command)
+                        }
+                    });
+                }
+            });
+
+            action
+        });
+
+        Ok(config)
+    }
+}
+
+fn setup_process(job: Job, _command: &Command) {
+    tokio::spawn(async move {
+        job.to_wait().await;
+        job.run(move |context| end_of_process(context.current));
+    });
+}
+
+fn end_of_process(state: &CommandState) {
+    let CommandState::Finished { status, started, finished } = state else {
+        return;
+    };
+
+    let duration = *finished - *started;
+    let timings = true;
+    let timing = if timings { format!(", lasted {duration:?}") } else { String::new() };
+    let (msg, fg) = match status {
+        ProcessEnd::ExitError(code) => (format!("Command exited with {code}{timing}"), Color::Red),
+        ProcessEnd::ExitSignal(sig) => {
+            (format!("Command killed by {sig:?}{timing}"), Color::Magenta)
+        }
+        ProcessEnd::ExitStop(sig) => (format!("Command stopped by {sig:?}{timing}"), Color::Blue),
+        ProcessEnd::Continued => (format!("Command continued{timing}"), Color::Cyan),
+        ProcessEnd::Exception(ex) => {
+            (format!("Command ended by exception {ex:#x}{timing}"), Color::Yellow)
+        }
+        ProcessEnd::Success => (format!("Command was successful{timing}"), Color::Green),
+    };
+
+    let quiet = false;
+    if !quiet {
+        eprintln!("{}", format!("[{msg}]").paint(fg.foreground()));
+    }
+}
+
+/// Runs the given [`watchexec::Config`].
+pub async fn run(config: watchexec::Config) -> Result<()> {
+    let wx = Watchexec::with_config(config)?;
+    wx.send_event(Event::default(), Priority::Urgent).await?;
+    wx.main().await??;
+    Ok(())
 }
 
 /// Executes a [`Watchexec`] that listens for changes in the project's src dir and reruns `forge
 /// build`
 pub async fn watch_build(args: BuildArgs) -> Result<()> {
-    let (init, mut runtime) = args.watchexec_config()?;
-    let cmd = cmd_args(args.watch.watch.as_ref().map(|paths| paths.len()).unwrap_or_default());
-
-    trace!("watch build cmd={:?}", cmd);
-    runtime.command(watch_command(cmd.clone()));
-
-    let wx = Watchexec::new(init, runtime.clone())?;
-    on_action(args.watch, runtime, Arc::clone(&wx), cmd, (), |_| {});
-
-    // start executing the command immediately
-    wx.send_event(Event::default(), Priority::default()).await?;
-    wx.main().await??;
-
-    Ok(())
+    let config = args.watchexec_config()?;
+    run(config).await
 }
 
 /// Executes a [`Watchexec`] that listens for changes in the project's src dir and reruns `forge
 /// snapshot`
 pub async fn watch_snapshot(args: SnapshotArgs) -> Result<()> {
-    let (init, mut runtime) = args.watchexec_config()?;
-    let cmd = cmd_args(args.test.watch.watch.as_ref().map(|paths| paths.len()).unwrap_or_default());
-
-    trace!("watch snapshot cmd={:?}", cmd);
-    runtime.command(watch_command(cmd.clone()));
-    let wx = Watchexec::new(init, runtime.clone())?;
-
-    on_action(args.test.watch.clone(), runtime, Arc::clone(&wx), cmd, (), |_| {});
-
-    // start executing the command immediately
-    wx.send_event(Event::default(), Priority::default()).await?;
-    wx.main().await??;
-
-    Ok(())
+    let config = args.watchexec_config()?;
+    run(config).await
 }
 
 /// Executes a [`Watchexec`] that listens for changes in the project's src dir and reruns `forge
 /// test`
 pub async fn watch_test(args: TestArgs) -> Result<()> {
-    let (init, mut runtime) = args.watchexec_config()?;
-    let cmd = cmd_args(args.watch.watch.as_ref().map(|paths| paths.len()).unwrap_or_default());
-    trace!("watch test cmd={:?}", cmd);
-    runtime.command(watch_command(cmd.clone()));
-    let wx = Watchexec::new(init, runtime.clone())?;
-
     let config: Config = args.build_args().into();
-
     let filter = args.filter(&config);
-
-    // marker to check whether to override the command
-    let no_reconfigure = filter.args().test_pattern.is_some() ||
+    // Marker to check whether to override the command.
+    let _no_reconfigure = filter.args().test_pattern.is_some() ||
         filter.args().path_pattern.is_some() ||
         filter.args().contract_pattern.is_some() ||
         args.watch.run_all;
 
-    let state = WatchTestState {
-        project_root: config.root.0,
-        no_reconfigure,
-        last_test_files: Default::default(),
-    };
-    on_action(args.watch.clone(), runtime, Arc::clone(&wx), cmd, state, on_test);
+    let last_test_files = Mutex::new(HashSet::<String>::new());
+    let project_root = config.root.0.to_string_lossy().into_owned();
+    let config = args.watch.watchexec_config_with_override(
+        || [&config.test, &config.src],
+        move |events, command| {
+            let mut changed_sol_test_files: HashSet<_> = events
+                .iter()
+                .flat_map(|e| e.paths())
+                .filter(|(path, _)| path.is_sol_test())
+                .filter_map(|(path, _)| path.to_str())
+                .map(str::to_string)
+                .collect();
 
-    // start executing the command immediately
-    wx.send_event(Event::default(), Priority::default()).await?;
-    wx.main().await??;
+            if changed_sol_test_files.len() > 1 {
+                // Run all tests if multiple files were changed at once, for example when running
+                // `forge fmt`.
+                return;
+            }
+
+            if changed_sol_test_files.is_empty() {
+                // Reuse the old test files if a non-test file was changed.
+                let last = last_test_files.lock();
+                if last.is_empty() {
+                    return;
+                }
+                changed_sol_test_files = last.clone();
+            }
+
+            // append `--match-path` glob
+            let mut file = changed_sol_test_files.iter().next().expect("test file present").clone();
+
+            // remove the project root dir from the detected file
+            if let Some(f) = file.strip_prefix(&project_root) {
+                file = f.trim_start_matches('/').to_string();
+            }
+
+            trace!(?file, "reconfigure test command");
+
+            command.arg("--match-path").arg(&file);
+        },
+    )?;
+    run(config).await?;
 
     Ok(())
 }
 
-#[derive(Clone, Debug)]
-struct WatchTestState {
-    /// the root directory of the project
-    project_root: PathBuf,
-    /// marks whether we can reconfigure the watcher command with the `--match-path` arg
-    no_reconfigure: bool,
-    /// Tracks the last changed test files, if any so that if a non-test file was modified we run
-    /// this file instead *Note:* this is a vec, so we can also watch out for changes
-    /// introduced by `forge fmt`
-    last_test_files: HashSet<String>,
-}
-
-/// The `on_action` hook for `forge test --watch`
-fn on_test(action: OnActionState<'_, WatchTestState>) {
-    let OnActionState { args, runtime, action, wx, cmd, other } = action;
-    let WatchTestState { project_root, no_reconfigure, last_test_files } = other;
-
-    if no_reconfigure {
-        // nothing to reconfigure
-        return
-    }
-
-    let mut cmd = cmd.clone();
-
-    let mut changed_sol_test_files: HashSet<_> = action
-        .events
-        .iter()
-        .flat_map(|e| e.paths())
-        .filter(|(path, _)| path.is_sol_test())
-        .filter_map(|(path, _)| path.to_str())
-        .map(str::to_string)
-        .collect();
-
-    // replace `--match-path` | `-mp` argument
-    if let Some(pos) = cmd.iter().position(|arg| arg == "--match-path" || arg == "-mp") {
-        // --match-path requires 1 argument
-        cmd.drain(pos..=(pos + 1));
-    }
-
-    if changed_sol_test_files.len() > 1 ||
-        (changed_sol_test_files.is_empty() && last_test_files.is_empty())
-    {
-        // this could happen if multiple files were changed at once, for example `forge fmt` was
-        // run, or if no test files were changed and no previous test files were modified in which
-        // case we simply run all
-        let mut config = runtime.clone();
-        config.command(watch_command(cmd.clone()));
-        // re-register the action
-        on_action(
-            args.clone(),
-            config,
-            wx,
-            cmd,
-            WatchTestState {
-                project_root,
-                no_reconfigure,
-                last_test_files: changed_sol_test_files,
-            },
-            on_test,
-        );
-        return
-    }
-
-    if changed_sol_test_files.is_empty() {
-        // reuse the old test files if a non-test file was changed
-        changed_sol_test_files = last_test_files;
-    }
-
-    // append `--match-path` glob
-    let mut file = changed_sol_test_files.clone().into_iter().next().expect("test file present");
-
-    // remove the project root dir from the detected file
-    if let Some(root) = project_root.as_os_str().to_str() {
-        if let Some(f) = file.strip_prefix(root) {
-            file = f.trim_start_matches('/').to_string();
-        }
-    }
-
-    let mut new_cmd = cmd.clone();
-    new_cmd.push("--match-path".to_string());
-    new_cmd.push(file);
-    trace!("reconfigure test command {:?}", new_cmd);
-
-    // reconfigure the executor with a new runtime
-    let mut config = runtime.clone();
-    config.command(watch_command(new_cmd));
-
-    // re-register the action
-    on_action(
-        args.clone(),
-        config,
-        wx,
-        cmd,
-        WatchTestState { project_root, no_reconfigure, last_test_files: changed_sol_test_files },
-        on_test,
-    );
-}
-
-/// Converts a list of arguments to a `watchexec::Command`
+/// Converts a list of arguments to a `watchexec::Command`.
 ///
-/// The first index in `args`, is expected to be the path to the executable, See `cmd_args`
+/// The first index in `args` is the path to the executable.
 ///
 /// # Panics
-/// if `args` is empty
+///
+/// Panics if `args` is empty.
 fn watch_command(mut args: Vec<String>) -> Command {
     debug_assert!(!args.is_empty());
     let prog = args.remove(0);
-    Command::Exec { prog, args }
+    Command { program: Program::Exec { prog: prog.into(), args }, options: Default::default() }
 }
 
 /// Returns the env args without the `--watch` flag from the args for the Watchexec command
@@ -297,148 +361,6 @@ fn clean_cmd_args(num: usize, mut cmd_args: Vec<String>) -> Vec<String> {
     }
 
     cmd_args
-}
-
-/// Returns the Initialisation configuration for [`Watchexec`].
-pub fn init() -> Result<InitConfig> {
-    let mut config = InitConfig::default();
-    config.on_error(SyncFnHandler::from(|data| {
-        trace!("[[{:?}]]", data);
-        Ok::<_, Infallible>(())
-    }));
-
-    Ok(config)
-}
-
-/// Contains all necessary context to reconfigure a [`Watchexec`] on the fly
-struct OnActionState<'a, T: Clone> {
-    args: &'a WatchArgs,
-    runtime: &'a RuntimeConfig,
-    action: &'a Action,
-    cmd: &'a Vec<String>,
-    wx: Arc<Watchexec>,
-    // additional context to inject
-    other: T,
-}
-
-/// Registers the `on_action` hook on the `RuntimeConfig` currently in use in the `Watchexec`
-///
-/// **Note** this is a bit weird since we're installing the hook on the config that's already used
-/// in `Watchexec` but necessary if we want to have access to it in order to
-/// [`Watchexec::reconfigure`]
-fn on_action<F, T>(
-    args: WatchArgs,
-    mut config: RuntimeConfig,
-    wx: Arc<Watchexec>,
-    cmd: Vec<String>,
-    other: T,
-    f: F,
-) where
-    F: for<'a> Fn(OnActionState<'a, T>) + Send + 'static,
-    T: Clone + Send + 'static,
-{
-    let on_busy = if args.no_restart { "do-nothing" } else { "restart" };
-    let runtime = config.clone();
-    let w = Arc::clone(&wx);
-    config.on_action(move |action: Action| {
-        let fut = async { Ok::<(), Infallible>(()) };
-        let signals: Vec<MainSignal> = action.events.iter().flat_map(|e| e.signals()).collect();
-        let has_paths = action.events.iter().flat_map(|e| e.paths()).next().is_some();
-
-        if signals.contains(&MainSignal::Terminate) || signals.contains(&MainSignal::Interrupt) {
-            action.outcome(Outcome::both(Outcome::Stop, Outcome::Exit));
-            return fut
-        }
-
-        if !has_paths {
-            if !signals.is_empty() {
-                let mut out = Outcome::DoNothing;
-                for sig in signals {
-                    out = Outcome::both(out, Outcome::Signal(sig));
-                }
-
-                action.outcome(out);
-                return fut
-            }
-
-            let completion = action.events.iter().flat_map(|e| e.completions()).next();
-            if let Some(status) = completion {
-                match status {
-                    Some(ProcessEnd::ExitError(code)) => {
-                        trace!("Command exited with {code}")
-                    }
-                    Some(ProcessEnd::ExitSignal(sig)) => {
-                        trace!("Command killed by {:?}", sig)
-                    }
-                    Some(ProcessEnd::ExitStop(sig)) => {
-                        trace!("Command stopped by {:?}", sig)
-                    }
-                    Some(ProcessEnd::Continued) => trace!("Command continued"),
-                    Some(ProcessEnd::Exception(ex)) => {
-                        trace!("Command ended by exception {:#x}", ex)
-                    }
-                    Some(ProcessEnd::Success) => trace!("Command was successful"),
-                    None => trace!("Command completed"),
-                };
-
-                action.outcome(Outcome::DoNothing);
-                return fut
-            }
-        }
-
-        f(OnActionState {
-            args: &args,
-            runtime: &runtime,
-            action: &action,
-            wx: w.clone(),
-            cmd: &cmd,
-            other: other.clone(),
-        });
-
-        // mattsse: could be made into flag to never clear the shell
-        let clear = false;
-        let when_running = match (clear, on_busy) {
-            (_, "do-nothing") => Outcome::DoNothing,
-            (true, "restart") => {
-                Outcome::both(Outcome::Stop, Outcome::both(Outcome::Clear, Outcome::Start))
-            }
-            (false, "restart") => Outcome::both(Outcome::Stop, Outcome::Start),
-            _ => Outcome::DoNothing,
-        };
-
-        let when_idle =
-            if clear { Outcome::both(Outcome::Clear, Outcome::Start) } else { Outcome::Start };
-
-        action.outcome(Outcome::if_running(when_running, when_idle));
-
-        fut
-    });
-
-    let _ = wx.reconfigure(config);
-}
-
-/// Returns the Runtime configuration for [`Watchexec`].
-pub fn runtime(args: &WatchArgs) -> Result<RuntimeConfig> {
-    let mut config = RuntimeConfig::default();
-
-    config.pathset(args.watch.clone().unwrap_or_default());
-
-    if let Some(delay) = &args.watch_delay {
-        config.action_throttle(utils::parse_delay(delay)?);
-    }
-
-    config.on_pre_spawn(move |prespawn: PreSpawn| async move {
-        let envs = summarise_events_to_env(prespawn.events.iter());
-        if let Some(mut command) = prespawn.command().await {
-            for (k, v) in envs {
-                command.env(format!("CARGO_WATCH_{k}_PATH"), v);
-            }
-        }
-
-        Ok::<(), Infallible>(())
-    });
-
-    Ok(config)
 }
 
 #[cfg(test)]

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,6 @@ unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
 ignore = [
-    "RUSTSEC-2023-0018",
     # https://github.com/watchexec/watchexec/issues/852
     "RUSTSEC-2024-0350",
     "RUSTSEC-2024-0351",

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,9 @@ yanked = "warn"
 notice = "warn"
 ignore = [
     "RUSTSEC-2023-0018",
+    # https://github.com/watchexec/watchexec/issues/852
+    "RUSTSEC-2024-0350",
+    "RUSTSEC-2024-0351",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Motivation

After the dependency update `cargo deny check advisories` fails due to couple vulnerabilities in `gix` related packages which is used by `watchexec`.

## Solution

Update watchexec. This is a direct cherry-pick from: https://github.com/foundry-rs/foundry/pull/7864 (+ cargo building and removing a stale ignored advisory)