### PR TITLE
chore: take historical block count from env

### DIFF
--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -297,7 +297,7 @@ fn get_historical_block_hashes<DB: Database>(ecx: &mut EvmContext<DB>) -> HashMa
     block_hashes
 }
 
-/// Get the number of historical blocks to fetch for mapping to block hashes from env. 
+/// Get the number of historical blocks to fetch, from the env.
 /// Default: `256`.
 fn get_env_historical_block_count() -> u32 {
     let name = "ZK_DEBUG_HISTORICAL_BLOCK_HASHES";

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -297,7 +297,8 @@ fn get_historical_block_hashes<DB: Database>(ecx: &mut EvmContext<DB>) -> HashMa
     block_hashes
 }
 
-/// Get the number of historical blocks to fetch for mapping to block hashes from env. Default: `256`.
+/// Get the number of historical blocks to fetch for mapping to block hashes from env. 
+/// Default: `256`.
 fn get_env_historical_block_count() -> u32 {
     let name = "ZK_DEBUG_HISTORICAL_BLOCK_HASHES";
     std::env::var(name)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Fetching last 256 blocks from rpc causes too much noise, in addition to, several rpc requests.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Make this parameter configurable with the env variable `ZK_DEBUG_HISTORICAL_BLOCK_HASHES`, in the absence of a generic config setting.

```bash
ZK_DEBUG_HISTORICAL_BLOCK_HASHES=0 forge test     # disables fetching historical block hashes
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
