### PR TITLE
fix: add solc artifacts to known contracts for traces

### DIFF
--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -475,6 +475,12 @@ impl MultiContractRunnerBuilder {
                     warn!("Abi not found for contract {}", id.identifier());
                 }
             }
+
+            // Extend zk contracts with solc contracts as well. This is required for traces to
+            // accurately detect contract names deployed in EVM mode, and when using
+            // `vm.zkVmSkip()` cheatcode.
+            zk_contracts_map.extend(linked_contracts);
+
             known_contracts = ContractsByArtifact::new(zk_contracts_map);
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
In zksync context, the traces cannot decode contracts via EVM bytecode as we only pass zksolc artifacts to `known_contracts`.

```bash
Traces:
  [1120167] 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496::testFoo()
    ├─ [0] VM::zkVmSkip()
    │   └─ ← [Return] 

```

Additionally, invariant tests do not work with `testContract` as during the test, they perform the lookup on the target address and try to match it with a known contract to obtain the ABI for invariant testing. This being an EVM bytecode, the test always fails as we do not know of any solc artifacts within `known_contracts`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Append solc artifacts to `known_contracts`. This is supported by the argument that in zksync context we are always aware of solc artifacts as we use them to translate bytecodes between VMs. 

This therefore fixes the decode problem:
```bash
Traces:
  [1120167] FooTest::testFoo()
    ├─ [0] VM::zkVmSkip()
    │   └─ ← [Return] 
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
