### PR TITLE
fix: Create2Factory on scripts

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -37,8 +37,7 @@ use foundry_evm_core::{
 use foundry_zksync_compiler::{DualCompiledContract, DualCompiledContracts};
 use foundry_zksync_core::{
     convert::{ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
-    get_account_code_key, get_balance_key, get_nonce_key, Call,
-    ZkTransactionMetadata,
+    get_account_code_key, get_balance_key, get_nonce_key, Call, ZkTransactionMetadata,
 };
 use itertools::Itertools;
 use revm::{
@@ -1516,7 +1515,7 @@ impl Cheatcodes {
         ecx: &mut EvmContext<DB>,
         call: &mut CallInputs,
         executor: &mut impl CheatcodesExecutor,
-        create2_factory_deps: Vec<Vec<u8>>,
+        factory_deps: Vec<Vec<u8>>,
     ) -> Option<CallOutcome>
     where
         DB: DatabaseExt,
@@ -1549,12 +1548,7 @@ impl Cheatcodes {
         // We currently exhaust the entire gas for the call as zkEVM returns a very high amount
         // of gas that OOGs revm.
         let gas = Gas::new(call.gas_limit);
-        match foundry_zksync_core::vm::call::<_, DatabaseError>(
-            call,
-            ecx,
-            ccx,
-            create2_factory_deps,
-        ) {
+        match foundry_zksync_core::vm::call::<_, DatabaseError>(call, factory_deps, ecx, ccx) {
             Ok(result) => {
                 // append console logs from zkEVM to the current executor's LogTracer
                 result.logs.iter().filter_map(decode_console_log).for_each(|decoded_log| {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1499,7 +1499,7 @@ impl Cheatcodes {
         }
 
         if self.use_zk_vm {
-            if let Some(result) = self.try_call_in_zk(ecx, call, executor, factory_deps) {
+            if let Some(result) = self.try_call_in_zk(ecx, call, factory_deps, executor) {
                 return Some(result);
             }
         }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -28,7 +28,7 @@ use foundry_evm_core::{
     backend::{DatabaseError, DatabaseExt, LocalForkId, RevertDiagnostic},
     constants::{
         CHEATCODE_ADDRESS, CHEATCODE_CONTRACT_HASH, DEFAULT_CREATE2_DEPLOYER,
-        DEFAULT_CREATE2_DEPLOYER_CODE, DEFAULT_CREATE2_DEPLOYER_ZKSYNC,
+        DEFAULT_CREATE2_DEPLOYER_CODE,
     },
     decode::decode_console_log,
     utils::new_evm_with_existing_context,
@@ -38,6 +38,7 @@ use foundry_zksync_compiler::{DualCompiledContract, DualCompiledContracts};
 use foundry_zksync_core::{
     convert::{ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
     get_account_code_key, get_balance_key, get_nonce_key, Call, ZkTransactionMetadata,
+    DEFAULT_CREATE2_DEPLOYER_ZKSYNC,
 };
 use itertools::Itertools;
 use revm::{
@@ -1499,7 +1500,7 @@ impl Cheatcodes {
         }
 
         if self.use_zk_vm {
-            if let Some(result) = self.try_call_in_zk(ecx, call, factory_deps, executor) {
+            if let Some(result) = self.try_call_in_zk(factory_deps, ecx, call, executor) {
                 return Some(result);
             }
         }
@@ -1512,10 +1513,10 @@ impl Cheatcodes {
     /// handled in EVM.
     fn try_call_in_zk<DB>(
         &mut self,
+        factory_deps: Vec<Vec<u8>>,
         ecx: &mut EvmContext<DB>,
         call: &mut CallInputs,
         executor: &mut impl CheatcodesExecutor,
-        factory_deps: Vec<Vec<u8>>,
     ) -> Option<CallOutcome>
     where
         DB: DatabaseExt,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1197,7 +1197,7 @@ impl Cheatcodes {
             let contract = self
                 .dual_compiled_contracts
                 .find_by_evm_bytecode(init_code)
-                .unwrap_or_else(|| panic!("failed finding contract for {:?}", init_code));
+                .unwrap_or_else(|| panic!("failed finding contract for {init_code:?}"));
 
             create2_factory_deps.push(contract.zk_deployed_bytecode.clone());
 

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -38,7 +38,8 @@ pub const DEFAULT_CREATE2_DEPLOYER_DEPLOYER: Address =
 /// The default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER: Address = address!("4e59b44847b379578588920ca78fbf26c0b4956c");
 
-/// The default CREATE2 deployer for zksync (0x0000000000000000000000000000000000010000)
+/// The default CREATE2 deployer for zkSync (0x0000000000000000000000000000000000010000)
+/// See: https://github.com/zkSync-Community-Hub/zksync-developers/discussions/519
 pub const DEFAULT_CREATE2_DEPLOYER_ZKSYNC: Address =
     address!("0000000000000000000000000000000000010000");
 

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -37,6 +37,11 @@ pub const DEFAULT_CREATE2_DEPLOYER_DEPLOYER: Address =
     address!("3fAB184622Dc19b6109349B94811493BF2a45362");
 /// The default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER: Address = address!("4e59b44847b379578588920ca78fbf26c0b4956c");
+
+/// The default CREATE2 deployer for zksync (0x0000000000000000000000000000000000010000)
+pub const DEFAULT_CREATE2_DEPLOYER_ZKSYNC: Address =
+    address!("0000000000000000000000000000000000010000");
+
 /// The initcode of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!("604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
 /// The runtime code of the default CREATE2 deployer.

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -38,11 +38,6 @@ pub const DEFAULT_CREATE2_DEPLOYER_DEPLOYER: Address =
 /// The default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER: Address = address!("4e59b44847b379578588920ca78fbf26c0b4956c");
 
-/// The default CREATE2 deployer for zkSync (0x0000000000000000000000000000000000010000)
-/// See: https://github.com/zkSync-Community-Hub/zksync-developers/discussions/519
-pub const DEFAULT_CREATE2_DEPLOYER_ZKSYNC: Address =
-    address!("0000000000000000000000000000000000010000");
-
 /// The initcode of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!("604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
 /// The runtime code of the default CREATE2 deployer.

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -145,7 +145,13 @@ pub fn create2_handler_register<DB: revm::Database, I: InspectorExt<DB>>(
                 .push((ctx.evm.journaled_state.depth(), call_inputs.clone()));
 
             // Sanity check that CREATE2 deployer exists.
-            let code_hash = ctx.evm.load_account(call_inputs.target_address)?.0.info.code_hash;
+            // We check which deployer we are using to separate the logic for zkSync and original
+            // foundry.
+            let code_hash = if call_inputs.target_address == DEFAULT_CREATE2_DEPLOYER {
+                ctx.evm.load_account(DEFAULT_CREATE2_DEPLOYER)?.0.info.code_hash
+            } else {
+                ctx.evm.load_account(call_inputs.target_address)?.0.info.code_hash
+            };
             if code_hash == KECCAK_EMPTY {
                 return Ok(FrameOrResult::Result(FrameResult::Call(CallOutcome {
                     result: InterpreterResult {

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -1,12 +1,10 @@
 pub use crate::ic::*;
-use crate::{
-    constants::{DEFAULT_CREATE2_DEPLOYER, DEFAULT_CREATE2_DEPLOYER_ZKSYNC},
-    InspectorExt,
-};
+use crate::{constants::DEFAULT_CREATE2_DEPLOYER, InspectorExt};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Selector, TxKind, U256};
 use alloy_rpc_types::{Block, Transaction};
 use foundry_config::NamedChain;
+use foundry_zksync_core::DEFAULT_CREATE2_DEPLOYER_ZKSYNC;
 use revm::{
     db::WrapDatabaseRef,
     handler::register::EvmHandler,

--- a/crates/forge/tests/fixtures/zk/Create2.s.sol
+++ b/crates/forge/tests/fixtures/zk/Create2.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.18;
 
 import {Script} from "forge-std/Script.sol";
 import {Greeter} from "../src/Greeter.sol";
+import {Create2Utils} from "../src/Create2Utils.sol";
 
 contract Create2Script is Script {
     function run() external {
@@ -18,10 +19,26 @@ contract Create2Script is Script {
         // Verify Greeter deployment
         require(address(greeter) != address(0), "Greeter deployment failed");
 
+        // Verify the deployed address matches the expected address
+        bytes32 bytecodeHash = getBytecodeHash("zkout/Greeter.sol/Greeter.json");
+        address expectedAddress = Create2Utils.computeCreate2Address(
+            address(0x0000000000000000000000000000000000010000), // DEFAULT_CREATE2_DEPLOYER_ZKSYNC
+            greeterSalt,
+            bytecodeHash,
+            keccak256(abi.encode())
+        );
+
+        require(address(greeter) == expectedAddress, "Deployed address doesn't match expected address");
+
         // Test Greeter functionality
         string memory greeting = greeter.greeting("Alice");
         require(bytes(greeting).length > 0, "Greeter greeting failed");
 
         vm.stopBroadcast();
+    }
+
+    function getBytecodeHash(string memory path) internal returns (bytes32 bytecodeHash) {
+        string memory artifact = vm.readFile(path);
+        bytecodeHash = vm.parseJsonBytes32(artifact, ".hash");
     }
 }

--- a/crates/forge/tests/fixtures/zk/Create2.s.sol
+++ b/crates/forge/tests/fixtures/zk/Create2.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import {Script} from "forge-std/Script.sol";
+import {Greeter} from "../src/Greeter.sol";
+import {CustomNumber} from "../src/CustomNumber.sol";
+
+contract Create2Script is Script {
+    function run() external {
+        (bool success,) = address(vm).call(abi.encodeWithSignature("zkVm(bool)", true));
+        require(success, "zkVm() call failed");
+        
+        vm.startBroadcast();
+
+        // Deploy Greeter using create2 with a salt
+        bytes32 greeterSalt = bytes32("12345");
+        Greeter greeter = new Greeter{salt: greeterSalt}();
+
+        // Verify Greeter deployment
+        require(address(greeter) != address(0), "Greeter deployment failed");
+
+        // Test Greeter functionality
+        string memory greeting = greeter.greeting("Alice");
+        require(bytes(greeting).length > 0, "Greeter greeting failed");
+
+        // Deploy CustomNumber using create2 with a salt value
+        uint8 customNumberValue = 42;
+        CustomNumber customNumber = new CustomNumber{salt: "123" }(customNumberValue);
+
+        // Verify CustomNumber deployment and initial value
+        require(address(customNumber) != address(0), "CustomNumber deployment failed");
+        require(customNumber.number() == customNumberValue, "CustomNumber initial value mismatch");
+
+        vm.stopBroadcast();
+    }
+}

--- a/crates/forge/tests/fixtures/zk/Create2.s.sol
+++ b/crates/forge/tests/fixtures/zk/Create2.s.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.18;
 
 import {Script} from "forge-std/Script.sol";
 import {Greeter} from "../src/Greeter.sol";
-import {CustomNumber} from "../src/CustomNumber.sol";
 
 contract Create2Script is Script {
     function run() external {
@@ -22,14 +21,6 @@ contract Create2Script is Script {
         // Test Greeter functionality
         string memory greeting = greeter.greeting("Alice");
         require(bytes(greeting).length > 0, "Greeter greeting failed");
-
-        // Deploy CustomNumber using create2 with a salt value
-        uint8 customNumberValue = 42;
-        CustomNumber customNumber = new CustomNumber{salt: "123" }(customNumberValue);
-
-        // Verify CustomNumber deployment and initial value
-        require(address(customNumber) != address(0), "CustomNumber deployment failed");
-        require(customNumber.number() == customNumberValue, "CustomNumber initial value mismatch");
 
         vm.stopBroadcast();
     }

--- a/crates/forge/tests/it/zk/create2.rs
+++ b/crates/forge/tests/it/zk/create2.rs
@@ -1,0 +1,22 @@
+use foundry_test_utils::{forgetest_async, util, TestProject};
+
+use crate::test_helpers::run_zk_script_test;
+
+forgetest_async!(can_deploy_via_create2, |prj, cmd| {
+    setup_create2_prj(&mut prj);
+    run_zk_script_test(
+        prj.root(),
+        &mut cmd,
+        "./script/Create2.s.sol",
+        "Create2Script",
+        None,
+        2,
+        Some(&["-vvvvv"]),
+    );
+});
+
+fn setup_create2_prj(prj: &mut TestProject) {
+    util::initialize(prj.root());
+    prj.add_script("Create2.s.sol", include_str!("../../fixtures/zk/Create2.s.sol")).unwrap();
+    prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
+}

--- a/crates/forge/tests/it/zk/create2.rs
+++ b/crates/forge/tests/it/zk/create2.rs
@@ -1,9 +1,13 @@
+use foundry_config::fs_permissions::PathPermission;
 use foundry_test_utils::{forgetest_async, util, TestProject};
 
 use crate::test_helpers::run_zk_script_test;
 
 forgetest_async!(can_deploy_via_create2, |prj, cmd| {
     setup_create2_prj(&mut prj);
+    let mut config = cmd.config();
+    config.fs_permissions.add(PathPermission::read("./zkout"));
+    prj.write_config(config);
     run_zk_script_test(
         prj.root(),
         &mut cmd,
@@ -19,4 +23,6 @@ fn setup_create2_prj(prj: &mut TestProject) {
     util::initialize(prj.root());
     prj.add_script("Create2.s.sol", include_str!("../../fixtures/zk/Create2.s.sol")).unwrap();
     prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
+    prj.add_source("Create2Utils.sol", include_str!("../../../../../testdata/zk/Create2Utils.sol"))
+        .unwrap();
 }

--- a/crates/forge/tests/it/zk/deploy.rs
+++ b/crates/forge/tests/it/zk/deploy.rs
@@ -24,24 +24,9 @@ forgetest_async!(multiple_deployments_of_the_same_contract, |prj, cmd| {
     );
 });
 
-forgetest_async!(can_deploy_via_create2, |prj, cmd| {
-    setup_deploy_prj(&mut prj);
-    run_zk_script_test(
-        prj.root(),
-        &mut cmd,
-        "./script/Create2.s.sol",
-        "Create2Script",
-        None,
-        3,
-        Some(&["-vvvvv"]),
-    );
-});
-
 fn setup_deploy_prj(prj: &mut TestProject) {
     util::initialize(prj.root());
     prj.add_script("Deploy.s.sol", include_str!("../../fixtures/zk/Deploy.s.sol")).unwrap();
-    prj.add_script("Create2.s.sol", include_str!("../../fixtures/zk/Create2.s.sol")).unwrap();
-    prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
     prj.add_source("CustomNumber.sol", include_str!("../../../../../testdata/zk/CustomNumber.sol"))
         .unwrap();
 }

--- a/crates/forge/tests/it/zk/deploy.rs
+++ b/crates/forge/tests/it/zk/deploy.rs
@@ -24,8 +24,24 @@ forgetest_async!(multiple_deployments_of_the_same_contract, |prj, cmd| {
     );
 });
 
+forgetest_async!(can_deploy_via_create2, |prj, cmd| {
+    setup_deploy_prj(&mut prj);
+    run_zk_script_test(
+        prj.root(),
+        &mut cmd,
+        "./script/Create2.s.sol",
+        "Create2Script",
+        None,
+        3,
+        Some(&["-vvvvv"]),
+    );
+});
+
 fn setup_deploy_prj(prj: &mut TestProject) {
     util::initialize(prj.root());
     prj.add_script("Deploy.s.sol", include_str!("../../fixtures/zk/Deploy.s.sol")).unwrap();
+    prj.add_script("Create2.s.sol", include_str!("../../fixtures/zk/Create2.s.sol")).unwrap();
     prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
+    prj.add_source("CustomNumber.sol", include_str!("../../../../../testdata/zk/CustomNumber.sol"))
+        .unwrap();
 }

--- a/crates/forge/tests/it/zk/deploy.rs
+++ b/crates/forge/tests/it/zk/deploy.rs
@@ -28,6 +28,4 @@ fn setup_deploy_prj(prj: &mut TestProject) {
     util::initialize(prj.root());
     prj.add_script("Deploy.s.sol", include_str!("../../fixtures/zk/Deploy.s.sol")).unwrap();
     prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
-    prj.add_source("CustomNumber.sol", include_str!("../../../../../testdata/zk/CustomNumber.sol"))
-        .unwrap();
 }

--- a/crates/forge/tests/it/zk/deploy.rs
+++ b/crates/forge/tests/it/zk/deploy.rs
@@ -27,6 +27,7 @@ forgetest_async!(multiple_deployments_of_the_same_contract, |prj, cmd| {
 fn setup_deploy_prj(prj: &mut TestProject) {
     util::initialize(prj.root());
     prj.add_script("Deploy.s.sol", include_str!("../../fixtures/zk/Deploy.s.sol")).unwrap();
+    prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
     prj.add_source("CustomNumber.sol", include_str!("../../../../../testdata/zk/CustomNumber.sol"))
         .unwrap();
 }

--- a/crates/forge/tests/it/zk/mod.rs
+++ b/crates/forge/tests/it/zk/mod.rs
@@ -3,6 +3,7 @@ mod basic;
 mod cheats;
 mod contracts;
 mod create;
+mod create2;
 mod deploy;
 mod factory;
 mod factory_deps;

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod vm;
 pub mod state;
 
 use alloy_network::{AnyNetwork, TxSigner};
-use alloy_primitives::{Address, Bytes, U256 as rU256};
+use alloy_primitives::{address, Address, Bytes, U256 as rU256};
 use alloy_provider::Provider;
 use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
@@ -53,6 +53,11 @@ pub const EMPTY_CODE: [u8; 32] = [0; 32];
 
 /// The minimum possible address that is not reserved in the zkSync space.
 const MIN_VALID_ADDRESS: u32 = 2u32.pow(16);
+
+/// The default CREATE2 deployer for zkSync (0x0000000000000000000000000000000000010000)
+/// See: https://github.com/zkSync-Community-Hub/zksync-developers/discussions/519
+pub const DEFAULT_CREATE2_DEPLOYER_ZKSYNC: Address =
+    address!("0000000000000000000000000000000000010000");
 
 /// Returns the balance key for a provided account address.
 pub fn get_balance_key(address: Address) -> rU256 {

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -172,9 +172,9 @@ where
 /// Executes a CALL opcode on the ZK-VM.
 pub fn call<DB, E>(
     call: &CallInputs,
+    factory_deps: Vec<Vec<u8>>,
     ecx: &mut EvmContext<DB>,
     mut ccx: CheatcodeTracerContext,
-    factory_deps: Vec<Vec<u8>>,
 ) -> ZKVMResult<E>
 where
     DB: Database,

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -297,7 +297,7 @@ fn get_historical_block_hashes<DB: Database>(ecx: &mut EvmContext<DB>) -> HashMa
     block_hashes
 }
 
-/// Get the number of historical blocks to fetch for mapping to block hashes from env. 
+/// Get the number of historical blocks to fetch, from the env.
 /// Default: `256`.
 fn get_env_historical_block_count() -> u32 {
     let name = "ZK_DEBUG_HISTORICAL_BLOCK_HASHES";

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -297,7 +297,8 @@ fn get_historical_block_hashes<DB: Database>(ecx: &mut EvmContext<DB>) -> HashMa
     block_hashes
 }
 
-/// Get the number of historical blocks to fetch for mapping to block hashes from env. Default: `256`.
+/// Get the number of historical blocks to fetch for mapping to block hashes from env. 
+/// Default: `256`.
 fn get_env_historical_block_count() -> u32 {
     let name = "ZK_DEBUG_HISTORICAL_BLOCK_HASHES";
     std::env::var(name)

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -174,6 +174,7 @@ pub fn call<DB, E>(
     call: &CallInputs,
     ecx: &mut EvmContext<DB>,
     mut ccx: CheatcodeTracerContext,
+    factory_deps: Vec<Vec<u8>>,
 ) -> ZKVMResult<E>
 where
     DB: Database,
@@ -200,7 +201,7 @@ where
             CallValue::Transfer(value) => value.to_u256(),
             _ => U256::zero(),
         },
-        Default::default(),
+        factory_deps,
         PaymasterParams::default(),
     );
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Using create2 in a script does not work as expected, as mentioned in this [issue](https://github.com/matter-labs/foundry-zksync/issues/570). Create2 was working for tests, but due to a check in the scripting process, we were unable to deploy it correctly in this case.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Adapt the script flow to use the create2Factory deployed in zksync

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
