### PR TITLE
chore: bump alloy-chains version so zksync-sepolia has correct chainID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ alloy-sol-macro-input = "0.7.7"
 alloy-sol-types = "0.7.7"
 syn-solidity = "0.7.7"
 
-alloy-chains = "0.1"
+alloy-chains = "0.1.33"
 alloy-rlp = "0.3.3"
 alloy-trie = "0.4.1"
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- Was getting the below error when working with `--verify` 

```
Error:
Chain 300 not supported
```

Since https://github.com/alloy-rs/chains/pull/92 is now merged we can bump the dep so its now supported correctly. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- bump to `alloy-chains = "0.1.33"`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
