### PR TITLE
chore: change meaning of l1 one gas price constant

### DIFF
--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -53,8 +53,8 @@ use foundry_evm_abi::{
     patch_hh_console_selector, Console, HardhatConsole, HARDHAT_CONSOLE_ADDRESS,
 };
 
-/// Maximum gas price allowed for L1.
-const MAX_L1_GAS_PRICE: u64 = 1000;
+/// Minimum gas price allowed for L1.
+const MIN_L1_GAS_PRICE: u64 = 1000;
 
 /// Represents the result of execution a [`L2Tx`] on EraVM
 #[derive(Debug)]
@@ -416,7 +416,7 @@ fn inspect_inner<S: ReadStorage>(
     ccx: &mut CheatcodeTracerContext,
     call_ctx: CallContext,
 ) -> InnerZkVmResult {
-    let l1_gas_price = call_ctx.block_basefee.to::<u64>().max(MAX_L1_GAS_PRICE);
+    let l1_gas_price = call_ctx.block_basefee.to::<u64>().max(MIN_L1_GAS_PRICE);
     let fair_l2_gas_price = call_ctx.block_basefee.saturating_to::<u64>();
     let batch_env = create_l1_batch_env(storage.clone(), l1_gas_price, fair_l2_gas_price);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Even though why we need this has been lost in context, the `MAX_L1_GAS_PRICE_VALE` is being used as a min value in practice as  it is the argument of a `max` call. This would make sense in principle to ensure a non 0 gas price, but we would need to investigate further if this is actually needed.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Change the `MAX` semantics to `MIN` for the l1 gas price.
