### PR TITLE
test(zk): cheatcode usage in zkVm

### DIFF
--- a/crates/forge/tests/it/zk/cheats.rs
+++ b/crates/forge/tests/it/zk/cheats.rs
@@ -113,3 +113,11 @@ async fn test_zk_record_logs() {
 
     TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zk_cheatcodes_in_zkvm() {
+    let runner = TEST_DATA_DEFAULT.runner_zksync();
+    let filter = Filter::new(".*", "ZkCheatcodesInZkVmTest", ".*");
+
+    TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
+}

--- a/testdata/zk/Cheatcodes.t.sol
+++ b/testdata/zk/Cheatcodes.t.sol
@@ -228,7 +228,7 @@ contract ZkCheatcodesTest is DSTest {
 
 contract UsesCheatcodes {
     function getNonce(Vm vm, address target) public view returns (uint64) {
-       return vm.getNonce(target);
+        return vm.getNonce(target);
     }
 
     function getZkBalance(Vm vm, address target) public view returns (uint256) {

--- a/testdata/zk/Cheatcodes.t.sol
+++ b/testdata/zk/Cheatcodes.t.sol
@@ -225,3 +225,56 @@ contract ZkCheatcodesTest is DSTest {
         // 11: EthToken
     }
 }
+
+contract UsesCheatcodes {
+    function getNonce(Vm vm, address target) public view returns (uint64) {
+       return vm.getNonce(target);
+    }
+
+    function getZkBalance(Vm vm, address target) public view returns (uint256) {
+        vm.zkVm(true);
+        getNonce(vm, target);
+        return target.balance;
+    }
+}
+
+contract ZkCheatcodesInZkVmTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    UsesCheatcodes helper;
+
+    function setUp() external {
+        vm.zkVm(true);
+        helper = new UsesCheatcodes();
+        // ensure we can call cheatcodes from the helper
+        vm.allowCheatcodes(address(helper));
+        // and that the contract is kept between vm switches
+        vm.makePersistent(address(helper));
+    }
+
+    function testCallVmInZkVm() external {
+        address target = address(this);
+
+        vm.expectRevert();
+        helper.getNonce(vm, target);
+    }
+
+    function testCallVmAfterDisableZkVm() external {
+        address target = address(this);
+        uint64 expected = vm.getNonce(target);
+
+        vm.zkVm(false);
+        uint64 got = helper.getNonce(vm, target);
+
+        assertEq(expected, got);
+    }
+
+    function testCallVmAfterDisableZkVmAndReEnable() external {
+        address target = address(this);
+        uint256 expected = target.balance;
+
+        vm.zkVm(false);
+        uint256 got = helper.getZkBalance(vm, target);
+
+        assertEq(expected, got);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Cheatcodes are not supported in zkVm, but there are no tests that display this limitation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Provide a test case which shows this limitation and also potential pattern to avoid a given contract from being executed in zkVm and thus circumvent this limtation
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
