### PR TITLE
fix: Ignore nonce update of initiator address on script setup

### DIFF
--- a/crates/forge/tests/fixtures/zk/ScriptSetup.s.sol
+++ b/crates/forge/tests/fixtures/zk/ScriptSetup.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+import {Greeter} from "../src/Greeter.sol";
+
+contract ScriptSetupNonce is Script {
+    address alice;
+
+    function setUp() public {
+        // Perform transactions and deploy contracts in setup to increment nonce and verify broadcast nonce matches onchain
+        new Greeter();
+        new Greeter();
+        alice = makeAddr("alice");
+        (bool success,) = address(alice).call{value: 1 ether}("");
+        require(success, "Failed to send ether");
+    }
+
+    function run() public {
+        vm.startBroadcast();
+        Greeter greeter = new Greeter();
+        greeter.greeting("john");
+        assert(address(alice).balance == 1 ether);
+        vm.stopBroadcast();
+    }
+}

--- a/crates/forge/tests/it/zk/mod.rs
+++ b/crates/forge/tests/it/zk/mod.rs
@@ -16,4 +16,5 @@ mod ownership;
 mod paymaster;
 mod proxy;
 mod repros;
+mod setup_script;
 mod traces;

--- a/crates/forge/tests/it/zk/setup_script.rs
+++ b/crates/forge/tests/it/zk/setup_script.rs
@@ -1,0 +1,23 @@
+use foundry_test_utils::{forgetest_async, util, TestProject};
+
+use crate::test_helpers::run_zk_script_test;
+
+forgetest_async!(setup_block_on_script_test, |prj, cmd| {
+    setup_deploy_prj(&mut prj);
+    run_zk_script_test(
+        prj.root(),
+        &mut cmd,
+        "./script/ScriptSetup.s.sol",
+        "ScriptSetupNonce",
+        None,
+        2,
+        Some(&["-vvvvv"]),
+    );
+});
+
+fn setup_deploy_prj(prj: &mut TestProject) {
+    util::initialize(prj.root());
+    prj.add_script("ScriptSetup.s.sol", include_str!("../../fixtures/zk/ScriptSetup.s.sol"))
+        .unwrap();
+    prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
+}


### PR DESCRIPTION
# What :computer: 
* Nonce was being updated in the script setup. Now we avoid this

# Why :hand:
* Scripts with this use case were failing because the on-chain nonce was different
