### PR TITLE
chore: remove deploy missing libraries mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Forge is quite fast at both compiling (leveraging [ethers-solc]) and testing.
 While `foundry-zksync` is **alpha stage**, there are some limitations to be aware of:
 
 - **Compile Time**: Some users may experience slower compile times.
-- **Compiling Libraries**: Compiling non-inlinable libraries requires deployment and adding to configuration. For more information please refer to [official docs](https://docs.zksync.io/build/developer-reference/ethereum-differences/libraries).
+- **Compiling Libraries**: Compiling non-inlinable libraries requires deployment and adding to configuration or the command line with the `--libraries` argument. For more information please refer to [official docs](https://docs.zksync.io/build/developer-reference/ethereum-differences/libraries).
 
     ```
     libraries = [
@@ -193,15 +193,12 @@ Compiling smart contracts...
 Compiled Successfully
 ```
 
-#### Deploying missing libraries
+#### Listing missing libraries
 
-In case missing libraries are detected during the compilation, we can deploy them using the following command:
+To scan missing non-inlinable libraries, you can build the project using the `--zk-detect-missing-libraries-flag`. This will give a list of the libraries that need to be deployed and their addresses
+provided via the `libraries` option for the contracts to compile.
+Metadata about the libraries will be saved in `.zksolc-libraries-cache/missing_library_dependencies.json`.
 
-```
-$ forge create --deploy-missing-libraries --private-key <PRIVATE_KEY> --rpc-url <RPC_URL> --chain <CHAIN_ID> --zksync
-```
-
-After deployment is done, the configuration file will be updated and contracts will be automatically compiled again.
 
 #### Running Tests
 

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -416,13 +416,19 @@ impl ProjectCompiler {
                 }
             })
             .collect();
+
         if !missing_libs.is_empty() {
             libraries::add_dependencies_to_missing_libraries_cache(
                 root_path,
                 missing_libs.as_slice(),
             )
             .expect("Error while adding missing libraries");
-            eyre::bail!("Missing libraries detected {:?}\n\nRun the following command in order to deploy the missing libraries:\nforge create --deploy-missing-libraries --private-key <PRIVATE_KEY> --rpc-url <RPC_URL> --chain <CHAIN_ID> --zksync", missing_libs);
+            let missing_libs_list = missing_libs
+                .iter()
+                .map(|ml| format!("{}:{}", ml.contract_path, ml.contract_name))
+                .collect::<Vec<String>>()
+                .join(", ");
+            eyre::bail!("Missing libraries detected: {missing_libs_list}\n\nRun the following command in order to deploy each missing library:\n\nforge create <LIBRARY> --private-key <PRIVATE_KEY> --rpc-url <RPC_URL> --chain <CHAIN_ID> --zksync\n\nThen pass the library addresses using the --libraries option");
         }
 
         // print any sizes or names


### PR DESCRIPTION
## Motivation

While we removed `--deploy-missing-libraries` feature, there were still some error messages and docs mentioning it.

## Solution

Replace mentions with messages that reflect current state of the missing libraries flow.
