### PR TITLE
fix: sanitize input based on solc version

### DIFF
--- a/crates/verify/src/zksync/standard_json.rs
+++ b/crates/verify/src/zksync/standard_json.rs
@@ -11,11 +11,14 @@ impl ZksyncSourceProvider for ZksyncStandardJsonSource {
         &self,
         context: &ZkVerificationContext,
     ) -> Result<(StandardJsonCompilerInput, String)> {
-        let input = foundry_compilers::zksync::project_standard_json_input(
+        let mut input = foundry_compilers::zksync::project_standard_json_input(
             &context.project,
             &context.target_path,
         )
         .wrap_err("failed to get zksolc standard json")?;
+
+        // Sanitize the input
+        input.settings = input.settings.clone().sanitized(&context.compiler_version.solc);
 
         let relative_path = context
             .target_path


### PR DESCRIPTION
# What :computer: 
* Sanitizes settings based on solc version prior to verification request

# Why :hand:
* Verification was failing for some solc versions due to evm_version always being `Cancun` 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->