### PR TITLE
test: use a regex to match build sizes output

### DIFF
--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -2,6 +2,7 @@ use foundry_common::fs::read_json_file;
 use foundry_config::Config;
 use foundry_test_utils::forgetest;
 use globset::Glob;
+use regex::Regex;
 use std::{collections::BTreeMap, path::PathBuf};
 
 // tests that json is printed when --json is passed
@@ -55,7 +56,9 @@ forgetest_init!(build_sizes_no_forge_std, |prj, cmd| {
 forgetest_init!(test_zk_build_sizes, |prj, cmd| {
     cmd.args(["build", "--sizes", "--zksync", "--evm-version", "shanghai"]);
     let stdout = cmd.stdout_lossy();
-    assert!(stdout.contains("| Counter        |      800 |    450,199 |"), "\n{stdout}");
+    let pattern = Regex::new(r"\|\s*Counter\s*\|\s*800\s*\|\s*450,199\s*\|").unwrap();
+
+    assert!(pattern.is_match(&stdout), "Unexpected size output:\n{stdout}");
 });
 
 // tests that skip key in config can be used to skip non-compilable contract


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When updating foundry I got some different amount of whitespace on the sizes test table. Whitespace on table alignment may not be consistent.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Use a regex as we care about the having the correct values in the table entry vs having the exact output.
