### PR TITLE
fix: install foundryzksync-up in /tmp to prevent conflict with source directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
         - uses: actions/checkout@v4
         - name: Install foundry-zksync
           run: |
-            curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
+            cd /tmp && curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
         - name: Verify installation
           run: forge --version
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
CI breaks currently as `foundryzksync-up` tries to install the script within the checked out source which already has a directory by that name.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Perform the install operation in /tmp directory.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
