### PR TITLE
feat: add additional gas usage info from bootloader

### DIFF
--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -469,8 +469,7 @@ fn inspect_inner<S: ReadStorage>(
     let bootloader_debug = Arc::try_unwrap(bootloader_debug_tracer_result)
         .unwrap()
         .take()
-        .map(|result| result.ok())
-        .flatten()
+        .and_then(|result| result.ok())
         .expect("failed obtaining bootloader debug info");
     trace!("{bootloader_debug:?}");
 

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -199,7 +199,7 @@ where
     } = inspect_inner(tx, storage_ptr, chain_id, ccx, call_ctx);
 
     info!(
-        total=?gas_usage.limit, computation=?gas_usage.execution, pubdata=?gas_usage.pubdata, refunded=?gas_usage.refunded,
+        limit=?gas_usage.limit, execution=?gas_usage.execution, pubdata=?gas_usage.pubdata, refunded=?gas_usage.refunded,
         "gas usage",
     );
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The gas usage value in `VmExecutionStatistics` is not representative of the actual gas a user pays which is observable when checking the values from the `RefundTracer`.

```
Gas Limit: 1073741824
Gas spent on computation: 260304
Gas spent on pubdata: 15827000
Pubdata published: 931
...
...
VmExecutionStatistics { gas_used: 25901, ... }
```



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Utilize the `BootloaderDebugTracer` from era-test-node's modified `bootloader.yul` to utilize the gas usage parameters, to compute the accurate information.

```
Gas Limit: 1073741824
Gas spent on computation: 260304
Gas spent on pubdata: 15827000
Pubdata published: 931
...
BootloaderDebug { total_gas_limit_from_user: 1073741824, reserved_gas: 993741824, gas_per_pubdata: 17000, gas_limit_after_intrinsic: 79975930, gas_after_validation: 79906438, gas_spent_on_execution: 166742, gas_spent_on_bytecode_preparation: 120492, refund_computed: 79739696, refund_by_operator: 1057914824, intrinsic_overhead: 14070, required_overhead: 11200, operator_overhead: 10000, overhead_for_length: 11200, overhead_for_slot: 10000 }
...
...
gas usage limit=80000000 execution=260304 pubdata=15827000 refunded=1057914824
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
