### PR TITLE
feat: use zk deployment sizes in gas report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5354,6 +5354,7 @@ dependencies = [
  "foundry-config",
  "foundry-evm-core",
  "foundry-linking",
+ "foundry-zksync-compiler",
  "futures 0.3.30",
  "itertools 0.13.0",
  "once_cell",

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -21,6 +21,7 @@ foundry-compilers.workspace = true
 foundry-linking.workspace = true
 foundry-config.workspace = true
 foundry-evm-core.workspace = true
+foundry-zksync-compiler.workspace = true
 
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-json-abi.workspace = true

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -105,6 +105,12 @@ impl GasReport {
             trace!(contract_name, "adding create gas info");
             contract_info.gas = trace.gas_used;
             contract_info.size = trace.data.len();
+
+            if decoder.zk_contracts.contains(&node.trace.address) {
+                // Intercepted creates in zkvm mode will have the evm bytecode as input
+                // and the zkvm bytecode as output on the trace.
+                contract_info.size = trace.output.len();
+            }
         } else if let Some(DecodedCallData { signature, .. }) = decoded().await.call_data {
             let name = signature.split('(').next().unwrap();
             // ignore any test/setup functions

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -12,6 +12,7 @@ use foundry_test_utils::{
     util::{pretty_err, read_string, OutputExt, TestCommand},
 };
 use semver::Version;
+use similar_asserts::assert_eq;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -1510,6 +1511,73 @@ contract ContractThreeTest is DSTest {
     cmd.forge_fuse();
     let third_out = cmd.arg("test").arg("--gas-report").stdout_lossy();
     assert!(third_out.contains("foo") && third_out.contains("bar") && third_out.contains("baz"));
+});
+
+forgetest!(zk_gas_report, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "Contracts.sol",
+        r#"
+//SPDX-license-identifier: MIT
+
+import "./test.sol";
+
+contract ContractOne {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function foo() public{
+        while(i<5){
+            i++;
+        }
+    }
+}
+
+contract ContractOneTest is DSTest {
+    ContractOne c1;
+
+    function setUp() public {
+        c1 = new ContractOne();
+    }
+
+    function testFoo() public {
+        c1.foo();
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    // report for all
+    prj.write_config(Config {
+        gas_reports: (vec!["*".to_string()]),
+        gas_reports_ignore: (vec![]),
+        ..Default::default()
+    });
+    let out = cmd.arg("test").arg("--gas-report").stdout_lossy();
+    cmd.forge_fuse();
+    let out_zk = cmd.arg("test").arg("--gas-report").arg("--zksync").stdout_lossy();
+
+    let mut cells = out.split('|');
+    let deployment_cost: u64 = cells.nth(22).unwrap().trim().parse().unwrap();
+    let deployment_size: u64 = cells.next().unwrap().trim().parse().unwrap();
+    let function = cells.nth(12).unwrap().trim();
+    let gas: u64 = cells.next().unwrap().trim().parse().unwrap();
+
+    let mut cells_zk = out_zk.split('|');
+    let deployment_cost_zk: u64 = cells_zk.nth(22).unwrap().trim().parse().unwrap();
+    let deployment_size_zk: u64 = cells_zk.next().unwrap().trim().parse().unwrap();
+    let function_zk = cells_zk.nth(12).unwrap().trim();
+    let gas_zk: u64 = cells_zk.next().unwrap().trim().parse().unwrap();
+
+    assert!(deployment_cost_zk > deployment_cost);
+    assert!(deployment_size_zk > deployment_size);
+    assert!(gas_zk > gas);
+    assert_eq!(function, "foo");
+    assert_eq!(function_zk, "foo");
 });
 
 forgetest_init!(can_use_absolute_imports, |prj, cmd| {

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1551,7 +1551,6 @@ contract ContractOneTest is DSTest {
     )
     .unwrap();
 
-    // report for all
     prj.write_config(Config {
         gas_reports: (vec!["*".to_string()]),
         gas_reports_ignore: (vec![]),

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -24,7 +24,9 @@ use foundry_evm::{
     opts::{Env, EvmOpts},
 };
 use foundry_test_utils::{fd_lock, init_tracing, TestCommand, ZkSyncNode};
-use foundry_zksync_compiler::{DualCompiledContracts, ZKSYNC_SOLIDITY_FILES_CACHE_FILENAME};
+use foundry_zksync_compiler::{
+    DualCompiledContracts, ZKSYNC_ARTIFACTS_DIR, ZKSYNC_SOLIDITY_FILES_CACHE_FILENAME,
+};
 use once_cell::sync::Lazy;
 use semver::Version;
 use std::{
@@ -91,7 +93,7 @@ impl ForgeTestProfile {
         let mut zk_project =
             foundry_zksync_compiler::config_create_project(&zk_config, zk_config.cache, false)
                 .expect("failed creating zksync project");
-        zk_project.paths.artifacts = zk_config.root.as_ref().join("zk").join("zkout");
+        zk_project.paths.artifacts = zk_config.root.as_ref().join("zk").join(ZKSYNC_ARTIFACTS_DIR);
         zk_project.paths.cache = zk_config
             .root
             .as_ref()

--- a/crates/zksync/compiler/src/lib.rs
+++ b/crates/zksync/compiler/src/lib.rs
@@ -31,6 +31,9 @@ use foundry_compilers::{
 /// Filename for zksync cache
 pub const ZKSYNC_SOLIDITY_FILES_CACHE_FILENAME: &str = "zksync-solidity-files-cache.json";
 
+/// Directory for zksync artifacts
+pub const ZKSYNC_ARTIFACTS_DIR: &str = "zkout";
+
 // Config overrides to create zksync specific foundry-compilers data structures
 
 /// Returns the configured `zksolc` `Settings` that includes:
@@ -160,7 +163,7 @@ pub fn config_project_paths(config: &Config) -> ProjectPathsConfig<SolcLanguage>
         .sources(&config.src)
         .tests(&config.test)
         .scripts(&config.script)
-        .artifacts(config.root.0.join("zkout"))
+        .artifacts(config.root.0.join(ZKSYNC_ARTIFACTS_DIR))
         .libs(config.libs.iter())
         .remappings(config.get_all_remappings())
         .allowed_path(&config.root.0)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Traces for intercepted creates in zkVM mode have evm bytecode on its input. The gas report uses that value to compute deployment size, which results in evm bytecode sizes being reported for zksync gas reports.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. Add a `zk_contracts` field to the `CallTraceDecoder`, and use the artifact path to identify contracts that are in the zkVM.
2. When analyzing the node on the gas report use the trace output for computing the deployment size on those contracts.

### Note
The way the matching is implemented, if user sets a path with `zkout` as the solc artifact output, the contracts will be interpreted as zkevm and the output (deployed bytecode) will be used instead of the input. We could handle this edge case, but that clash would probably create problems elsewhere as well so, if we ever want to address it might be worth thinking about the clash problem holistically and solve it in a dedicated PR.