### PR TITLE
fix: add verbosity for verification compilation error

### DIFF
--- a/crates/verify/src/zksync/mod.rs
+++ b/crates/verify/src/zksync/mod.rs
@@ -120,9 +120,7 @@ impl VerificationProvider for ZkVerificationProvider {
         let verification_status =
             self.retry_verification_status(&client, &url, max_retries, delay_in_seconds).await?;
 
-        self.process_status_response(Some(verification_status), &url)?;
-
-        Ok(())
+        self.process_status_response(Some(verification_status), &url)
     }
 }
 


### PR DESCRIPTION
# What :computer: 
* Outputs more details on compiler related errors during verification

# Why :hand:
* Previously users only saw "Verification error: Compilation error`" which was not that helpful in understanding the issue
* Now:

```
Verification failed:

Error:
Compilation error

Error Details:
- Invalid EVM version requested.

View verification response:
https://explorer.sepolia.era.zksync.dev/contract_verification/31422
```

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->