### PR TITLE
fix: Update dependency foundry compilers use of ZksolcSettings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.10.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#b597d1d8887e2568dda08f81c45d3ec2df832a46"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#7719a78a44fa451a84228b68ce0118e08919ed34"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.10.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#b597d1d8887e2568dda08f81c45d3ec2df832a46"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#7719a78a44fa451a84228b68ce0118e08919ed34"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.10.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#b597d1d8887e2568dda08f81c45d3ec2df832a46"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#7719a78a44fa451a84228b68ce0118e08919ed34"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.10.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#b597d1d8887e2568dda08f81c45d3ec2df832a46"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#7719a78a44fa451a84228b68ce0118e08919ed34"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-zksolc"
 version = "0.10.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#b597d1d8887e2568dda08f81c45d3ec2df832a46"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#7719a78a44fa451a84228b68ce0118e08919ed34"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.10.0"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#b597d1d8887e2568dda08f81c45d3ec2df832a46"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.10.0#7719a78a44fa451a84228b68ce0118e08919ed34"
 dependencies = [
  "alloy-primitives",
  "cfg-if 1.0.0",

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -129,6 +129,7 @@ impl ZkSyncConfig {
             },
         };
 
+         // `cli_settings` get set from `Project` values when building `ZkSolcVersionedInput` 
         ZkSolcSettings { settings: zk_settings, cli_settings: CliSettings::default() }
     }
 

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -4,8 +4,9 @@ use foundry_compilers::{
         EvmVersion, Libraries,
     },
     solc::CliSettings,
-    zksolc::settings::{
-        BytecodeHash, Optimizer, OptimizerDetails, SettingsMetadata, ZkSolcSettings,
+    zksolc::{
+        settings::{BytecodeHash, Optimizer, OptimizerDetails, SettingsMetadata, ZkSolcSettings},
+        ZkSettings,
     },
 };
 
@@ -108,7 +109,7 @@ impl ZkSyncConfig {
             jump_table_density_threshold: None,
         };
 
-        ZkSolcSettings {
+        let zk_settings = ZkSettings {
             libraries,
             optimizer,
             evm_version: Some(evm_version),
@@ -126,8 +127,9 @@ impl ZkSyncConfig {
                     per_contract: Some([OutputSelectionFlag::ABI].into()),
                 }),
             },
-            cli_settings: CliSettings::default(),
-        }
+        };
+
+        ZkSolcSettings { settings: zk_settings, cli_settings: CliSettings::default() }
     }
 
     pub fn avoid_contracts(&self) -> Option<Vec<globset::GlobMatcher>> {

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -129,7 +129,7 @@ impl ZkSyncConfig {
             },
         };
 
-         // `cli_settings` get set from `Project` values when building `ZkSolcVersionedInput` 
+        // `cli_settings` get set from `Project` values when building `ZkSolcVersionedInput`
         ZkSolcSettings { settings: zk_settings, cli_settings: CliSettings::default() }
     }
 

--- a/crates/verify/src/etherscan/flatten.rs
+++ b/crates/verify/src/etherscan/flatten.rs
@@ -12,7 +12,7 @@ use foundry_compilers::{
         solc::{SolcCompiler, SolcLanguage, SolcVersionedInput},
         Compiler, CompilerInput,
     },
-    solc::Solc,
+    solc::{CliSettings, Solc},
     zksolc::{
         input::{ZkSolcInput, ZkSolcVersionedInput},
         ZkSolc, ZkSolcCompiler,
@@ -70,7 +70,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         args: &VerifyArgs,
         context: &ZkVerificationContext,
     ) -> Result<(String, String, CodeFormat)> {
-        let metadata = context.project.settings.metadata.as_ref();
+        let metadata = context.project.settings.settings.metadata.as_ref();
         let bch = metadata.and_then(|m| m.bytecode_hash).unwrap_or_default();
 
         eyre::ensure!(
@@ -190,9 +190,7 @@ Diagnostics: {diags}",
                 ..Default::default()
             },
             solc_version: solc_version.clone(),
-            allow_paths: Default::default(),
-            base_path: Default::default(),
-            include_paths: Default::default(),
+            cli_settings: CliSettings::default(),
         };
 
         let solc_compiler = if compiler_version.is_zksync_solc {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Foundry compilers now uses the ZkSettings and ZkSolcSettings as original Foundry does so we need to adapt to that change

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This would solve the [issue](https://github.com/matter-labs/foundry-zksync/issues/411) regarding `allow_paths` not reaching ZK compilation process. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
