### PR TITLE
fix: add factory_deps to estimate_gas

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -120,6 +120,17 @@ pub async fn send_transaction(
     // Chains which use `eth_estimateGas` are being sent sequentially and require their
     // gas to be re-estimated right before broadcasting.
     if !is_fixed_gas_limit && estimate_via_rpc {
+        // manually add factory_deps to estimate_gas
+        if let Some(zk) = zk {
+            tx.other.insert(
+                "eip712Meta".into(),
+                serde_json::to_value(&Eip712Meta {
+                    factory_deps: zk.factory_deps.clone(),
+                    ..Default::default()
+                })
+                .expect("failed serializing json"),
+            );
+        }
         estimate_gas(&mut tx, &provider, estimate_multiplier).await?;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Broadcast would fail if simulation was skipped as `factory_deps` weren't being provided.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add factory deps while estimating gas.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
