### PR TITLE
feat: Paymaster support in Forge create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5011,6 +5011,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tracy",
  "yansi 1.0.1",
+ "zksync-web3-rs",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,7 @@ foundry-config.workspace = true
 foundry-debugger.workspace = true
 foundry-evm.workspace = true
 foundry-wallets.workspace = true
+zksync-web3-rs.workspace = true
 
 foundry-compilers = { workspace = true, features = ["full"] }
 

--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use foundry_config::ZkSyncConfig;
 use serde::Serialize;
+use zksync_web3_rs::types::{Address, Bytes};
 
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 #[clap(next_help_heading = "ZKSync configuration")]
@@ -104,6 +105,22 @@ pub struct ZkSyncArgs {
     /// Contracts to avoid compiling on zkSync
     #[clap(long = "zk-avoid-contracts", visible_alias = "avoid-contracts", value_delimiter = ',')]
     pub avoid_contracts: Option<Vec<String>>,
+
+    /// Paymaster address
+    #[clap(
+        long = "zk-paymaster-address",
+        value_name = "PAYMASTER_ADDRESS",
+        visible_alias = "paymaster-address"
+    )]
+    pub paymaster_address: Option<Address>,
+
+    /// Paymaster input
+    #[clap(
+        long = "zk-paymaster-input",
+        value_name = "PAYMASTER_INPUT",
+        visible_alias = "paymaster-input"
+    )]
+    pub paymaster_input: Option<Bytes>,
 }
 
 impl ZkSyncArgs {

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -110,6 +110,7 @@ pub async fn new_eip712_transaction<
 >(
     tx: WithOtherFields<TransactionRequest>,
     factory_deps: Vec<Vec<u8>>,
+    paymaster_data: Option<PaymasterParams>,
     provider: P,
     signer: S,
 ) -> Result<Bytes> {
@@ -126,7 +127,10 @@ pub async fn new_eip712_transaction<
     let gas_price = tx.gas_price.ok_or_eyre("`gas_price` cannot be empty")?;
 
     let data = tx.input.clone().into_input().unwrap_or_default();
-    let custom_data = Eip712Meta::new().factory_deps(factory_deps);
+    let mut custom_data = Eip712Meta::new().factory_deps(factory_deps);
+    if let Some(params) = paymaster_data {
+        custom_data = custom_data.paymaster_params(params);
+    }
 
     let mut deploy_request = Eip712TransactionRequest::new()
         .r#type(EIP712_TX_TYPE)


### PR DESCRIPTION
## Motivation
Forge create didn't support the use of paymaster parameters to be able to use this zksync specific feature to deploy a contract. 

## Solution
Introduce the ability to pass the paymaster address and input data in Forge create command

`zkforge create ./src/Counter.sol:Counter --rpc-url "https://sepolia.era.zksync.dev/" --private-key {PK} --zksync --zk-paymaster-address 0x3cB2b87D10Ac01736A65688F3e0Fb1b070B3eeA3 --zk-paymaster-input $(zkcast calldata "approvalBased(address,uint256,bytes)" 0x31c43ac5e6A0fe62954B9056441b0A214722516e 1000000000000000000 "0x")`
https://sepolia.explorer.zksync.io/tx/0xe57788a909df8bb4aae2265558ece52acd082328a46568d0d627db264d1ba039