### PR TITLE
chore: use InspectorExt trait for logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,7 +5237,6 @@ dependencies = [
  "foundry-evm-traces",
  "foundry-zksync-core",
  "indicatif",
- "itertools 0.13.0",
  "parking_lot 0.12.3",
  "proptest",
  "revm",

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -927,7 +927,7 @@ impl Cheatcodes {
 
                 // append console logs from zkEVM to the current executor's LogTracer
                 let executor = &mut TransparentCheatcodesExecutor;
-                result.logs.iter().filter_map(|log| decode_console_log).for_each(|decoded_log| {
+                result.logs.iter().filter_map(decode_console_log).for_each(|decoded_log| {
                     executor.console_log(
                         &mut CheatsCtxt {
                             state: self,
@@ -1404,7 +1404,7 @@ impl Cheatcodes {
                 }
 
                 // append console logs from zkEVM to the current executor's LogTracer
-                result.logs.iter().filter_map(|log| decode_console_log).for_each(|decoded_log| {
+                result.logs.iter().filter_map(decode_console_log).for_each(|decoded_log| {
                     executor.console_log(
                         &mut CheatsCtxt {
                             state: self,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -927,20 +927,18 @@ impl Cheatcodes {
 
                 // append console logs from zkEVM to the current executor's LogTracer
                 let executor = &mut TransparentCheatcodesExecutor;
-                result.logs.iter().filter_map(|log| decode_console_log(log)).for_each(
-                    |decoded_log| {
-                        executor.console_log(
-                            &mut CheatsCtxt {
-                                state: self,
-                                ecx: &mut ecx.inner,
-                                precompiles: &mut ecx.precompiles,
-                                gas_limit: create_inputs.gas_limit,
-                                caller: create_inputs.caller,
-                            },
-                            decoded_log,
-                        );
-                    },
-                );
+                result.logs.iter().filter_map(|log| decode_console_log).for_each(|decoded_log| {
+                    executor.console_log(
+                        &mut CheatsCtxt {
+                            state: self,
+                            ecx: &mut ecx.inner,
+                            precompiles: &mut ecx.precompiles,
+                            gas_limit: create_inputs.gas_limit,
+                            caller: create_inputs.caller,
+                        },
+                        decoded_log,
+                    );
+                });
 
                 // for each log in cloned logs call handle_expect_emit
                 if !self.expected_emits.is_empty() {
@@ -1406,20 +1404,18 @@ impl Cheatcodes {
                 }
 
                 // append console logs from zkEVM to the current executor's LogTracer
-                result.logs.iter().filter_map(|log| decode_console_log(log)).for_each(
-                    |decoded_log| {
-                        executor.console_log(
-                            &mut CheatsCtxt {
-                                state: self,
-                                ecx: &mut ecx.inner,
-                                precompiles: &mut ecx.precompiles,
-                                gas_limit: call.gas_limit,
-                                caller: call.caller,
-                            },
-                            decoded_log,
-                        );
-                    },
-                );
+                result.logs.iter().filter_map(|log| decode_console_log).for_each(|decoded_log| {
+                    executor.console_log(
+                        &mut CheatsCtxt {
+                            state: self,
+                            ecx: &mut ecx.inner,
+                            precompiles: &mut ecx.precompiles,
+                            gas_limit: call.gas_limit,
+                            caller: call.caller,
+                        },
+                        decoded_log,
+                    );
+                });
 
                 // for each log in cloned logs call handle_expect_emit
                 if !self.expected_emits.is_empty() {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -927,7 +927,7 @@ impl Cheatcodes {
 
                 // append console logs from zkEVM to the current executor's LogTracer
                 let executor = &mut TransparentCheatcodesExecutor;
-                result.logs.iter().filter_map(|log| decode_console_log(&log)).for_each(
+                result.logs.iter().filter_map(|log| decode_console_log(log)).for_each(
                     |decoded_log| {
                         executor.console_log(
                             &mut CheatsCtxt {
@@ -1406,7 +1406,7 @@ impl Cheatcodes {
                 }
 
                 // append console logs from zkEVM to the current executor's LogTracer
-                result.logs.iter().filter_map(|log| decode_console_log(&log)).for_each(
+                result.logs.iter().filter_map(|log| decode_console_log(log)).for_each(
                     |decoded_log| {
                         executor.console_log(
                             &mut CheatsCtxt {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -46,7 +46,7 @@ use revm::{
         AccountInfo, BlockEnv, Bytecode, CreateScheme, EVMError, Env, EvmStorageSlot,
         ExecutionResult, HashMap as rHashMap, Output, TransactTo, KECCAK_EMPTY,
     },
-    EvmContext, GetInspector, InnerEvmContext, Inspector,
+    EvmContext, InnerEvmContext, Inspector,
 };
 use rustc_hash::FxHashMap;
 use serde_json::Value;

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -237,7 +237,7 @@ bytecode_hash = "none"
 # size limitations
 fallback_oz = false 
 # Enable EraVM extensions (ex system-mode)
-eravm_extensions = false
+enable_eravm_extensions = false
 # Force compilation via EVMLA instead of Yul codegen pipeline
 force_evmla = false 
 # List of globs that match contracts to avoid compiling with zksolc

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -50,5 +50,4 @@ parking_lot.workspace = true
 proptest.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-itertools.workspace = true
 indicatif = "0.17"

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -25,7 +25,6 @@ use foundry_evm_core::{
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::{CallTraceArena, TraceMode};
 use foundry_zksync_core::ZkTransactionMetadata;
-use itertools::Itertools;
 use revm::{
     db::{DatabaseCommit, DatabaseRef},
     interpreter::{return_ok, InstructionResult},
@@ -936,31 +935,8 @@ fn convert_executed_result(
         _ => Bytes::new(),
     };
 
-    let combined_logs =
-        inspector.cheatcodes.as_ref().map(|cheatcodes| cheatcodes.combined_logs.clone());
-    let InspectorData { mut logs, labels, traces, coverage, cheatcodes, chisel_state } =
+    let InspectorData { logs, labels, traces, coverage, cheatcodes, chisel_state } =
         inspector.collect();
-
-    let logs = match combined_logs {
-        Some(combined_logs) => {
-            let new_logs = combined_logs
-                .into_iter()
-                // .map(|log| log.unwrap_or_else(|| logs.remove(0)))
-                .map(|log| {
-                    log.unwrap_or_else(|| {
-                        if !logs.is_empty() {
-                            logs.remove(0)
-                        } else {
-                            Default::default()
-                        }
-                    })
-                })
-                .collect_vec();
-            assert!(logs.is_empty(), "logs were not fully combined");
-            new_logs
-        }
-        None => logs,
-    };
 
     let transactions = cheatcodes
         .as_ref()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Reduce custom code for appending zkEVM logs 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Remove `combined_logs` workaround and use `InspectorExt` trait instead.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
