### PR TITLE
feat: return actual gas charged to the transaction caller for zkVM transactions

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1029,7 +1029,6 @@ impl Cheatcodes {
                 match result.execution_result {
                     ExecutionResult::Success { output, gas_used, .. } => {
                         let _ = gas.record_cost(gas_used);
-                        println!("{gas:?}");
                         match output {
                             Output::Create(bytes, address) => Some(CreateOutcome {
                                 result: InterpreterResult {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When vm is on zkVM mode, Calls/Creates on EVM are intercepted and run as transactions on the zkVM made by the caller of the test contract. There are currently two problems related to gas visibility for them: 
1.  `gas_used` value being returned is the computational gas spent by a bootloader program run on `OneTx` mode with that transaction on its heap. This includes the gas for general setup and transaction validation + execution. This value does not make sense in neither the case where we would want to interpret the intercepted call as a `CALL` opcode, because it would include setup + validation costs, nor for when we want to interpret it as an actual transaction (like done on evm tests when run on `isolate` mode), because it includes non transaction related gas and does not account for neither pubdata nor intrinsic costs.
2. Gas sent back to the revm via `InterpreterResult` represents 0 gas spent. This value is then used in traces which result in them showing 0 gas cost and gas report stats not showing any meaningful value.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1) Treat intercepted calls/creates as transactions, yielding the gas charged to user making the transaction as the `gas_used`.
2) Account for this gas in the gas returned in `InterpreterResult`.