### PR TITLE
fix: Add gas limit estimation using paymaster balance when in use

### DIFF
--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -272,16 +272,15 @@ where
     let use_paymaster = !paymaster_params.paymaster.is_zero();
 
     // Get balance of either paymaster or caller depending on who's paying
-    let balance = if use_paymaster {
-        let paymaster_addr = Address::from_slice(paymaster_params.paymaster.as_bytes());
-        ZKVMData::new(ecx).get_balance(paymaster_addr)
+    let address = if use_paymaster {
+        Address::from_slice(paymaster_params.paymaster.as_bytes())
     } else {
-        ZKVMData::new(ecx).get_balance(caller)
+        caller
     };
+    let balance = ZKVMData::new(ecx).get_balance(address);
 
     if balance.is_zero() {
-        let address = if use_paymaster { paymaster_params.paymaster } else { caller.to_h160() };
-        error!("balance is 0 for {}, transaction will fail", address);
+        error!("balance is 0 for {}, transaction will fail", address.to_h160());
     }
 
     let max_fee_per_gas = fix_l2_gas_price(ecx.env.tx.gas_price.to_u256());


### PR DESCRIPTION
# What :computer: 
* Use paymaster balance to estimate gas limit instead of hardcoding the max gas limit value

# Why :hand:
* Gas limit value maxed out leads to a gas estimation from the paymaster side to be extremely high.
