### PR TITLE
feat: adds zk cheatcode for retrieving bytecode hash

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5093,6 +5093,26 @@
     },
     {
       "func": {
+        "id": "getRawCodeHash",
+        "description": "Gets the deployed bytecodeHash from state. Takes in the address of the contract.",
+        "declaration": "function getRawCodeHash(address target) external view returns (bytes memory byteCodeHash);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getRawCodeHash(address)",
+        "selector": "0x4de2e468",
+        "selectorBytes": [
+          77,
+          226,
+          228,
+          104
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "getRecordedLogs",
         "description": "Gets all the recorded logs.",
         "declaration": "function getRecordedLogs() external returns (Log[] memory logs);",
@@ -8633,26 +8653,6 @@
     },
     {
       "func": {
-        "id": "zkRegisterContract",
-        "description": "Registers bytecodes for ZK-VM for transact/call and create instructions.",
-        "declaration": "function zkRegisterContract(string calldata name, bytes32 evmBytecodeHash, bytes calldata evmDeployedBytecode, bytes calldata evmBytecode, bytes32 zkBytecodeHash, bytes calldata zkDeployedBytecode) external pure;",
-        "visibility": "external",
-        "mutability": "pure",
-        "signature": "zkRegisterContract(string,bytes32,bytes,bytes,bytes32,bytes)",
-        "selector": "0x428cb039",
-        "selectorBytes": [
-          66,
-          140,
-          176,
-          57
-        ]
-      },
-      "group": "testing",
-      "status": "stable",
-      "safety": "safe"
-    },
-    {
-      "func": {
         "id": "writeToml_0",
         "description": "Takes serialized JSON, converts to TOML and write a serialized TOML to a file.",
         "declaration": "function writeToml(string calldata json, string calldata path) external;",
@@ -8673,26 +8673,6 @@
     },
     {
       "func": {
-        "id": "zkVm",
-        "description": "Enables/Disables use ZK-VM usage for transact/call and create instructions.",
-        "declaration": "function zkVm(bool enable) external pure;",
-        "visibility": "external",
-        "mutability": "pure",
-        "signature": "zkVm(bool)",
-        "selector": "0x9d7804fe",
-        "selectorBytes": [
-          157,
-          120,
-          4,
-          254
-        ]
-      },
-      "group": "testing",
-      "status": "stable",
-      "safety": "safe"
-    },
-    {
-      "func": {
         "id": "writeToml_1",
         "description": "Takes serialized JSON, converts to TOML and write a serialized TOML table to an **existing** TOML file, replacing a value with key = <value_key.>\nThis is useful to replace a specific value of a TOML file, without having to parse the entire thing.",
         "declaration": "function writeToml(string calldata json, string calldata path, string calldata valueKey) external;",
@@ -8708,6 +8688,46 @@
         ]
       },
       "group": "toml",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "zkRegisterContract",
+        "description": "Registers bytecodes for ZK-VM for transact/call and create instructions.",
+        "declaration": "function zkRegisterContract(string calldata name, bytes32 evmBytecodeHash, bytes calldata evmDeployedBytecode, bytes calldata evmBytecode, bytes32 zkBytecodeHash, bytes calldata zkDeployedBytecode) external pure;",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "zkRegisterContract(string,bytes32,bytes,bytes,bytes32,bytes)",
+        "selector": "0x428cb039",
+        "selectorBytes": [
+          66,
+          140,
+          176,
+          57
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "zkVm",
+        "description": "Enables/Disables use ZK-VM usage for transact/call and create instructions.",
+        "declaration": "function zkVm(bool enable) external pure;",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "zkVm(bool)",
+        "selector": "0x9d7804fe",
+        "selectorBytes": [
+          157,
+          120,
+          4,
+          254
+        ]
+      },
+      "group": "testing",
       "status": "stable",
       "safety": "safe"
     }

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -465,6 +465,10 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
     function cool(address target) external;
 
+    /// Gets the deployed bytecodeHash from state. Takes in the address of the contract.
+    #[cheatcode(group = Evm, safety = Safe)]
+    function getRawCodeHash(address target) external view returns (bytes memory byteCodeHash);
+
     // -------- Call Manipulation --------
     // --- Mocks ---
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -598,6 +598,18 @@ impl Cheatcode for setBlockhashCall {
     }
 }
 
+impl Cheatcode for getRawCodeHashCall {
+    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { target } = self;
+        if ccx.state.use_zk_vm {
+            let code = foundry_zksync_core::cheatcodes::get_raw_code_hash(*target, ccx.ecx);
+            return Ok(code.abi_encode());
+        }
+
+        Ok(Bytecode::new().bytes().abi_encode())
+    }
+}
+
 pub(super) fn get_nonce<DB: DatabaseExt>(ccx: &mut CheatsCtxt<DB>, address: &Address) -> Result {
     let (account, _) = ccx.ecx.journaled_state.load_account(*address, &mut ccx.ecx.db)?;
     Ok(account.info.nonce.abi_encode())

--- a/crates/forge/tests/it/zk/cheats.rs
+++ b/crates/forge/tests/it/zk/cheats.rs
@@ -121,3 +121,11 @@ async fn test_zk_cheatcodes_in_zkvm() {
 
     TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zk_contract_get_raw_code_hash() {
+    let runner = TEST_DATA_DEFAULT.runner_zksync();
+    let filter = Filter::new("testZkGetRawCodeHash", "ZkCheatcodesGetRawCodeHashTest", ".*");
+
+    TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
+}

--- a/crates/zksync/core/src/cheatcodes.rs
+++ b/crates/zksync/core/src/cheatcodes.rs
@@ -199,17 +199,18 @@ where
     }
 }
 
-    /// Retrieves the bytecode hash for a given address.
-    pub fn get_raw_code_hash<DB>(address: Address, ecx: &mut InnerEvmContext<DB>) -> rU256
-    where
-        DB: Database,
-        <DB as Database>::Error: Debug,
-    {
+/// Retrieves the bytecode hash for a given address.
+pub fn get_raw_code_hash<DB>(address: Address, ecx: &mut InnerEvmContext<DB>) -> rU256
+where
+    DB: Database,
+    <DB as Database>::Error: Debug,
+{
     info!(?address, "cheatcode getRawCodeHash");
 
     // Load the account code storage system address
     let account_code_addr = ACCOUNT_CODE_STORAGE_ADDRESS.to_address();
-    ecx.load_account(account_code_addr).expect("account 'ACCOUNT_CODE_STORAGE_ADDRESS' could not be loaded");
+    ecx.load_account(account_code_addr)
+        .expect("account 'ACCOUNT_CODE_STORAGE_ADDRESS' could not be loaded");
 
     let zk_address = address.to_h160();
     let account_key = zk_address.to_h256().to_ru256();

--- a/crates/zksync/core/src/cheatcodes.rs
+++ b/crates/zksync/core/src/cheatcodes.rs
@@ -199,6 +199,32 @@ where
     }
 }
 
+    /// Retrieves the bytecode hash for a given address.
+    pub fn get_raw_code_hash<DB>(address: Address, ecx: &mut InnerEvmContext<DB>) -> rU256
+    where
+        DB: Database,
+        <DB as Database>::Error: Debug,
+    {
+    info!(?address, "cheatcode getRawCodeHash");
+
+    // Load the account code storage system address
+    let account_code_addr = ACCOUNT_CODE_STORAGE_ADDRESS.to_address();
+    ecx.load_account(account_code_addr).expect("account 'ACCOUNT_CODE_STORAGE_ADDRESS' could not be loaded");
+
+    let zk_address = address.to_h160();
+    let account_key = zk_address.to_h256().to_ru256();
+
+    // Load the bytecode hash from the system storage
+    let (bytecode_hash, _) = ecx.sload(account_code_addr, account_key).unwrap_or_default();
+
+    if bytecode_hash.is_zero() {
+        info!(?address, "no bytecode found for address");
+        return rU256::ZERO;
+    }
+
+    bytecode_hash
+}
+
 #[cfg(test)]
 mod tests {
     use revm::db::EmptyDB;

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -6,130 +6,20 @@ pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 interface Vm {
-    enum CallerMode {
-        None,
-        Broadcast,
-        RecurrentBroadcast,
-        Prank,
-        RecurrentPrank
-    }
-    enum AccountAccessKind {
-        Call,
-        DelegateCall,
-        CallCode,
-        StaticCall,
-        Create,
-        SelfDestruct,
-        Resume,
-        Balance,
-        Extcodesize,
-        Extcodehash,
-        Extcodecopy
-    }
-    enum ForgeContext {
-        TestGroup,
-        Test,
-        Coverage,
-        Snapshot,
-        ScriptGroup,
-        ScriptDryRun,
-        ScriptBroadcast,
-        ScriptResume,
-        Unknown
-    }
-
-    struct Log {
-        bytes32[] topics;
-        bytes data;
-        address emitter;
-    }
-
-    struct Rpc {
-        string key;
-        string url;
-    }
-
-    struct EthGetLogs {
-        address emitter;
-        bytes32[] topics;
-        bytes data;
-        bytes32 blockHash;
-        uint64 blockNumber;
-        bytes32 transactionHash;
-        uint64 transactionIndex;
-        uint256 logIndex;
-        bool removed;
-    }
-
-    struct DirEntry {
-        string errorMessage;
-        string path;
-        uint64 depth;
-        bool isDir;
-        bool isSymlink;
-    }
-
-    struct FsMetadata {
-        bool isDir;
-        bool isSymlink;
-        uint256 length;
-        bool readOnly;
-        uint256 modified;
-        uint256 accessed;
-        uint256 created;
-    }
-
-    struct Wallet {
-        address addr;
-        uint256 publicKeyX;
-        uint256 publicKeyY;
-        uint256 privateKey;
-    }
-
-    struct FfiResult {
-        int32 exitCode;
-        bytes stdout;
-        bytes stderr;
-    }
-
-    struct ChainInfo {
-        uint256 forkId;
-        uint256 chainId;
-    }
-
-    struct AccountAccess {
-        ChainInfo chainInfo;
-        AccountAccessKind kind;
-        address account;
-        address accessor;
-        bool initialized;
-        uint256 oldBalance;
-        uint256 newBalance;
-        bytes deployedCode;
-        uint256 value;
-        bytes data;
-        bool reverted;
-        StorageAccess[] storageAccesses;
-        uint64 depth;
-    }
-
-    struct StorageAccess {
-        address account;
-        bytes32 slot;
-        bool isWrite;
-        bytes32 previousValue;
-        bytes32 newValue;
-        bool reverted;
-    }
-
-    struct Gas {
-        uint64 gasLimit;
-        uint64 gasTotalUsed;
-        uint64 gasMemoryUsed;
-        int64 gasRefunded;
-        uint64 gasRemaining;
-    }
-
+    enum CallerMode { None, Broadcast, RecurrentBroadcast, Prank, RecurrentPrank }
+    enum AccountAccessKind { Call, DelegateCall, CallCode, StaticCall, Create, SelfDestruct, Resume, Balance, Extcodesize, Extcodehash, Extcodecopy }
+    enum ForgeContext { TestGroup, Test, Coverage, Snapshot, ScriptGroup, ScriptDryRun, ScriptBroadcast, ScriptResume, Unknown }
+    struct Log { bytes32[] topics; bytes data; address emitter; }
+    struct Rpc { string key; string url; }
+    struct EthGetLogs { address emitter; bytes32[] topics; bytes data; bytes32 blockHash; uint64 blockNumber; bytes32 transactionHash; uint64 transactionIndex; uint256 logIndex; bool removed; }
+    struct DirEntry { string errorMessage; string path; uint64 depth; bool isDir; bool isSymlink; }
+    struct FsMetadata { bool isDir; bool isSymlink; uint256 length; bool readOnly; uint256 modified; uint256 accessed; uint256 created; }
+    struct Wallet { address addr; uint256 publicKeyX; uint256 publicKeyY; uint256 privateKey; }
+    struct FfiResult { int32 exitCode; bytes stdout; bytes stderr; }
+    struct ChainInfo { uint256 forkId; uint256 chainId; }
+    struct AccountAccess { ChainInfo chainInfo; AccountAccessKind kind; address account; address accessor; bool initialized; uint256 oldBalance; uint256 newBalance; bytes deployedCode; uint256 value; bytes data; bool reverted; StorageAccess[] storageAccesses; uint64 depth; }
+    struct StorageAccess { address account; bytes32 slot; bool isWrite; bytes32 previousValue; bytes32 newValue; bool reverted; }
+    struct Gas { uint64 gasLimit; uint64 gasTotalUsed; uint64 gasMemoryUsed; int64 gasRefunded; uint64 gasRemaining; }
     function _expectCheatcodeRevert() external;
     function _expectCheatcodeRevert(bytes4 revertData) external;
     function _expectCheatcodeRevert(bytes calldata revertData) external;
@@ -138,53 +28,21 @@ interface Vm {
     function addr(uint256 privateKey) external pure returns (address keyAddr);
     function allowCheatcodes(address account) external;
     function assertApproxEqAbsDecimal(uint256 left, uint256 right, uint256 maxDelta, uint256 decimals) external pure;
-    function assertApproxEqAbsDecimal(
-        uint256 left,
-        uint256 right,
-        uint256 maxDelta,
-        uint256 decimals,
-        string calldata error
-    ) external pure;
+    function assertApproxEqAbsDecimal(uint256 left, uint256 right, uint256 maxDelta, uint256 decimals, string calldata error) external pure;
     function assertApproxEqAbsDecimal(int256 left, int256 right, uint256 maxDelta, uint256 decimals) external pure;
-    function assertApproxEqAbsDecimal(
-        int256 left,
-        int256 right,
-        uint256 maxDelta,
-        uint256 decimals,
-        string calldata error
-    ) external pure;
+    function assertApproxEqAbsDecimal(int256 left, int256 right, uint256 maxDelta, uint256 decimals, string calldata error) external pure;
     function assertApproxEqAbs(uint256 left, uint256 right, uint256 maxDelta) external pure;
     function assertApproxEqAbs(uint256 left, uint256 right, uint256 maxDelta, string calldata error) external pure;
     function assertApproxEqAbs(int256 left, int256 right, uint256 maxDelta) external pure;
     function assertApproxEqAbs(int256 left, int256 right, uint256 maxDelta, string calldata error) external pure;
-    function assertApproxEqRelDecimal(uint256 left, uint256 right, uint256 maxPercentDelta, uint256 decimals)
-        external
-        pure;
-    function assertApproxEqRelDecimal(
-        uint256 left,
-        uint256 right,
-        uint256 maxPercentDelta,
-        uint256 decimals,
-        string calldata error
-    ) external pure;
-    function assertApproxEqRelDecimal(int256 left, int256 right, uint256 maxPercentDelta, uint256 decimals)
-        external
-        pure;
-    function assertApproxEqRelDecimal(
-        int256 left,
-        int256 right,
-        uint256 maxPercentDelta,
-        uint256 decimals,
-        string calldata error
-    ) external pure;
+    function assertApproxEqRelDecimal(uint256 left, uint256 right, uint256 maxPercentDelta, uint256 decimals) external pure;
+    function assertApproxEqRelDecimal(uint256 left, uint256 right, uint256 maxPercentDelta, uint256 decimals, string calldata error) external pure;
+    function assertApproxEqRelDecimal(int256 left, int256 right, uint256 maxPercentDelta, uint256 decimals) external pure;
+    function assertApproxEqRelDecimal(int256 left, int256 right, uint256 maxPercentDelta, uint256 decimals, string calldata error) external pure;
     function assertApproxEqRel(uint256 left, uint256 right, uint256 maxPercentDelta) external pure;
-    function assertApproxEqRel(uint256 left, uint256 right, uint256 maxPercentDelta, string calldata error)
-        external
-        pure;
+    function assertApproxEqRel(uint256 left, uint256 right, uint256 maxPercentDelta, string calldata error) external pure;
     function assertApproxEqRel(int256 left, int256 right, uint256 maxPercentDelta) external pure;
-    function assertApproxEqRel(int256 left, int256 right, uint256 maxPercentDelta, string calldata error)
-        external
-        pure;
+    function assertApproxEqRel(int256 left, int256 right, uint256 maxPercentDelta, string calldata error) external pure;
     function assertEqDecimal(uint256 left, uint256 right, uint256 decimals) external pure;
     function assertEqDecimal(uint256 left, uint256 right, uint256 decimals, string calldata error) external pure;
     function assertEqDecimal(int256 left, int256 right, uint256 decimals) external pure;
@@ -297,10 +155,7 @@ interface Vm {
     function clearMockedCalls() external;
     function closeFile(string calldata path) external;
     function coinbase(address newCoinbase) external;
-    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer)
-        external
-        pure
-        returns (address);
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer) external pure returns (address);
     function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external pure returns (address);
     function computeCreateAddress(address deployer, uint256 nonce) external pure returns (address);
     function cool(address target) external;
@@ -319,22 +174,11 @@ interface Vm {
     function deleteSnapshot(uint256 snapshotId) external returns (bool success);
     function deleteSnapshots() external;
     function deployCode(string calldata artifactPath) external returns (address deployedAddress);
-    function deployCode(string calldata artifactPath, bytes calldata constructorArgs)
-        external
-        returns (address deployedAddress);
+    function deployCode(string calldata artifactPath, bytes calldata constructorArgs) external returns (address deployedAddress);
     function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);
-    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index)
-        external
-        pure
-        returns (uint256 privateKey);
-    function deriveKey(string calldata mnemonic, uint32 index, string calldata language)
-        external
-        pure
-        returns (uint256 privateKey);
-    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index, string calldata language)
-        external
-        pure
-        returns (uint256 privateKey);
+    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index) external pure returns (uint256 privateKey);
+    function deriveKey(string calldata mnemonic, uint32 index, string calldata language) external pure returns (uint256 privateKey);
+    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index, string calldata language) external pure returns (uint256 privateKey);
     function difficulty(uint256 newDifficulty) external;
     function dumpState(string calldata pathToStateJson) external;
     function ensNamehash(string calldata name) external pure returns (bytes32);
@@ -351,72 +195,39 @@ interface Vm {
     function envInt(string calldata name, string calldata delim) external view returns (int256[] memory value);
     function envOr(string calldata name, bool defaultValue) external view returns (bool value);
     function envOr(string calldata name, uint256 defaultValue) external view returns (uint256 value);
-    function envOr(string calldata name, string calldata delim, address[] calldata defaultValue)
-        external
-        view
-        returns (address[] memory value);
-    function envOr(string calldata name, string calldata delim, bytes32[] calldata defaultValue)
-        external
-        view
-        returns (bytes32[] memory value);
-    function envOr(string calldata name, string calldata delim, string[] calldata defaultValue)
-        external
-        view
-        returns (string[] memory value);
-    function envOr(string calldata name, string calldata delim, bytes[] calldata defaultValue)
-        external
-        view
-        returns (bytes[] memory value);
+    function envOr(string calldata name, string calldata delim, address[] calldata defaultValue) external view returns (address[] memory value);
+    function envOr(string calldata name, string calldata delim, bytes32[] calldata defaultValue) external view returns (bytes32[] memory value);
+    function envOr(string calldata name, string calldata delim, string[] calldata defaultValue) external view returns (string[] memory value);
+    function envOr(string calldata name, string calldata delim, bytes[] calldata defaultValue) external view returns (bytes[] memory value);
     function envOr(string calldata name, int256 defaultValue) external view returns (int256 value);
     function envOr(string calldata name, address defaultValue) external view returns (address value);
     function envOr(string calldata name, bytes32 defaultValue) external view returns (bytes32 value);
     function envOr(string calldata name, string calldata defaultValue) external view returns (string memory value);
     function envOr(string calldata name, bytes calldata defaultValue) external view returns (bytes memory value);
-    function envOr(string calldata name, string calldata delim, bool[] calldata defaultValue)
-        external
-        view
-        returns (bool[] memory value);
-    function envOr(string calldata name, string calldata delim, uint256[] calldata defaultValue)
-        external
-        view
-        returns (uint256[] memory value);
-    function envOr(string calldata name, string calldata delim, int256[] calldata defaultValue)
-        external
-        view
-        returns (int256[] memory value);
+    function envOr(string calldata name, string calldata delim, bool[] calldata defaultValue) external view returns (bool[] memory value);
+    function envOr(string calldata name, string calldata delim, uint256[] calldata defaultValue) external view returns (uint256[] memory value);
+    function envOr(string calldata name, string calldata delim, int256[] calldata defaultValue) external view returns (int256[] memory value);
     function envString(string calldata name) external view returns (string memory value);
     function envString(string calldata name, string calldata delim) external view returns (string[] memory value);
     function envUint(string calldata name) external view returns (uint256 value);
     function envUint(string calldata name, string calldata delim) external view returns (uint256[] memory value);
     function etch(address target, bytes calldata newRuntimeBytecode) external;
-    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address target, bytes32[] memory topics)
-        external
-        returns (EthGetLogs[] memory logs);
+    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address target, bytes32[] memory topics) external returns (EthGetLogs[] memory logs);
     function exists(string calldata path) external returns (bool result);
     function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data) external;
-    function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data, uint64 count)
-        external;
+    function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data, uint64 count) external;
     function expectCall(address callee, bytes calldata data) external;
     function expectCall(address callee, bytes calldata data, uint64 count) external;
     function expectCall(address callee, uint256 msgValue, bytes calldata data) external;
     function expectCall(address callee, uint256 msgValue, bytes calldata data, uint64 count) external;
     function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data) external;
     function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data, uint64 count) external;
-    function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData)
-        external;
-    function expectEmitAnonymous(
-        bool checkTopic0,
-        bool checkTopic1,
-        bool checkTopic2,
-        bool checkTopic3,
-        bool checkData,
-        address emitter
-    ) external;
+    function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
+    function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
     function expectEmitAnonymous() external;
     function expectEmitAnonymous(address emitter) external;
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
-    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter)
-        external;
+    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
     function expectEmit() external;
     function expectEmit(address emitter) external;
     function expectRevert() external;
@@ -434,13 +245,12 @@ interface Vm {
     function getCode(string calldata artifactPath) external view returns (bytes memory creationBytecode);
     function getDeployedCode(string calldata artifactPath) external view returns (bytes memory runtimeBytecode);
     function getLabel(address account) external view returns (string memory currentLabel);
-    function getMappingKeyAndParentOf(address target, bytes32 elementSlot)
-        external
-        returns (bool found, bytes32 key, bytes32 parent);
+    function getMappingKeyAndParentOf(address target, bytes32 elementSlot) external returns (bool found, bytes32 key, bytes32 parent);
     function getMappingLength(address target, bytes32 mappingSlot) external returns (uint256 length);
     function getMappingSlotAt(address target, bytes32 mappingSlot, uint256 idx) external returns (bytes32 value);
     function getNonce(address account) external view returns (uint64 nonce);
     function getNonce(Wallet calldata wallet) external returns (uint64 nonce);
+    function getRawCodeHash(address target) external view returns (bytes memory byteCodeHash);
     function getRecordedLogs() external returns (Log[] memory logs);
     function indexOf(string calldata input, string calldata key) external pure returns (uint256);
     function isContext(ForgeContext context) external view returns (bool result);
@@ -459,8 +269,7 @@ interface Vm {
     function makePersistent(address account0, address account1, address account2) external;
     function makePersistent(address[] calldata accounts) external;
     function mockCallRevert(address callee, bytes calldata data, bytes calldata revertData) external;
-    function mockCallRevert(address callee, uint256 msgValue, bytes calldata data, bytes calldata revertData)
-        external;
+    function mockCallRevert(address callee, uint256 msgValue, bytes calldata data, bytes calldata revertData) external;
     function mockCall(address callee, bytes calldata data, bytes calldata returnData) external;
     function mockCall(address callee, uint256 msgValue, bytes calldata data, bytes calldata returnData) external;
     function parseAddress(string calldata stringifiedValue) external pure returns (address parsedValue);
@@ -469,53 +278,32 @@ interface Vm {
     function parseBytes32(string calldata stringifiedValue) external pure returns (bytes32 parsedValue);
     function parseInt(string calldata stringifiedValue) external pure returns (int256 parsedValue);
     function parseJsonAddress(string calldata json, string calldata key) external pure returns (address);
-    function parseJsonAddressArray(string calldata json, string calldata key)
-        external
-        pure
-        returns (address[] memory);
+    function parseJsonAddressArray(string calldata json, string calldata key) external pure returns (address[] memory);
     function parseJsonBool(string calldata json, string calldata key) external pure returns (bool);
     function parseJsonBoolArray(string calldata json, string calldata key) external pure returns (bool[] memory);
     function parseJsonBytes(string calldata json, string calldata key) external pure returns (bytes memory);
     function parseJsonBytes32(string calldata json, string calldata key) external pure returns (bytes32);
-    function parseJsonBytes32Array(string calldata json, string calldata key)
-        external
-        pure
-        returns (bytes32[] memory);
+    function parseJsonBytes32Array(string calldata json, string calldata key) external pure returns (bytes32[] memory);
     function parseJsonBytesArray(string calldata json, string calldata key) external pure returns (bytes[] memory);
     function parseJsonInt(string calldata json, string calldata key) external pure returns (int256);
     function parseJsonIntArray(string calldata json, string calldata key) external pure returns (int256[] memory);
     function parseJsonKeys(string calldata json, string calldata key) external pure returns (string[] memory keys);
     function parseJsonString(string calldata json, string calldata key) external pure returns (string memory);
     function parseJsonStringArray(string calldata json, string calldata key) external pure returns (string[] memory);
-    function parseJsonTypeArray(string calldata json, string calldata key, string calldata typeDescription)
-        external
-        pure
-        returns (bytes memory);
-    function parseJsonType(string calldata json, string calldata typeDescription)
-        external
-        pure
-        returns (bytes memory);
-    function parseJsonType(string calldata json, string calldata key, string calldata typeDescription)
-        external
-        pure
-        returns (bytes memory);
+    function parseJsonTypeArray(string calldata json, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
+    function parseJsonType(string calldata json, string calldata typeDescription) external pure returns (bytes memory);
+    function parseJsonType(string calldata json, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
     function parseJsonUint(string calldata json, string calldata key) external pure returns (uint256);
     function parseJsonUintArray(string calldata json, string calldata key) external pure returns (uint256[] memory);
     function parseJson(string calldata json) external pure returns (bytes memory abiEncodedData);
     function parseJson(string calldata json, string calldata key) external pure returns (bytes memory abiEncodedData);
     function parseTomlAddress(string calldata toml, string calldata key) external pure returns (address);
-    function parseTomlAddressArray(string calldata toml, string calldata key)
-        external
-        pure
-        returns (address[] memory);
+    function parseTomlAddressArray(string calldata toml, string calldata key) external pure returns (address[] memory);
     function parseTomlBool(string calldata toml, string calldata key) external pure returns (bool);
     function parseTomlBoolArray(string calldata toml, string calldata key) external pure returns (bool[] memory);
     function parseTomlBytes(string calldata toml, string calldata key) external pure returns (bytes memory);
     function parseTomlBytes32(string calldata toml, string calldata key) external pure returns (bytes32);
-    function parseTomlBytes32Array(string calldata toml, string calldata key)
-        external
-        pure
-        returns (bytes32[] memory);
+    function parseTomlBytes32Array(string calldata toml, string calldata key) external pure returns (bytes32[] memory);
     function parseTomlBytesArray(string calldata toml, string calldata key) external pure returns (bytes[] memory);
     function parseTomlInt(string calldata toml, string calldata key) external pure returns (int256);
     function parseTomlIntArray(string calldata toml, string calldata key) external pure returns (int256[] memory);
@@ -544,10 +332,7 @@ interface Vm {
     function readCallers() external returns (CallerMode callerMode, address msgSender, address txOrigin);
     function readDir(string calldata path) external view returns (DirEntry[] memory entries);
     function readDir(string calldata path, uint64 maxDepth) external view returns (DirEntry[] memory entries);
-    function readDir(string calldata path, uint64 maxDepth, bool followLinks)
-        external
-        view
-        returns (DirEntry[] memory entries);
+    function readDir(string calldata path, uint64 maxDepth, bool followLinks) external view returns (DirEntry[] memory entries);
     function readFile(string calldata path) external view returns (string memory data);
     function readFileBinary(string calldata path) external view returns (bytes memory data);
     function readLine(string calldata path) external view returns (string memory line);
@@ -557,10 +342,7 @@ interface Vm {
     function rememberKey(uint256 privateKey) external returns (address keyAddr);
     function removeDir(string calldata path, bool recursive) external;
     function removeFile(string calldata path) external;
-    function replace(string calldata input, string calldata from, string calldata to)
-        external
-        pure
-        returns (string memory output);
+    function replace(string calldata input, string calldata from, string calldata to) external pure returns (string memory output);
     function resetNonce(address account) external;
     function resumeGasMetering() external;
     function revertTo(uint256 snapshotId) external returns (bool success);
@@ -576,66 +358,26 @@ interface Vm {
     function rpcUrlStructs() external view returns (Rpc[] memory urls);
     function rpcUrls() external view returns (string[2][] memory urls);
     function rpc(string calldata method, string calldata params) external returns (bytes memory data);
-    function rpc(string calldata urlOrAlias, string calldata method, string calldata params)
-        external
-        returns (bytes memory data);
+    function rpc(string calldata urlOrAlias, string calldata method, string calldata params) external returns (bytes memory data);
     function selectFork(uint256 forkId) external;
-    function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
-        external
-        returns (string memory json);
-    function serializeAddress(string calldata objectKey, string calldata valueKey, address[] calldata values)
-        external
-        returns (string memory json);
-    function serializeBool(string calldata objectKey, string calldata valueKey, bool value)
-        external
-        returns (string memory json);
-    function serializeBool(string calldata objectKey, string calldata valueKey, bool[] calldata values)
-        external
-        returns (string memory json);
-    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value)
-        external
-        returns (string memory json);
-    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32[] calldata values)
-        external
-        returns (string memory json);
-    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes calldata value)
-        external
-        returns (string memory json);
-    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes[] calldata values)
-        external
-        returns (string memory json);
-    function serializeInt(string calldata objectKey, string calldata valueKey, int256 value)
-        external
-        returns (string memory json);
-    function serializeInt(string calldata objectKey, string calldata valueKey, int256[] calldata values)
-        external
-        returns (string memory json);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address value) external returns (string memory json);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address[] calldata values) external returns (string memory json);
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool value) external returns (string memory json);
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool[] calldata values) external returns (string memory json);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value) external returns (string memory json);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32[] calldata values) external returns (string memory json);
+    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes calldata value) external returns (string memory json);
+    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes[] calldata values) external returns (string memory json);
+    function serializeInt(string calldata objectKey, string calldata valueKey, int256 value) external returns (string memory json);
+    function serializeInt(string calldata objectKey, string calldata valueKey, int256[] calldata values) external returns (string memory json);
     function serializeJson(string calldata objectKey, string calldata value) external returns (string memory json);
-    function serializeJsonType(string calldata typeDescription, bytes memory value)
-        external
-        pure
-        returns (string memory json);
-    function serializeJsonType(
-        string calldata objectKey,
-        string calldata valueKey,
-        string calldata typeDescription,
-        bytes memory value
-    ) external returns (string memory json);
-    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value)
-        external
-        returns (string memory json);
-    function serializeString(string calldata objectKey, string calldata valueKey, string[] calldata values)
-        external
-        returns (string memory json);
-    function serializeUintToHex(string calldata objectKey, string calldata valueKey, uint256 value)
-        external
-        returns (string memory json);
-    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
-        external
-        returns (string memory json);
-    function serializeUint(string calldata objectKey, string calldata valueKey, uint256[] calldata values)
-        external
-        returns (string memory json);
+    function serializeJsonType(string calldata typeDescription, bytes memory value) external pure returns (string memory json);
+    function serializeJsonType(string calldata objectKey, string calldata valueKey, string calldata typeDescription, bytes memory value) external returns (string memory json);
+    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value) external returns (string memory json);
+    function serializeString(string calldata objectKey, string calldata valueKey, string[] calldata values) external returns (string memory json);
+    function serializeUintToHex(string calldata objectKey, string calldata valueKey, uint256 value) external returns (string memory json);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value) external returns (string memory json);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256[] calldata values) external returns (string memory json);
     function setBlockhash(uint256 blockNumber, bytes32 blockHash) external;
     function setEnv(string calldata name, string calldata value) external;
     function setNonce(address account, uint64 newNonce) external;
@@ -688,13 +430,6 @@ interface Vm {
     function writeLine(string calldata path, string calldata data) external;
     function writeToml(string calldata json, string calldata path) external;
     function writeToml(string calldata json, string calldata path, string calldata valueKey) external;
-    function zkRegisterContract(
-        string calldata name,
-        bytes32 evmBytecodeHash,
-        bytes calldata evmDeployedBytecode,
-        bytes calldata evmBytecode,
-        bytes32 zkBytecodeHash,
-        bytes calldata zkDeployedBytecode
-    ) external pure;
+    function zkRegisterContract(string calldata name, bytes32 evmBytecodeHash, bytes calldata evmDeployedBytecode, bytes calldata evmBytecode, bytes32 zkBytecodeHash, bytes calldata zkDeployedBytecode) external pure;
     function zkVm(bool enable) external pure;
 }

--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -12,7 +12,7 @@ cache_path = "cache"
 evm_version = "paris"
 extra_output = []
 extra_output_files = []
-ffi = false
+ffi = true
 force = false
 invariant_fail_on_revert = false
 invariant_call_override = false
@@ -41,7 +41,10 @@ test = "./"
 tx_origin = "0x00a329c0648769a73afac7f9381e08fb43dbea72"
 verbosity = 3
 via_ir = false
-fs_permissions = [{ access = "read-write", path = "./" }]
+fs_permissions = [
+    { access = "read-write", path = "./" },
+    { access = "read", path = "../zkout/Greeter.sol/Greeter.0.8.18.json" }
+]
 
 [profile.default.rpc_storage_caching]
 chains = "all"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
- ZKsync makes uses of bytecodehash for deployments like create2, this cheatcode aims to provide foundry-zksync users an easier way to retrieve the bytecodehash. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- Create `getRawCodeHash` cheatcode to retrieve bytecode hash 

### Usage example:

```
counter = new Counter();
(bool success, bytes memory returnData) = address(vm).call(
    abi.encodeWithSignature("getRawCodeHash(address)", address(counter))
);
require(success, "getRawCodeHash call failed");

// Decode the bytecode hash returned by the cheatcode
bytes32 rawCodeHash = abi.decode(returnData, (bytes32));
```