### PR TITLE
Blockhash returning expected value

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -647,58 +647,30 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
     fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<DB>) {
         // ovverride address(x).balance retrieval to make it consistent between EraVM and EVM
         if self.use_zk_vm {
-            match interpreter.current_opcode() {
-                opcode::SELFBALANCE => {
-                    let address = interpreter.contract().target_address;
-                    let balance = foundry_zksync_core::balance(address, ecx);
-
-                    // Skip the current SELFBALANCE instruction since we've already handled it
-                    match interpreter.stack.push(balance) {
-                        Ok(_) => unsafe {
-                            interpreter.instruction_pointer =
-                                interpreter.instruction_pointer.add(1);
-                        },
-                        Err(e) => {
-                            interpreter.instruction_result = e;
-                        }
-                    }
-                }
+            let address = match interpreter.current_opcode() {
+                opcode::SELFBALANCE => interpreter.contract().target_address,
                 opcode::BALANCE => {
                     if interpreter.stack.is_empty() {
                         interpreter.instruction_result = InstructionResult::StackUnderflow;
                         return;
                     }
 
-                    let address =
-                        Address::from_word(B256::from(unsafe { interpreter.stack.pop_unsafe() }));
-                    let balance = foundry_zksync_core::balance(address, ecx);
-
-                    // Skip the current BALANCE instruction since we've already handled it
-                    match interpreter.stack.push(balance) {
-                        Ok(_) => unsafe {
-                            interpreter.instruction_pointer =
-                                interpreter.instruction_pointer.add(1);
-                        },
-                        Err(e) => {
-                            interpreter.instruction_result = e;
-                        }
-                    }
-                }
-                opcode::BLOCKHASH => {
-                    let block_number = U256::from(interpreter.stack.pop().unwrap());
-                    let block_hash = ecx.block_hash(block_number.into()).unwrap();
-                    warn!("block_hash: {:?}", block_hash);
-                    warn!("use blockhash_override");
-                    warn!("block number: {:?}", block_number);
-                    match interpreter.stack.push(block_hash.into()) {
-                        Ok(_) => unsafe {
-                            interpreter.instruction_pointer =
-                                interpreter.instruction_pointer.add(1);
-                        },
-                        Err(e) => interpreter.instruction_result = e,
-                    }
+                    Address::from_word(B256::from(unsafe { interpreter.stack.pop_unsafe() }))
                 }
                 _ => return,
+            };
+
+            // Safety: Length is checked above.
+            let balance = foundry_zksync_core::balance(address, ecx);
+
+            // Skip the current BALANCE instruction since we've already handled it
+            match interpreter.stack.push(balance) {
+                Ok(_) => unsafe {
+                    interpreter.instruction_pointer = interpreter.instruction_pointer.add(1);
+                },
+                Err(e) => {
+                    interpreter.instruction_result = e;
+                }
             }
         }
     }

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -230,7 +230,8 @@ impl PreSimulationState {
             .into_iter()
             .map(|btx| {
                 let mut tx = TransactionWithMetadata::from_tx_request(btx.transaction);
-                tx.zk = btx.zk_tx.map(|metadata| ZkTransaction { factory_deps: metadata.factory_deps });
+                tx.zk =
+                    btx.zk_tx.map(|metadata| ZkTransaction { factory_deps: metadata.factory_deps });
                 tx.rpc = btx.rpc.expect("missing broadcastable tx rpc url");
                 tx
             })

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -63,6 +63,21 @@ where
         PaymasterParams::default(),
     );
 
+    let current_block_number = ecx.env.block.number;
+
+    let blockhashes = (0..=255)
+        .map(|i| current_block_number - alloy_primitives::U256::from(i))
+        .map(|index| {
+            let block_hash = ecx.block_hash(index);
+            block_hash.map(|block_hash| (index, block_hash))
+        })
+        .take_while(|result| match result {
+            Ok((_, block_hash)) => !block_hash.is_zero(),
+            Err(_) => false,
+        })
+        .filter_map(Result::ok)
+        .collect();
+
     let call_ctx = CallContext {
         tx_caller: env.tx.caller,
         msg_sender: env.tx.caller,
@@ -70,6 +85,7 @@ where
         delegate_as: None,
         block_number: env.block.number,
         block_timestamp: env.block.timestamp,
+        blockhashes,
         block_basefee: min(max_fee_per_gas.to_ru256(), env.block.basefee),
         is_create,
         is_static: false,
@@ -151,6 +167,21 @@ where
         PaymasterParams::default(),
     );
 
+    let current_block_number = ecx.env.block.number;
+
+    let blockhashes = (0..=255)
+        .map(|i| current_block_number - alloy_primitives::U256::from(i))
+        .map(|index| {
+            let block_hash = ecx.block_hash(index);
+            block_hash.map(|block_hash| (index, block_hash))
+        })
+        .take_while(|result| match result {
+            Ok((_, block_hash)) => !block_hash.is_zero(),
+            Err(_) => false,
+        })
+        .filter_map(Result::ok)
+        .collect();
+
     let call_ctx = CallContext {
         tx_caller: ecx.env.tx.caller,
         msg_sender: call.caller,
@@ -159,6 +190,7 @@ where
         block_number: ecx.env.block.number,
         block_timestamp: ecx.env.block.timestamp,
         block_basefee: min(max_fee_per_gas.to_ru256(), ecx.env.block.basefee),
+        blockhashes,
         is_create: true,
         is_static: false,
     };
@@ -201,6 +233,21 @@ where
         PaymasterParams::default(),
     );
 
+    let current_block_number = ecx.env.block.number;
+
+    let blockhashes = (0..=255)
+        .map(|i| current_block_number - alloy_primitives::U256::from(i))
+        .map(|index| {
+            let block_hash = ecx.block_hash(index);
+            block_hash.map(|block_hash| (index, block_hash))
+        })
+        .take_while(|result| match result {
+            Ok((_, block_hash)) => !block_hash.is_zero(),
+            Err(_) => false,
+        })
+        .filter_map(Result::ok)
+        .collect();
+
     // address and caller are specific to the type of call:
     // Call | StaticCall => { address: to, caller: contract.address }
     // CallCode          => { address: contract.address, caller: contract.address }
@@ -215,6 +262,7 @@ where
         },
         block_number: ecx.env.block.number,
         block_timestamp: ecx.env.block.timestamp,
+        blockhashes,
         block_basefee: min(max_fee_per_gas.to_ru256(), ecx.env.block.basefee),
         is_create: false,
         is_static: call.is_static,

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -109,7 +109,8 @@ pub struct CallContext {
     pub is_create: bool,
     /// Whether the current call is a static call.
     pub is_static: bool,
-    /// Blockhashes
+    /// L1 blockhashes to ensure consistency when returning environment data in L2, similar to
+    /// other cases (e.g., Block number, Block timestamp)
     pub blockhashes: HashMap<alloy_primitives::U256, alloy_primitives::FixedBytes<32>>,
 }
 

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -295,17 +295,17 @@ impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer 
         }
 
         // Override blockhash
-        if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
-            let calldata = get_calldata(&state, memory);
-            let current = state.vm_local_state.callstack.current;
+        // if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
+        //     let calldata = get_calldata(&state, memory);
+        //     let current = state.vm_local_state.callstack.current;
 
-            if current.code_address == SYSTEM_CONTEXT_ADDRESS &&
-                calldata.starts_with(&SELECTOR_BLOCK_HASH)
-            {
-                self.farcall_handler.set_immediate_return(rU256::ZERO.to_be_bytes_vec());
-                return
-            }
-        }
+        //     if current.code_address == SYSTEM_CONTEXT_ADDRESS &&
+        //         calldata.starts_with(&SELECTOR_BLOCK_HASH)
+        //     {
+        //         self.farcall_handler.set_immediate_return(rU256::ZERO.to_be_bytes_vec());
+        //         return
+        //     }
+        // }
 
         if let Some(delegate_as) = self.call_context.delegate_as {
             if let Opcode::FarCall(_call) = data.opcode.variant.opcode {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Previously, the CheatcodeTracer was configured to override the blockhash calls and return 0. This approach was a temporary solution to ensure consistency in the environment data being returned.

## Solution

This PR updates the CheatcodeTracer to retrieve and return the actual L1 blockhashes. By intercepting the blockhash calls within the tracer, we ensure that the environment data being returned is consistent with the real L1 blockhashes. This change enhances the accuracy and reliability of the environment data, providing a more realistic testing and debugging experience.
