### PR TITLE
feat: update installation scripts for quick install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
-        - name: install foundry-zksync
-          run: ./install-foundry-zksync
-        - name: verify
+        - name: Install foundry-zksync
+          run: |
+            curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
+        - name: Verify installation
           run: forge --version
+

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Follow these steps to quickly install the binaries for `foundry-zksync`:
 
 ### 1. **Run the Installer**
 
-You can now install `foundry-zksync` without needing to clone the repository. Simply run the following `curl` command, which downloads and runs the installation script:
+Run the following `curl` command, which downloads and runs the installation script:
 
 ```bash
 curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash

--- a/README.md
+++ b/README.md
@@ -80,35 +80,25 @@ For the most effective use of our library, we recommend familiarizing yourself w
 
 Follow these steps to quickly install the binaries for `foundry-zksync`:
 
-**Note:** This installation overrides any existing forge and cast binaries in ~/.foundry. You can use forge without the --zksync flag for standard EVM chains. To revert to a previous installation, follow the instructions [here](https://book.getfoundry.sh/getting-started/installation#using-foundryup).
+**Note:** This installation overrides any existing `forge` and `cast` binaries in `~/.foundry`. You can use `forge` without the `--zksync` flag for standard EVM chains. To revert to a previous installation, follow the instructions [here](https://book.getfoundry.sh/getting-started/installation#using-foundryup).
 
-1. **Clone the Repository**:
-   Begin by cloning the `foundry-zksync` repository from GitHub. This will download the latest version of the source code to your local machine.
+### 1. **Run the Installer**
 
-   ```bash
-   git clone git@github.com:matter-labs/foundry-zksync.git
-   ```
+You can now install `foundry-zksync` without needing to clone the repository. Simply run the following `curl` command, which downloads and runs the installation script:
 
-2. **Change Directory**:
-   Navigate into the directory where the repository has been cloned. This is where you will run the installation commands.
+```bash
+curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
+```
 
-   ```bash
-   cd foundry-zksync
-   ```
+This command will download the latest `foundry-zksync` binaries (`forge` and `cast`) and set them up on your system.
 
-3. **Run the Installer**:
-   Now, you're ready to execute the installation script. This command initializes the setup and installs `foundry-zksync` binaries `forge` and `cast`.
+### 2. **Verify the Installation** (Recommended)
 
-   ```bash
-   ./install-foundry-zksync
-   ```
+After installation, it's recommended to verify that the binaries have been installed correctly. Run the following command to check the installed version:
 
-4. **Verify the Installation** (Recommended):
-   After installation, it's good practice to verify that the binaries have been installed correctly. Run the following command to check the installed version:
-
-   ```bash
-   forge --version
-   ```
+```bash
+forge --version
+```
 
 This should return the installed version of `forge`, confirming that `foundry-zksync` is installed properly on your system.
 

--- a/foundryup-zksync/foundryup-zksync
+++ b/foundryup-zksync/foundryup-zksync
@@ -183,7 +183,7 @@ EOF
   # Install by cloning the repo with the provided branch/tag
   else
     need_cmd cargo
-    FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH:-dev}
+    FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH:-main}
     REPO_PATH="$FOUNDRY_DIR/$FOUNDRYUP_REPO"
 
     # If repo path does not exist, grab the author from the repo, make a directory in .foundry, cd to it and clone.

--- a/foundryup-zksync/install
+++ b/foundryup-zksync/install
@@ -8,7 +8,7 @@ FOUNDRY_DIR="${FOUNDRY_DIR-"$BASE_DIR/.foundry"}"
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
-BIN_URL="https://raw.githubusercontent.com/matter-labs/foundry-zksync/dev/foundryup-zksync/foundryup-zksync"
+BIN_URL="https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/foundryup-zksync/foundryup-zksync"
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup-zksync"
 
 # Create the .foundry bin directory and foundryup binary if it doesn't exist.

--- a/install-foundry-zksync
+++ b/install-foundry-zksync
@@ -2,8 +2,13 @@
 
 set -e
 
-echo "Navigating to the foundryup-zksync script..."
-cd foundryup-zksync
+# URLs to the raw files on GitHub
+INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/foundryup-zksync/install"
+FOUNDRYUP_ZKSYNC_URL="https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/foundryup-zksync/foundryup-zksync"
+
+# Download the install script
+echo "Downloading the install script..."
+curl -L "$INSTALL_SCRIPT_URL" -o install
 
 echo "Making install script executable..."
 chmod +x ./install


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

- Currently quick installation requires cloning the repo locally which all we really need is the `forge` and `cast` binaries. 
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- Updates installation scripts to pull and execute script from GH instead.