### PR TITLE
test(zk): migrate mocked modifier

### DIFF
--- a/crates/forge/tests/it/zk/cheats.rs
+++ b/crates/forge/tests/it/zk/cheats.rs
@@ -90,3 +90,11 @@ async fn test_zk_cheat_works_after_fork() {
 
     TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zk_can_mock_modifiers() {
+    let runner = TEST_DATA_DEFAULT.runner_zksync();
+    let filter = Filter::new(".*", "MockedModifierTest", ".*");
+
+    TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
+}

--- a/testdata/zk/MockedModifier.t.sol
+++ b/testdata/zk/MockedModifier.t.sol
@@ -7,11 +7,7 @@ import "../cheats/Vm.sol";
 
 contract MockInner {
     // this covers an edge case that mainfests when returning >=5 items
-    function mockedMethod()
-        external
-        pure
-        returns (uint256, uint256, uint256, uint256, uint256)
-    {
+    function mockedMethod() external pure returns (uint256, uint256, uint256, uint256, uint256) {
         // We fail if this function isn't mocked
         assert(false);
         return (0, 0, 0, 0, 0);
@@ -27,7 +23,7 @@ contract Echoer {
 
     modifier needsMocking(uint256 n) {
         //we just check that we actually mock the value (to avoid optimization)
-        (, , uint r, , ) = mockInner.mockedMethod();
+        (,, uint256 r,,) = mockInner.mockedMethod();
         assert(r == n);
         _;
     }
@@ -40,16 +36,12 @@ contract Echoer {
         return n;
     }
 
-    function echo(
-        uint256[] memory n
-    ) external view needsMocking(42) returns (uint256[] memory) {
+    function echo(uint256[] memory n) external view needsMocking(42) returns (uint256[] memory) {
         assert(n.length == 1);
         return n;
     }
 
-    function echo(
-        Foo memory n
-    ) external view needsMocking(42) returns (Foo memory) {
+    function echo(Foo memory n) external view needsMocking(42) returns (Foo memory) {
         return n;
     }
 }
@@ -69,9 +61,7 @@ contract MockedModifierTest is DSTest {
         uint256 n = 10;
 
         vm.mockCall(
-            address(mockInner),
-            abi.encodeWithSelector(MockInner.mockedMethod.selector),
-            abi.encode(0, 0, 42, 0, 0, 0)
+            address(mockInner), abi.encodeWithSelector(MockInner.mockedMethod.selector), abi.encode(0, 0, 42, 0, 0, 0)
         );
 
         assertEq(n, target.echo(n));
@@ -82,11 +72,9 @@ contract MockedModifierTest is DSTest {
         n[0] = 10;
 
         vm.mockCall(
-            address(mockInner),
-            abi.encodeWithSelector(MockInner.mockedMethod.selector),
-            abi.encode(0, 0, 42, 0, 0, 0)
+            address(mockInner), abi.encodeWithSelector(MockInner.mockedMethod.selector), abi.encode(0, 0, 42, 0, 0, 0)
         );
-        
+
         assertEq(n[0], target.echo(n)[0]);
     }
 
@@ -94,11 +82,9 @@ contract MockedModifierTest is DSTest {
         Echoer.Foo memory n = Echoer.Foo({foo: 10});
 
         vm.mockCall(
-            address(mockInner),
-            abi.encodeWithSelector(MockInner.mockedMethod.selector),
-            abi.encode(0, 0, 42, 0, 0, 0)
+            address(mockInner), abi.encodeWithSelector(MockInner.mockedMethod.selector), abi.encode(0, 0, 42, 0, 0, 0)
         );
-        
+
         assertEq(n.foo, target.echo(n).foo);
     }
 }

--- a/testdata/zk/MockedModifier.t.sol
+++ b/testdata/zk/MockedModifier.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+contract MockInner {
+    // this covers an edge case that mainfests when returning >=5 items
+    function mockedMethod()
+        external
+        pure
+        returns (uint256, uint256, uint256, uint256, uint256)
+    {
+        // We fail if this function isn't mocked
+        assert(false);
+        return (0, 0, 0, 0, 0);
+    }
+}
+
+contract Echoer {
+    MockInner internal mockInner;
+
+    struct Foo {
+        uint256 foo;
+    }
+
+    modifier needsMocking(uint256 n) {
+        //we just check that we actually mock the value (to avoid optimization)
+        (, , uint r, , ) = mockInner.mockedMethod();
+        assert(r == n);
+        _;
+    }
+
+    constructor(address _mockInnerAddress) {
+        mockInner = MockInner(_mockInnerAddress);
+    }
+
+    function echo(uint256 n) external view needsMocking(42) returns (uint256) {
+        return n;
+    }
+
+    function echo(
+        uint256[] memory n
+    ) external view needsMocking(42) returns (uint256[] memory) {
+        assert(n.length == 1);
+        return n;
+    }
+
+    function echo(
+        Foo memory n
+    ) external view needsMocking(42) returns (Foo memory) {
+        return n;
+    }
+}
+
+contract MockedModifierTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    Echoer target;
+    MockInner mockInner;
+
+    function setUp() public {
+        mockInner = new MockInner();
+        target = new Echoer(address(mockInner));
+    }
+
+    function testMockedModifierTestCanMockNumber() public {
+        uint256 n = 10;
+
+        vm.mockCall(
+            address(mockInner),
+            abi.encodeWithSelector(MockInner.mockedMethod.selector),
+            abi.encode(0, 0, 42, 0, 0, 0)
+        );
+
+        assertEq(n, target.echo(n));
+    }
+
+    function testMockedModifierTestCanMockArray() public {
+        uint256[] memory n = new uint256[](1);
+        n[0] = 10;
+
+        vm.mockCall(
+            address(mockInner),
+            abi.encodeWithSelector(MockInner.mockedMethod.selector),
+            abi.encode(0, 0, 42, 0, 0, 0)
+        );
+        
+        assertEq(n[0], target.echo(n)[0]);
+    }
+
+    function testMockedModifierTestCanMockStruct() public {
+        Echoer.Foo memory n = Echoer.Foo({foo: 10});
+
+        vm.mockCall(
+            address(mockInner),
+            abi.encodeWithSelector(MockInner.mockedMethod.selector),
+            abi.encode(0, 0, 42, 0, 0, 0)
+        );
+        
+        assertEq(n.foo, target.echo(n).foo);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently we only ensure we can mock calls in modifiers in zk-tests
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Migrate test to forge test suite
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
