### PR TITLE
fix: use zksync contract size limits in --zksync mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#50e8785e8b880373bc741bdbeb9b6eb7c20501f1"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4974,6 +4974,7 @@ dependencies = [
  "derivative",
  "dirs 5.0.1",
  "dyn-clone",
+ "fd-lock 4.0.2",
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
@@ -5004,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#50e8785e8b880373bc741bdbeb9b6eb7c20501f1"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5014,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#50e8785e8b880373bc741bdbeb9b6eb7c20501f1"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5036,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#50e8785e8b880373bc741bdbeb9b6eb7c20501f1"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5048,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-zksolc"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#50e8785e8b880373bc741bdbeb9b6eb7c20501f1"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5069,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#50e8785e8b880373bc741bdbeb9b6eb7c20501f1"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
 dependencies = [
  "alloy-primitives",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#e4afd97fc5a5f1b48b279c0f90b53388503dbb5b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4974,9 +4974,9 @@ dependencies = [
  "derivative",
  "dirs 5.0.1",
  "dyn-clone",
- "fd-lock 4.0.2",
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
+ "fs4",
  "fs_extra",
  "futures-util",
  "home",
@@ -5005,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#e4afd97fc5a5f1b48b279c0f90b53388503dbb5b"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#e4afd97fc5a5f1b48b279c0f90b53388503dbb5b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#e4afd97fc5a5f1b48b279c0f90b53388503dbb5b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-zksolc"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#e4afd97fc5a5f1b48b279c0f90b53388503dbb5b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5070,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.8.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#752ab0cf4fa4a7211137ddca563fcf6381de94e7"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.8.0#e4afd97fc5a5f1b48b279c0f90b53388503dbb5b"
 dependencies = [
  "alloy-primitives",
  "cfg-if 1.0.0",

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -112,6 +112,7 @@ impl BuildArgs {
             let zk_compiler = ProjectCompiler::new()
                 .print_names(self.names)
                 .print_sizes(self.sizes)
+                .zksync_sizes()
                 .quiet(self.format_json)
                 .bail(!self.format_json);
 

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -51,6 +51,13 @@ forgetest_init!(build_sizes_no_forge_std, |prj, cmd| {
     assert!(stdout.contains("Counter"), "\n{stdout}");
 });
 
+// tests build output is as expected in zksync mode
+forgetest_init!(test_zk_build_sizes, |prj, cmd| {
+    cmd.args(["build", "--sizes", "--zksync"]);
+    let stdout = cmd.stdout_lossy();
+    assert!(stdout.contains("| Counter        |      800 |    450,199 |"), "\n{stdout}");
+});
+
 // tests that skip key in config can be used to skip non-compilable contract
 forgetest_init!(test_can_skip_contract, |prj, cmd| {
     prj.add_source(

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -53,7 +53,7 @@ forgetest_init!(build_sizes_no_forge_std, |prj, cmd| {
 
 // tests build output is as expected in zksync mode
 forgetest_init!(test_zk_build_sizes, |prj, cmd| {
-    cmd.args(["build", "--sizes", "--zksync"]);
+    cmd.args(["build", "--sizes", "--zksync", "--evm-version", "shanghai"]);
     let stdout = cmd.stdout_lossy();
     assert!(stdout.contains("| Counter        |      800 |    450,199 |"), "\n{stdout}");
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1539,6 +1539,8 @@ contract DeployScript is Script {
         "--rpc-url",
         node.url().as_str(),
         "--slow",
+        "--evm-version",
+        "shanghai",
     ]);
 
     assert!(cmd.stdout_lossy().contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL"));

--- a/crates/forge/tests/cli/zksync_node.rs
+++ b/crates/forge/tests/cli/zksync_node.rs
@@ -16,7 +16,7 @@ use futures::{SinkExt, StreamExt};
 use jsonrpc_core::IoHandler;
 use zksync_types::H160;
 
-const DEFAULT_PORT: u16 = 8011;
+const DEFAULT_PORT: u16 = 108011;
 
 /// List of legacy wallets (address, private key) that we seed with tokens at start.
 const LEGACY_RICH_WALLETS: [(&str, &str); 10] = [

--- a/crates/forge/tests/cli/zksync_node.rs
+++ b/crates/forge/tests/cli/zksync_node.rs
@@ -16,7 +16,7 @@ use futures::{SinkExt, StreamExt};
 use jsonrpc_core::IoHandler;
 use zksync_types::H160;
 
-const DEFAULT_PORT: u16 = 108011;
+const DEFAULT_PORT: u16 = 18011;
 
 /// List of legacy wallets (address, private key) that we seed with tokens at start.
 const LEGACY_RICH_WALLETS: [(&str, &str); 10] = [


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
As reported in #504 we are still reporting the size margins from [eip-170](https://eips.ethereum.org/EIPS/eip-170) (foundry default) in zksync mode.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Report margins via zksync's contract sizes as stated in their [documentation](https://docs.zksync.io/build/developer-reference/ethereum-differences/contract-deployment#contract-size-limit-and-format-of-bytecode-hash).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
