### PR TITLE
fix(zk): merge code storage & nonce with zk-zk

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -34,7 +34,7 @@ use foundry_evm_core::{
 use foundry_zksync_compiler::{DualCompiledContract, DualCompiledContracts};
 use foundry_zksync_core::{
     convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
-    ZkTransactionMetadata,
+    get_account_code_key, get_balance_key, get_nonce_key, ZkTransactionMetadata,
 };
 use itertools::Itertools;
 use revm::{
@@ -60,8 +60,7 @@ use std::{
 };
 use zksync_types::{
     block::{pack_block_info, unpack_block_info},
-    get_code_key, get_nonce_key,
-    utils::{decompose_full_nonce, nonces_to_full_nonce, storage_key_for_eth_balance},
+    utils::{decompose_full_nonce, nonces_to_full_nonce},
     ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, CURRENT_VIRTUAL_BLOCK_INFO_POSITION,
     H256, KNOWN_CODES_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
     SYSTEM_CONTEXT_ADDRESS,
@@ -486,15 +485,15 @@ impl Cheatcodes {
             info!(?address, "importing to evm state");
 
             let zk_address = address.to_h160();
-            let balance_key = storage_key_for_eth_balance(&zk_address).key().to_ru256();
-            let nonce_key = get_nonce_key(&zk_address).key().to_ru256();
+            let balance_key = get_balance_key(address);
+            let nonce_key = get_nonce_key(address);
 
             let (balance, _) = data.sload(balance_account, balance_key).unwrap_or_default();
             let (full_nonce, _) = data.sload(nonce_account, nonce_key).unwrap_or_default();
             let (tx_nonce, _deployment_nonce) = decompose_full_nonce(full_nonce.to_u256());
             let nonce = tx_nonce.as_u64();
 
-            let account_code_key = get_code_key(&zk_address).key().to_ru256();
+            let account_code_key = get_account_code_key(address);
             let (code_hash, code) = data
                 .sload(account_code_account, account_code_key)
                 .map(|(value, _)| value)
@@ -562,19 +561,20 @@ impl Cheatcodes {
             let info = &account.info;
             let zk_address = address.to_h160();
 
-            let balance_key = storage_key_for_eth_balance(&zk_address).key().to_ru256();
-            let nonce_key = get_nonce_key(&zk_address).key().to_ru256();
+            let balance_key = get_balance_key(address);
             l2_eth_storage.insert(balance_key, EvmStorageSlot::new(info.balance));
 
             // TODO we need to find a proper way to handle deploy nonces instead of replicating
             let full_nonce = nonces_to_full_nonce(info.nonce.into(), info.nonce.into());
+
+            let nonce_key = get_nonce_key(address);
             nonce_storage.insert(nonce_key, EvmStorageSlot::new(full_nonce.to_ru256()));
 
             if let Some(contract) = self.dual_compiled_contracts.iter().find(|contract| {
                 info.code_hash != KECCAK_EMPTY && info.code_hash == contract.evm_bytecode_hash
             }) {
                 account_code_storage.insert(
-                    zk_address.to_h256().to_ru256(),
+                    get_account_code_key(address),
                     EvmStorageSlot::new(contract.zk_bytecode_hash.to_ru256()),
                 );
                 known_codes_storage

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -484,7 +484,6 @@ impl Cheatcodes {
         for address in data.db.persistent_accounts().into_iter().chain([data.env.tx.caller]) {
             info!(?address, "importing to evm state");
 
-            let zk_address = address.to_h160();
             let balance_key = get_balance_key(address);
             let nonce_key = get_nonce_key(address);
 
@@ -559,7 +558,6 @@ impl Cheatcodes {
 
             let account = journaled_account(data, address).expect("failed to load account");
             let info = &account.info;
-            let zk_address = address.to_h160();
 
             let balance_key = get_balance_key(address);
             l2_eth_storage.insert(balance_key, EvmStorageSlot::new(info.balance));

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -593,7 +593,7 @@ impl Cheatcodes {
                     },
                 );
             } else {
-                tracing::debug!("no zk contract found for {:?}", info.code_hash)
+                tracing::debug!(code_hash = ?info.code_hash, ?address, "no zk contract found")
             }
         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -33,7 +33,7 @@ use foundry_evm_core::{
 };
 use foundry_zksync_compiler::{DualCompiledContract, DualCompiledContracts};
 use foundry_zksync_core::{
-    convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
+    convert::{ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
     get_account_code_key, get_balance_key, get_nonce_key, ZkTransactionMetadata,
 };
 use itertools::Itertools;
@@ -284,19 +284,18 @@ impl Cheatcodes {
         let cheatcodes_bytecode = {
             let mut bytecode = CHEATCODE_ADDRESS.abi_encode_packed();
             bytecode.append(&mut [0; 12].to_vec());
-            bytecode
+            Bytes::from(bytecode)
         };
-        let cheatcodes_bytecode_bytes = Bytes::from(cheatcodes_bytecode);
         dual_compiled_contracts.push(DualCompiledContract {
             name: String::from("CheatcodeBytecode"),
             // we put a different bytecode hash here so when importing back to EVM
             // we avoid collision with EmptyEVMBytecode for the cheatcodes
             zk_bytecode_hash: foundry_zksync_core::hash_bytecode(CHEATCODE_CONTRACT_HASH.as_ref()),
-            zk_deployed_bytecode: cheatcodes_bytecode_bytes.to_vec(),
+            zk_deployed_bytecode: cheatcodes_bytecode.to_vec(),
             zk_factory_deps: Default::default(),
             evm_bytecode_hash: CHEATCODE_CONTRACT_HASH,
-            evm_deployed_bytecode: cheatcodes_bytecode_bytes.to_vec(),
-            evm_bytecode: cheatcodes_bytecode_bytes.to_vec(),
+            evm_deployed_bytecode: cheatcodes_bytecode.to_vec(),
+            evm_bytecode: cheatcodes_bytecode.to_vec(),
         });
 
         let mut persisted_factory_deps = HashMap::new();

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -281,14 +281,23 @@ impl Cheatcodes {
             evm_deployed_bytecode: Bytecode::new_raw(empty_bytes.clone()).bytecode().to_vec(),
             evm_bytecode: Bytecode::new_raw(empty_bytes.clone()).bytecode().to_vec(),
         });
+
+        let cheatcodes_bytecode = {
+            let mut bytecode = CHEATCODE_ADDRESS.abi_encode_packed();
+            bytecode.append(&mut [0; 12].to_vec());
+            bytecode
+        };
+        let cheatcodes_bytecode_bytes = Bytes::from(cheatcodes_bytecode);
         dual_compiled_contracts.push(DualCompiledContract {
             name: String::from("CheatcodeBytecode"),
-            zk_bytecode_hash,
-            zk_deployed_bytecode: zk_deployed_bytecode.clone(),
+            // we put a different bytecode hash here so when importing back to EVM
+            // we avoid collision with EmptyEVMBytecode for the cheatcodes
+            zk_bytecode_hash: foundry_zksync_core::hash_bytecode(CHEATCODE_CONTRACT_HASH.as_ref()),
+            zk_deployed_bytecode: cheatcodes_bytecode_bytes.to_vec(),
             zk_factory_deps: Default::default(),
             evm_bytecode_hash: CHEATCODE_CONTRACT_HASH,
-            evm_deployed_bytecode: Bytecode::new_raw(empty_bytes.clone()).bytecode().to_vec(),
-            evm_bytecode: Bytecode::new_raw(empty_bytes).bytecode().to_vec(),
+            evm_deployed_bytecode: cheatcodes_bytecode_bytes.to_vec(),
+            evm_bytecode: cheatcodes_bytecode_bytes.to_vec(),
         });
 
         let mut persisted_factory_deps = HashMap::new();

--- a/crates/evm/core/src/backend/fork_type.rs
+++ b/crates/evm/core/src/backend/fork_type.rs
@@ -37,12 +37,12 @@ impl CachedForkType {
 
         let is_zk_url = foundry_common::provider::try_get_http_provider(fork_url)
             .map(|provider| {
-                let is_zk_url =
-                    futures::executor::block_on(provider.raw_request("zks_L1ChainId".into(), ()))
-                        .map(|_: String| true)
-                        .unwrap_or_default();
-
-                is_zk_url
+                tokio::task::block_in_place(move || {
+                    tokio::runtime::Handle::current()
+                        .block_on(provider.raw_request::<_, String>("zks_L1ChainId".into(), ()))
+                        .map(|_| true)
+                })
+                .unwrap_or_default()
             })
             .unwrap_or_default();
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1947,26 +1947,31 @@ fn merge_db_account_data<ExtDB: DatabaseRef>(
     active: &CacheDB<ExtDB>,
     fork_db: &mut ForkDB,
 ) {
+    let Some(acc) = active.accounts.get(&addr) else { return };
 
-    let mut acc = if let Some(acc) = active.accounts.get(&addr).cloned() {
-        acc
-    } else {
-        // Account does not exist
-        return;
-    };
-
-    if let Some(code) = active.contracts.get(&acc.info.code_hash).cloned() {
-        fork_db.contracts.insert(acc.info.code_hash, code);
+    // port contract cache over
+    if let Some(code) = active.contracts.get(&acc.info.code_hash) {
+        trace!("merging contract cache");
+        fork_db.contracts.insert(acc.info.code_hash, code.clone());
     }
 
-    if let Some(fork_account) = fork_db.accounts.get_mut(&addr) {
-        // This will merge the fork's tracked storage with active storage and update values
-        fork_account.storage.extend(std::mem::take(&mut acc.storage));
-        // swap them so we can insert the account as whole in the next step
-        std::mem::swap(&mut fork_account.storage, &mut acc.storage);
+    // port account storage over
+    use std::collections::hash_map::Entry;
+    match fork_db.accounts.entry(addr) {
+        Entry::Vacant(vacant) => {
+            trace!("target account not present - inserting from active");
+            // if the fork_db doesn't have the target account
+            // insert the entire thing
+            vacant.insert(acc.clone());
+        }
+        Entry::Occupied(mut occupied) => {
+            trace!("target account present - merging storage slots");
+            // if the fork_db does have the system,
+            // extend the existing storage (overriding)
+            let fork_account = occupied.get_mut();
+            fork_account.storage.extend(&acc.storage);
+        }
     }
-
-    fork_db.accounts.insert(addr, acc);
 }
 
 /// Clones the zk account data from the `active` db into the `ForkDB`

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -14,8 +14,7 @@ use alloy_serde::WithOtherFields;
 use eyre::Context;
 use foundry_common::{is_known_system_sender, SYSTEM_TRANSACTION_TYPE};
 use foundry_zksync_core::{
-    convert::{ConvertH160},
-    ACCOUNT_CODE_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
+    convert::ConvertH160, ACCOUNT_CODE_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
 };
 use itertools::Itertools;
 use revm::{

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -14,7 +14,7 @@ use alloy_serde::WithOtherFields;
 use eyre::Context;
 use foundry_common::{is_known_system_sender, SYSTEM_TRANSACTION_TYPE};
 use foundry_zksync_core::{
-    convert::{ConvertH160, ConvertRU256},
+    convert::{ConvertH160},
     ACCOUNT_CODE_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
 };
 use itertools::Itertools;
@@ -29,7 +29,7 @@ use revm::{
     Database, DatabaseCommit, JournaledState,
 };
 use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     time::Instant,
 };
 

--- a/crates/forge/tests/it/zk/issues.rs
+++ b/crates/forge/tests/it/zk/issues.rs
@@ -9,7 +9,7 @@ use foundry_test_utils::Filter;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zk_issue497() {
     let runner = TEST_DATA_DEFAULT.runner_zksync();
-    let filter = Filter::new("*", "Issue497", ".*");
+    let filter = Filter::new(".*", "Issue497", ".*");
 
     TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
 }

--- a/crates/forge/tests/it/zk/issues.rs
+++ b/crates/forge/tests/it/zk/issues.rs
@@ -1,0 +1,19 @@
+//! Forge tests for zkysnc issues, to avoid regressions.
+//!
+//! Issue list: https://github.com/matter-labs/foundry-zksync/issues
+
+use crate::{config::*, test_helpers::TEST_DATA_DEFAULT};
+use forge::revm::primitives::SpecId;
+use foundry_test_utils::Filter;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zk_issue497() {
+    let runner = TEST_DATA_DEFAULT.runner_zksync();
+    let filter = Filter::new(
+        "*",
+        "Issue497",
+        ".*",
+    );
+
+    TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
+}

--- a/crates/forge/tests/it/zk/issues.rs
+++ b/crates/forge/tests/it/zk/issues.rs
@@ -9,11 +9,7 @@ use foundry_test_utils::Filter;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zk_issue497() {
     let runner = TEST_DATA_DEFAULT.runner_zksync();
-    let filter = Filter::new(
-        "*",
-        "Issue497",
-        ".*",
-    );
+    let filter = Filter::new("*", "Issue497", ".*");
 
     TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
 }

--- a/crates/forge/tests/it/zk/mod.rs
+++ b/crates/forge/tests/it/zk/mod.rs
@@ -2,4 +2,5 @@
 mod basic;
 mod cheats;
 mod contracts;
+mod issues;
 mod logs;

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -58,6 +58,16 @@ pub fn get_balance_key(address: Address) -> rU256 {
     storage_key_for_eth_balance(&address.to_h160()).key().to_ru256()
 }
 
+/// Returns the account code storage key for a provided account address.
+pub fn get_account_code_key(address: Address) -> rU256 {
+    zksync_types::get_code_key(&address.to_h160()).key().to_ru256()
+}
+
+/// Returns the account nonce key for a provided account address.
+pub fn get_nonce_key(address: Address) -> rU256 {
+    zksync_types::get_nonce_key(&address.to_h160()).key().to_ru256()
+}
+
 /// Represents additional data for ZK transactions.
 #[derive(Clone, Debug, Default)]
 pub struct ZkTransactionMetadata {

--- a/crates/zksync/core/src/vm/storage_view.rs
+++ b/crates/zksync/core/src/vm/storage_view.rs
@@ -76,7 +76,7 @@ impl<S: ReadStorage + fmt::Debug> ReadStorage for StorageView<S> {
         if key.address() == &ACCOUNT_CODE_STORAGE_ADDRESS && key.key() == &self.caller.to_h256() {
             let value = StorageValue::zero();
             tracing::trace!(
-                hash = ?key.hashed_key(),
+                hashed_key = ?key.hashed_key(),
                 ?value,
                 address = ?key.address(),
                 key = ?key.key(),
@@ -87,7 +87,7 @@ impl<S: ReadStorage + fmt::Debug> ReadStorage for StorageView<S> {
         }
 
         tracing::trace!(
-            hash = ?key.hashed_key(),
+            hashed_key = ?key.hashed_key(),
             ?value,
             address = ?key.address(),
             key = ?key.key(),
@@ -127,7 +127,7 @@ impl<S: ReadStorage + fmt::Debug> WriteStorage for StorageView<S> {
         let original = self.get_value_no_log(&key);
 
         tracing::trace!(
-            hash = ?key.hashed_key(),
+            hashed_key = ?key.hashed_key(),
             ?value,
             ?original,
             address = ?key.address(),

--- a/crates/zksync/core/src/vm/storage_view.rs
+++ b/crates/zksync/core/src/vm/storage_view.rs
@@ -76,22 +76,22 @@ impl<S: ReadStorage + fmt::Debug> ReadStorage for StorageView<S> {
         if key.address() == &ACCOUNT_CODE_STORAGE_ADDRESS && key.key() == &self.caller.to_h256() {
             let value = StorageValue::zero();
             tracing::trace!(
-                "override read value {:?} {:?} ({:?}/{:?})",
-                key.hashed_key(),
-                value,
-                key.address(),
-                key.key()
+                hash = ?key.hashed_key(),
+                ?value,
+                address = ?key.address(),
+                key = ?key.key(),
+                "override read value",
             );
 
             return value
         }
 
         tracing::trace!(
-            "read value {:?} {:?} ({:?}/{:?})",
-            key.hashed_key(),
-            value,
-            key.address(),
-            key.key()
+            hash = ?key.hashed_key(),
+            ?value,
+            address = ?key.address(),
+            key = ?key.key(),
+            "read value",
         );
 
         value
@@ -127,12 +127,12 @@ impl<S: ReadStorage + fmt::Debug> WriteStorage for StorageView<S> {
         let original = self.get_value_no_log(&key);
 
         tracing::trace!(
-            "write value {:?} value: {:?} original value: {:?} ({:?}/{:?})",
-            key.hashed_key(),
-            value,
-            original,
-            key.address(),
-            key.key()
+            hash = ?key.hashed_key(),
+            ?value,
+            ?original,
+            address = ?key.address(),
+            key = ?key.key(),
+            "write value",
         );
         self.modified_storage_keys.insert(key, value);
 

--- a/testdata/zk/Issues.t.sol
+++ b/testdata/zk/Issues.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+import {Globals} from "./Globals.sol";
+
+// https://github.com/matter-labs/foundry-zksync/issues/497
+contract Issue497 is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    uint256 constant ERA_FORK_BLOCK = 19579636;
+
+    uint256 forkEra;
+
+    function setUp() public {
+        forkEra = vm.createFork(Globals.ZKSYNC_MAINNET_URL, ERA_FORK_BLOCK);
+    }
+
+    function testZkEnsureContractMigratedWhenForkZkSyncThenZkVmOff() external {
+       vm.selectFork(forkEra);
+       vm.zkVm(false);
+       assert(address(vm).codehash != 0);
+    }
+}

--- a/testdata/zk/Issues.t.sol
+++ b/testdata/zk/Issues.t.sol
@@ -18,8 +18,8 @@ contract Issue497 is DSTest {
     }
 
     function testZkEnsureContractMigratedWhenForkZkSyncThenZkVmOff() external {
-       vm.selectFork(forkEra);
-       vm.zkVm(false);
-       assert(address(vm).codehash != 0);
+        vm.selectFork(forkEra);
+        vm.zkVm(false);
+        assert(address(vm).codehash != 0);
     }
 }

--- a/zk-tests/src/Basic.t.sol
+++ b/zk-tests/src/Basic.t.sol
@@ -45,14 +45,6 @@ contract ZkBasicTest is Test {
         );
     }
 
-    function test_migrateCodeHashWhenforkZkSyncThenZkVmOff() external {
-       vm.createSelectFork("mainnet");
-       (bool success, ) = address(vm).call(
-           abi.encodeWithSignature("zkVm(bool)", false)
-       );
-       assert(address(vm).codehash != 0);
-    }
-
     function testZkBasicBlockNumber() public {
         vm.selectFork(forkEra);
         require(block.number == ERA_FORK_BLOCK, "era block number mismatch");

--- a/zk-tests/src/Basic.t.sol
+++ b/zk-tests/src/Basic.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
+import "forge-std/Test.sol";
 
 contract BlockEnv {
     uint256 public number;

--- a/zk-tests/src/Basic.t.sol
+++ b/zk-tests/src/Basic.t.sol
@@ -45,6 +45,14 @@ contract ZkBasicTest is Test {
         );
     }
 
+    function test_migrateCodeHashWhenforkZkSyncThenZkVmOff() external {
+       vm.createSelectFork("mainnet");
+       (bool success, ) = address(vm).call(
+           abi.encodeWithSignature("zkVm(bool)", false)
+       );
+       assert(address(vm).codehash != 0);
+    }
+
     function testZkBasicBlockNumber() public {
         vm.selectFork(forkEra);
         require(block.number == ERA_FORK_BLOCK, "era block number mismatch");

--- a/zk-tests/src/Issues.t.sol
+++ b/zk-tests/src/Issues.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 import "forge-std/Test.sol";
 
 // https://github.com/matter-labs/foundry-zksync/issues/497
-contract Issue497 is DSTest {
+contract Issue497 is Test {
     uint256 constant ERA_FORK_BLOCK = 19579636;
 
     uint256 forkEra;

--- a/zk-tests/src/Issues.t.sol
+++ b/zk-tests/src/Issues.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "forge-std/Test.sol";
+
+// https://github.com/matter-labs/foundry-zksync/issues/497
+contract Issue497 is DSTest {
+    uint256 constant ERA_FORK_BLOCK = 19579636;
+
+    uint256 forkEra;
+
+    function setUp() public {
+        forkEra = vm.createFork("mainnet", ERA_FORK_BLOCK);
+    }
+
+    function testZkEnsureContractMigratedWhenForkZkSyncThenZkVmOff() external {
+       vm.selectFork(forkEra);
+       (bool success, ) = address(vm).call(
+           abi.encodeWithSignature("zkVm(bool)", false)
+       );
+       assert(address(vm).codehash != 0);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
After #497 report, investigation led to find that the cause was the incorrectly read value from ZK storage, done when migrating back to EVM, which lead to the checks inserted by solidity to fail.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Also migrate account code storage & nonce when switching between ZK forks
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
