### PR TITLE
fix: remove unused `Send` bound on `DB`

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -626,7 +626,7 @@ impl Cheatcodes {
     }
 }
 
-impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
+impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
     #[inline]
     fn initialize_interp(&mut self, _: &mut Interpreter, ecx: &mut EvmContext<DB>) {
         // When the first interpreter is initialized we've circumvented the balance and gas checks,
@@ -2083,7 +2083,7 @@ impl<DB: DatabaseExt + Send> Inspector<DB> for Cheatcodes {
     }
 }
 
-impl<DB: DatabaseExt + Send> InspectorExt<DB> for Cheatcodes {
+impl<DB: DatabaseExt> InspectorExt<DB> for Cheatcodes {
     fn should_use_create2_factory(
         &mut self,
         ecx: &mut EvmContext<DB>,

--- a/crates/zksync/core/src/vm/farcall.rs
+++ b/crates/zksync/core/src/vm/farcall.rs
@@ -151,7 +151,7 @@ impl FarCallHandler {
 
     /// Attempts to return the preset data ignoring any following opcodes, if set.
     /// Must be called during `finish_cycle`.
-    pub(crate) fn maybe_return_early<S: WriteStorage + Send, H: HistoryMode>(
+    pub(crate) fn maybe_return_early<S: WriteStorage, H: HistoryMode>(
         &mut self,
         state: &mut ZkSyncVmState<S, H>,
         _bootloader_state: &mut BootloaderState,
@@ -211,7 +211,7 @@ impl FarCallHandler {
 
     /// Returns immediate [CallAction]s for the currently active FarCall.
     /// Must be called during `finish_cycle`.
-    pub(crate) fn take_immediate_actions<S: WriteStorage + Send, H: HistoryMode>(
+    pub(crate) fn take_immediate_actions<S: WriteStorage, H: HistoryMode>(
         &mut self,
         state: &mut ZkSyncVmState<S, H>,
         _bootloader_state: &mut BootloaderState,
@@ -220,7 +220,7 @@ impl FarCallHandler {
     }
 }
 
-fn populate_page_with_data<S: WriteStorage + Send, H: HistoryMode>(
+fn populate_page_with_data<S: WriteStorage, H: HistoryMode>(
     state: &mut ZkSyncVmState<S, H>,
     page: MemoryPage,
     data: Vec<u8>,

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -75,8 +75,8 @@ pub fn inspect_as_batch<DB, E>(
     call_ctx: CallContext,
 ) -> ZKVMResult<E>
 where
-    DB: Database + Send,
-    <DB as Database>::Error: Send + Debug,
+    DB: Database,
+    <DB as Database>::Error: Debug,
 {
     let txns = split_tx_by_factory_deps(tx);
     let total_txns = txns.len();
@@ -141,8 +141,8 @@ pub fn inspect<DB, E>(
     call_ctx: CallContext,
 ) -> ZKVMResult<E>
 where
-    DB: Database + Send,
-    <DB as Database>::Error: Send + Debug,
+    DB: Database,
+    <DB as Database>::Error: Debug,
 {
     let chain_id = if ecx.env.cfg.chain_id <= u32::MAX as u64 {
         L2ChainId::from(ecx.env.cfg.chain_id as u32)
@@ -329,7 +329,7 @@ where
     Ok(execution_result)
 }
 
-fn inspect_inner<S: ReadStorage + Send>(
+fn inspect_inner<S: ReadStorage>(
     l2_tx: L2Tx,
     storage: StoragePtr<StorageView<S>>,
     chain_id: L2ChainId,

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -32,8 +32,8 @@ pub fn transact<'a, DB>(
     db: &'a mut DB,
 ) -> eyre::Result<ResultAndState>
 where
-    DB: Database + Send,
-    <DB as Database>::Error: Send + Debug,
+    DB: Database,
+    <DB as Database>::Error: Debug,
 {
     info!(calldata = ?env.tx.data, fdeps = factory_deps.as_ref().map(|deps| deps.iter().map(|dep| dep.len()).join(",")).unwrap_or_default(), "zk transact");
 
@@ -124,8 +124,8 @@ pub fn create<DB, E>(
     mut ccx: CheatcodeTracerContext,
 ) -> ZKVMResult<E>
 where
-    DB: Database + Send,
-    <DB as Database>::Error: Send + Debug,
+    DB: Database,
+    <DB as Database>::Error: Debug,
 {
     info!(?call, "create tx {}", hex::encode(&call.init_code));
     let constructor_input = call.init_code[contract.evm_bytecode.len()..].to_vec();
@@ -175,8 +175,8 @@ pub fn call<DB, E>(
     mut ccx: CheatcodeTracerContext,
 ) -> ZKVMResult<E>
 where
-    DB: Database + Send,
-    <DB as Database>::Error: Send + Debug,
+    DB: Database,
+    <DB as Database>::Error: Debug,
 {
     info!(?call, "call tx {}", hex::encode(&call.input));
     let caller = ecx.env.tx.caller;
@@ -229,7 +229,7 @@ where
 /// Assign gas parameters that satisfy zkSync's fee model.
 fn gas_params<DB>(ecx: &mut EvmContext<DB>, caller: Address) -> (U256, U256)
 where
-    DB: Database + Send,
+    DB: Database,
     <DB as Database>::Error: Debug,
 {
     let value = ecx.env.tx.value.to_u256();

--- a/crates/zksync/core/src/vm/tracer.rs
+++ b/crates/zksync/core/src/vm/tracer.rs
@@ -141,7 +141,7 @@ impl CheatcodeTracer {
     }
 }
 
-impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer {
+impl<S, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer {
     fn before_decoding(&mut self, _state: VmLocalStateData<'_>, _memory: &SimpleMemory<H>) {}
 
     fn after_decoding(
@@ -328,7 +328,7 @@ impl<S: Send, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for CheatcodeTracer 
     }
 }
 
-impl<S: WriteStorage + Send, H: HistoryMode> VmTracer<S, H> for CheatcodeTracer {
+impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for CheatcodeTracer {
     fn initialize_tracer(&mut self, _state: &mut ZkSyncVmState<S, H>) {}
 
     fn finish_cycle(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
We had added a `Send` bound to the `DB` for Cheatcodes, but it doesn't seem to be used anywhere, and this makes merging with upstream more difficult.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Remove excess `Send`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
