### PR TITLE
chore: deal with proc_macro_error and gix_path cargo deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5970,9 +5970,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d23d5bbda31344d8abc8de7c075b3cf26e5873feba7c4a15d916bce67382bd9"
+checksum = "38d5b8722112fa2fa87135298780bc833b0e9f6c56cc82795d209804b3a03484"
 dependencies = [
  "bstr 1.9.1",
  "gix-trace",
@@ -7317,7 +7317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,8 @@ ignore = [
     # https://github.com/launchbadge/sqlx/issues/3440
     # Should remove once we can update sqlx which is used by some zksync dependencies
     "RUSTSEC-2024-0363",
+    # Used by alloy
+    "RUSTSEC-2024-0370",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

ID: RUSTSEC-2024-0370
Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0370
proc-macro-error's maintainer seems to be unreachable, with no commits for 2 years, no releases pushed for 4 years, and no activity on the GitLab repo or response to email.


ID: RUSTSEC-2024-0367
Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0367
`gix-path` executes `git` to find the path of a configuration file that belongs to the `git` installation itself, but mistakenly treats the local repository's configuration as system-wide if no higher scope
d configuration is found. In rare cases, this causes a less trusted repository to be treated as more trusted, or leaks sensitive information from one repository to another, such as sending credentials to another
repository's remote.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

* RUSTSEC-2024-0370: This is used by alloy so we need to wait for them to deal with it. Added to ignored advisories
* RUSTSEC-2024-0367: Bump `gix-path` via `cargo update -p gix-path`
 

