### PR TITLE
feat: init forge project with zksync

### DIFF
--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -44,7 +44,7 @@ pub struct InitArgs {
 impl InitArgs {
     pub fn run(self) -> Result<()> {
         let Self { root, template, branch, opts, offline, force, vscode } = self;
-        let DependencyInstallOpts { shallow, no_git, no_commit, quiet } = opts;
+        let DependencyInstallOpts { shallow, no_git, no_commit, quiet, zksync } = opts;
 
         // create the root dir if it does not exist
         if !root.exists() {
@@ -149,6 +149,17 @@ impl InitArgs {
                     self.opts.install(&mut config, vec![])?;
                 } else {
                     let dep = "https://github.com/foundry-rs/forge-std".parse()?;
+                    self.opts.install(&mut config, vec![dep])?;
+                }
+            }
+
+            // install forge-zksync-std
+            if zksync && !offline {
+                if root.join("lib/forge-zksync-std").exists() {
+                    p_println!(!quiet => "\"lib/forge-zksync-std\" already exists, skipping install....");
+                    self.opts.install(&mut config, vec![])?;
+                } else {
+                    let dep = "https://github.com/Moonsong-Labs/forge-zksync-std".parse()?;
                     self.opts.install(&mut config, vec![dep])?;
                 }
             }

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -81,6 +81,10 @@ pub struct DependencyInstallOpts {
     /// Do not print any messages.
     #[arg(short, long)]
     pub quiet: bool,
+
+    /// Install ZKsync specific libraries.
+    #[arg(long)]
+    pub zksync: bool,
 }
 
 impl DependencyInstallOpts {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
https://github.com/Moonsong-Labs/forge-zksync-std was added to help with accessing our custom cheatcodes. But currently there's no way to `init` a forge project with these automatically.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add `--zksync` flag to `forge init` that will automatically install `forge-zksync-std`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
