### PR TITLE
fix: patch create traces to work with foundry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.10"
+version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d5b8722112fa2fa87135298780bc833b0e9f6c56cc82795d209804b3a03484"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7317,7 +7317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8083,7 +8083,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.71",
@@ -8128,9 +8128,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "oorandom"
@@ -9265,7 +9265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.71",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,7 +5972,7 @@ dependencies = [
 name = "gix-path"
 version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d5b8722112fa2fa87135298780bc833b0e9f6c56cc82795d209804b3a03484"
+checksum = "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af"
 dependencies = [
  "bstr 1.9.1",
  "gix-trace",
@@ -6030,9 +6030,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
+checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
 
 [[package]]
 name = "gix-utils"

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -159,7 +159,7 @@ pub trait CheatcodesExecutor {
         self.get_inspector::<DB>(ccx.state).console_log(message);
     }
 
-    fn trace<DB: DatabaseExt>(
+    fn trace_zksync<DB: DatabaseExt>(
         &mut self,
         ccx_state: &mut Cheatcodes,
         ecx: &mut EvmContext<DB>,
@@ -950,7 +950,7 @@ impl Cheatcodes {
                 });
 
                 // append traces
-                executor.trace(self, ecx, result.call_traces);
+                executor.trace_zksync(self, ecx, result.call_traces);
 
                 // for each log in cloned logs call handle_expect_emit
                 if !self.expected_emits.is_empty() {
@@ -1441,7 +1441,7 @@ impl Cheatcodes {
                     }
 
                     // append traces
-                    executor.trace(self, ecx, result.call_traces);
+                    executor.trace_zksync(self, ecx, result.call_traces);
 
                     // for each log in cloned logs call handle_expect_emit
                     if !self.expected_emits.is_empty() {

--- a/crates/evm/evm/src/inspectors/trace.rs
+++ b/crates/evm/evm/src/inspectors/trace.rs
@@ -287,9 +287,6 @@ impl<DB: Database> InspectorExt<DB> for TraceCollector {
                             address: None,
                         }
                     } else {
-                        // zkEVM traces do not have the create address in output
-                        // it's always an empty slice, so we fill it from the `call.to`
-                        // which contains the correct address
                         CreateOutcome {
                             result: InterpreterResult {
                                 result: InstructionResult::Return,

--- a/crates/evm/evm/src/inspectors/trace.rs
+++ b/crates/evm/evm/src/inspectors/trace.rs
@@ -293,7 +293,7 @@ impl<DB: Database> InspectorExt<DB> for TraceCollector {
                         CreateOutcome {
                             result: InterpreterResult {
                                 result: InstructionResult::Return,
-                                output: Bytes::from(call.to.to_h256().0),
+                                output: Bytes::from(call.output),
                                 gas: Gas::new_spent(call.gas_used + extra_gas),
                             },
                             address: Some(call.to.to_address()),

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -126,6 +126,7 @@ foundry-test-utils.workspace = true
 
 mockall = "0.12"
 criterion = "0.5"
+once_cell = "1.20.0"
 paste = "1.0"
 path-slash = "0.2"
 similar-asserts.workspace = true

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -275,10 +275,12 @@ pub fn encode_create_params(
     signature.iter().copied().chain(params).collect()
 }
 
-/// Get last 256 block hashes mapped to block numbers. This excludes the current block.
+/// Get historical block hashes mapped to block numbers. This excludes the current block.
 fn get_historical_block_hashes<DB: Database>(ecx: &mut EvmContext<DB>) -> HashMap<rU256, B256> {
     let mut block_hashes = HashMap::default();
-    for i in 1..=256u32 {
+    let num_blocks = get_env_historical_block_count();
+    tracing::debug!("fetching last {num_blocks} block hashes");
+    for i in 1..=num_blocks {
         let (block_number, overflow) =
             ecx.env.block.number.overflowing_sub(alloy_primitives::U256::from(i));
         if overflow {
@@ -293,4 +295,18 @@ fn get_historical_block_hashes<DB: Database>(ecx: &mut EvmContext<DB>) -> HashMa
     }
 
     block_hashes
+}
+
+/// Get the number of historical blocks to fetch, from the env.
+/// Default: `256`.
+fn get_env_historical_block_count() -> u32 {
+    let name = "ZK_DEBUG_HISTORICAL_BLOCK_HASHES";
+    std::env::var(name)
+        .map(|value| {
+            value.parse::<u32>().unwrap_or_else(|err| {
+                panic!("failed parsing env variable {}={}, {:?}", name, value, err)
+            })
+        })
+        .map(|num| num.min(256))
+        .unwrap_or(256)
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Unlike EVM, `CREATE` call traces obtained from zkEVM do not contain the bytecode in the `output` section but a 0-padded address instead. This causes the traces to not be decoded properly in foundry causing issues in gas reporting and invariant tests.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Patch zkEVM `CREATE` call trace to populate it with the bytecode, for better interoperability with foundry.


Now:
```
Traces:
  [32676] ZkTraceTest::testZkTraceOutputDuringCreate()
    ├─ [0] → new ConstructorAdder@0xF9E9ba9Ed9B96AB918c74B21dD0f1D5f2ac38a30
    │   ├─ [127] → new Number@0xf232f12E115391c535FD519B00efADf042fc8Be5
    │   │   └─ ← [Return] 2272 bytes of code
    │   ├─ [85280] Number::five()
    │   │   ├─ [91] → new InnerNumber@0xEd570f3F91621894E001DF0fB70BfbD123D3c8AD
    │   │   │   └─ ← [Return] 736 bytes of code
    │   │   ├─ [889] InnerNumber::innerFive()
    │   │   │   └─ ← [Return] 5
    │   │   └─ ← [Return] 5
    │   ├─ [74776] Number::five()
    │   │   ├─ [91] → new InnerNumber@0xAbceAEaC3d3a2ac3Dcffd7A60Ca00A3fAC9490cA
    │   │   │   └─ ← [Return] 736 bytes of code
    │   │   ├─ [889] InnerNumber::innerFive()
    │   │   │   └─ ← [Return] 5
    │   │   └─ ← [Return] 5
    │   ├─ [276] console::log(10)
    │   │   └─ ← [Return] 
    │   └─ ← [Return] 3168 bytes of code
    └─ ← [Stop] 
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
