### PR TITLE
chore: add sqlx issue to cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,9 @@ ignore = [
     "RUSTSEC-2022-0041",
     "RUSTSEC-2023-0045",
     "RUSTSEC-2020-0016",
+    # https://github.com/launchbadge/sqlx/issues/3440
+    # Should remove once we can update sqlx which is used by some zksync dependencies
+    "RUSTSEC-2024-0363",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`cargo deny` is failing due to [an issue in sqlx](https://github.com/launchbadge/sqlx/issues/3440) which may potentially cause sql injection involving large user inputs. The issue has not been fixed yet, and the maintainers claim it might not be problematic save for some edge cases. Furthermore, the package is used by `era_test_node`,  where sql injection would not matter as it runs on the user's machine.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Ignore the issue on `cargo deny`
