### PR TITLE
feat: adds support for forge clean to remove zkout directory 

### DIFF
--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -83,7 +83,10 @@ fn main() -> Result<()> {
         ForgeSubcommand::Clean { root } => {
             let config = utils::load_config_with_root(root.as_deref());
             let project = config.project()?;
+            let zk_project =
+                foundry_zksync_compiler::config_create_project(&config, config.cache, false)?;
             config.cleanup(&project)?;
+            config.cleanup(&zk_project)?;
             Ok(())
         }
         ForgeSubcommand::Snapshot(cmd) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- Tired of manually deleting `zkout/` directory and cache 
- Adds support for running `forge clean` to zksync context
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- Add zk_project.cleanup cmd to `forge clean` 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
