### PR TITLE
fix: Add check in ZK create to check if it's the test contract

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -950,7 +950,7 @@ impl Cheatcodes {
                 .info
                 .nonce;
             let address = caller.create(nonce);
-            if let Some(true) = ecx.db.get_test_contract_address().map(|addr| address == addr) {
+            if ecx.db.get_test_contract_address().map(|addr| address == addr).unwrap_or_default() {
                 info!("running create in EVM, instead of zkEVM (Test Contract) {:#?}", address);
                 return None
             }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -939,6 +939,23 @@ impl Cheatcodes {
             return None
         }
 
+        if let Some(CreateScheme::Create) = input.scheme() {
+            let caller = input.caller();
+            let nonce = ecx
+                .inner
+                .journaled_state
+                .load_account(input.caller(), &mut ecx.inner.db)
+                .unwrap()
+                .0
+                .info
+                .nonce;
+            let address = caller.create(nonce);
+            if let Some(true) = ecx.db.get_test_contract_address().map(|addr| address == addr) {
+                info!("running create in EVM, instead of zkEVM (Test Contract) {:#?}", address);
+                return None
+            }
+        }
+
         if input.init_code().0 == DEFAULT_CREATE2_DEPLOYER_CODE {
             info!("running create in EVM, instead of zkEVM (DEFAULT_CREATE2_DEPLOYER_CODE)");
             return None

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -130,6 +130,7 @@ impl ScriptRunner {
 
         let address = CALLER.create(self.executor.get_nonce(CALLER)?);
 
+        self.executor.backend_mut().set_test_contract(address);
         // Set the contracts initial balance before deployment, so it is available during the
         // construction
         self.executor.set_balance(address, self.evm_opts.initial_balance)?;
@@ -147,7 +148,6 @@ impl ScriptRunner {
 
         // Optionally call the `setUp` function
         let (success, gas_used, labeled_addresses, transactions) = if !setup {
-            self.executor.backend_mut().set_test_contract(address);
             (true, 0, Default::default(), Some(library_transactions))
         } else {
             match self.executor.setup(Some(self.evm_opts.sender), address, None) {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The motivation of this PR is to solve the [issue 579](https://github.com/matter-labs/foundry-zksync/issues/579) that raised that a script that was meant to fail was not when not passing an rpc-url or fork-url

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Check wether we are dealing with the test contract to avoid deploying it in Zk-vm and later try to execute in EVM. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
