### PR TITLE
feat: support suppressed warnings/errors for zksolc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.11.4"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#7d2dc971a21db4e188fd42d086ad0daea2dc7ae9"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#8f1613ec0f386f025012dc8ec89037eea7a37b43"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5141,7 +5141,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.11.4"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#7d2dc971a21db4e188fd42d086ad0daea2dc7ae9"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#8f1613ec0f386f025012dc8ec89037eea7a37b43"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.11.4"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#7d2dc971a21db4e188fd42d086ad0daea2dc7ae9"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#8f1613ec0f386f025012dc8ec89037eea7a37b43"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5174,7 +5174,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.11.4"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#7d2dc971a21db4e188fd42d086ad0daea2dc7ae9"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#8f1613ec0f386f025012dc8ec89037eea7a37b43"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-zksolc"
 version = "0.11.4"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#7d2dc971a21db4e188fd42d086ad0daea2dc7ae9"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#8f1613ec0f386f025012dc8ec89037eea7a37b43"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5209,7 +5209,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.11.4"
-source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#7d2dc971a21db4e188fd42d086ad0daea2dc7ae9"
+source = "git+https://github.com/Moonsong-Labs/compilers?branch=zksync-v0.11.4#8f1613ec0f386f025012dc8ec89037eea7a37b43"
 dependencies = [
  "alloy-primitives",
  "cfg-if 1.0.0",

--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use clap::Parser;
+use foundry_compilers::zksolc::settings::{ZkSolcError, ZkSolcWarning};
 use foundry_config::ZkSyncConfig;
 use serde::Serialize;
 use zksync_web3_rs::types::{Address, Bytes};
@@ -102,6 +103,14 @@ pub struct ZkSyncArgs {
     #[clap(long = "zk-optimizer")]
     pub optimizer: bool,
 
+    /// zksolc suppressed warnings
+    #[clap(long = "zk-suppressed-warnings")]
+    pub suppressed_warnings: Option<Vec<ZkSolcWarning>>,
+
+    /// zksolc suppressed errors
+    #[clap(long = "zk-suppressed-errors")]
+    pub suppressed_errors: Option<Vec<ZkSolcError>>,
+
     /// Contracts to avoid compiling on zkSync
     #[clap(long = "zk-avoid-contracts", visible_alias = "avoid-contracts", value_delimiter = ',')]
     pub avoid_contracts: Option<Vec<String>>,
@@ -153,6 +162,10 @@ impl ZkSyncArgs {
         set_if_some!(self.avoid_contracts.clone(), zksync.avoid_contracts);
 
         set_if_some!(self.optimizer.then_some(true), zksync.optimizer);
+        let maybe_suppressed_warnings = self.suppressed_warnings.clone().map(HashSet::from_iter);
+        set_if_some!(maybe_suppressed_warnings, zksync.suppressed_warnings);
+        let maybe_suppressed_errors = self.suppressed_errors.clone().map(HashSet::from_iter);
+        set_if_some!(maybe_suppressed_errors, zksync.suppressed_errors);
         set_if_some!(
             self.optimizer_mode.as_ref().and_then(|mode| mode.parse::<char>().ok()),
             zksync.optimizer_mode

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -6,14 +6,15 @@ use foundry_compilers::{
     solc::CliSettings,
     zksolc::{
         settings::{
-            BytecodeHash, Codegen, Optimizer, OptimizerDetails, SettingsMetadata, ZkSolcSettings,
+            BytecodeHash, Codegen, Optimizer, OptimizerDetails, SettingsMetadata, ZkSolcError,
+            ZkSolcSettings, ZkSolcWarning,
         },
         ZkSettings,
     },
 };
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use crate::SolcReq;
 
@@ -59,8 +60,14 @@ pub struct ZkSyncConfig {
     /// The optimization mode string for zkSync
     pub optimizer_mode: char,
 
-    /// zkSolc optimizer details
+    /// zksolc optimizer details
     pub optimizer_details: Option<OptimizerDetails>,
+
+    /// zksolc suppressed errors
+    pub suppressed_warnings: HashSet<ZkSolcWarning>,
+
+    /// zksolc suppressed warnings
+    pub suppressed_errors: HashSet<ZkSolcError>,
 }
 
 impl Default for ZkSyncConfig {
@@ -80,6 +87,8 @@ impl Default for ZkSyncConfig {
             optimizer: true,
             optimizer_mode: '3',
             optimizer_details: Default::default(),
+            suppressed_warnings: Default::default(),
+            suppressed_errors: Default::default(),
         }
     }
 }
@@ -130,6 +139,8 @@ impl ZkSyncConfig {
                 },
             },
             codegen: if self.force_evmla { Codegen::EVMLA } else { Codegen::Yul },
+            suppressed_warnings: self.suppressed_warnings.clone(),
+            suppressed_errors: self.suppressed_errors.clone(),
         };
 
         // `cli_settings` get set from `Project` values when building `ZkSolcVersionedInput`


### PR DESCRIPTION
# What :computer: 
Add support for zksolc's suppressed error/warnings arguments

# Why :hand:
Closes https://github.com/matter-labs/foundry-zksync/issues/633

# Evidence :camera:
warnings/errors get suppressed when either adding `suppressed_errors`/`suppressed_warnings` under `zksync` table in `Cargo.toml` or using `--zk-suppressed-errors`/`--zk-suppressed-warnings` cli options
 

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->

DRAFT: Needs (https://github.com/Moonsong-Labs/compilers/pull/37)