### PR TITLE
fix(zk): avoid observing log from staticcalls

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1550,7 +1550,6 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
     }
 
     fn log(&mut self, _interpreter: &mut Interpreter, _context: &mut EvmContext<DB>, log: &Log) {
-        tracing::error!(?log, "log call");
         if !self.expected_emits.is_empty() {
             expect::handle_expect_emit(self, log);
         }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1395,6 +1395,20 @@ impl Cheatcodes {
                 persisted_factory_deps: Some(&mut self.persisted_factory_deps),
             };
             if let Ok(result) = foundry_zksync_core::vm::call::<_, DatabaseError>(call, ecx, ccx) {
+                // append console logs from zkEVM to the current executor's LogTracer
+                result.logs.iter().filter_map(decode_console_log).for_each(|decoded_log| {
+                    executor.console_log(
+                        &mut CheatsCtxt {
+                            state: self,
+                            ecx: &mut ecx.inner,
+                            precompiles: &mut ecx.precompiles,
+                            gas_limit: call.gas_limit,
+                            caller: call.caller,
+                        },
+                        decoded_log,
+                    );
+                });
+
                 // skip log processing for static calls
                 if !call.is_static {
                     if let Some(recorded_logs) = &mut self.recorded_logs {
@@ -1404,20 +1418,6 @@ impl Cheatcodes {
                             emitter: log.address,
                         }));
                     }
-
-                    // append console logs from zkEVM to the current executor's LogTracer
-                    result.logs.iter().filter_map(decode_console_log).for_each(|decoded_log| {
-                        executor.console_log(
-                            &mut CheatsCtxt {
-                                state: self,
-                                ecx: &mut ecx.inner,
-                                precompiles: &mut ecx.precompiles,
-                                gas_limit: call.gas_limit,
-                                caller: call.caller,
-                            },
-                            decoded_log,
-                        );
-                    });
 
                     // for each log in cloned logs call handle_expect_emit
                     if !self.expected_emits.is_empty() {
@@ -1550,6 +1550,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
     }
 
     fn log(&mut self, _interpreter: &mut Interpreter, _context: &mut EvmContext<DB>, log: &Log) {
+        tracing::error!(?log, "log call");
         if !self.expected_emits.is_empty() {
             expect::handle_expect_emit(self, log);
         }

--- a/crates/forge/tests/it/zk/cheats.rs
+++ b/crates/forge/tests/it/zk/cheats.rs
@@ -58,7 +58,7 @@ async fn test_zk_cheat_record_works() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zk_cheat_expect_emit_works() {
     let runner = TEST_DATA_DEFAULT.runner_zksync();
-    let filter = Filter::new("testExpectEmit|testExpectEmitOnCreate", "ZkCheatcodesTest", ".*");
+    let filter = Filter::new("testExpectEmit", "ZkCheatcodesTest", ".*");
 
     TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
 }

--- a/testdata/zk/Cheatcodes.t.sol
+++ b/testdata/zk/Cheatcodes.t.sol
@@ -53,12 +53,15 @@ contract Emitter {
     event EventConstructor(string message);
     event EventFunction(string message);
 
+    string public constant CONSTRUCTOR_MESSAGE = "constructor";
+    string public constant FUNCTION_MESSAGE = "function";
+
     constructor() {
-        emit EventConstructor("constructor");
+        emit EventConstructor(CONSTRUCTOR_MESSAGE);
     }
 
     function functionEmit() public {
-        emit EventFunction("function");
+        emit EventFunction(FUNCTION_MESSAGE);
     }
 }
 
@@ -155,6 +158,14 @@ contract ZkCheatcodesTest is DSTest {
         vm.expectEmit(true, true, true, true);
         emit EventConstructor("constructor");
         new Emitter();
+    }
+
+    function testExpectEmitIgnoresStaticCalls() public {
+        Emitter emitter = new Emitter();
+
+        vm.expectEmit(true, true, true, true);
+        emit EventFunction(emitter.FUNCTION_MESSAGE());
+        emitter.functionEmit();
     }
 
     function testZkCheatcodesValueFunctionMockReturn() public {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
After investigating #546 we noticed that logs were being processed also for `STATICCALL`, which aren't supposed to edit the state.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Logs are part of the state, so we should ignore observing them for `STATICCALL`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
