### PR TITLE
chore: specify sources for cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -98,4 +98,11 @@ allow-git = [
     "https://github.com/alloy-rs/alloy",
     "https://github.com/paradigmxyz/revm-inspectors",
     "https://github.com/bluealloy/revm",
+    "https://github.com/lambdaclass/zksync-web3-rs",
+    "https://github.com/Moonsong-Labs/compilers",
+    "https://github.com/Moonsong-Labs/block-explorers",
+    "https://github.com/RustCrypto/hashes",
 ]
+
+[sources.allow-org]
+github = ["matter-labs"]


### PR DESCRIPTION
## Motivation

`cargo deny check sources` is failing due to unspecified git sources

## Solution

Specify required sources in `deny.toml`