### PR TITLE
fix: allow immutable variables to be merged during forks

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1244,6 +1244,21 @@ impl Cheatcodes {
                     }
                 }
 
+                // record immutable variables
+                if result.execution_result.is_success() {
+                    for (addr, imm_values) in result.recorded_immutables {
+                        let addr = addr.to_address();
+                        let keys = imm_values
+                            .into_keys()
+                            .map(|slot_index| {
+                                foundry_zksync_core::get_immutable_slot_key(addr, slot_index)
+                                    .to_ru256()
+                            })
+                            .collect::<HashSet<_>>();
+                        ecx.db.save_zk_immutable_storage(addr, keys);
+                    }
+                }
+
                 match result.execution_result {
                     ExecutionResult::Success { output, gas_used, .. } => {
                         let _ = gas.record_cost(gas_used);

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -21,7 +21,10 @@ use revm::{
     },
     Database, DatabaseCommit, JournaledState,
 };
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashSet},
+};
 
 /// A wrapper around `Backend` that ensures only `revm::DatabaseRef` functions are called.
 ///
@@ -131,6 +134,10 @@ impl<'a> CowBackend<'a> {
 impl DatabaseExt for CowBackend<'_> {
     fn get_fork_info(&mut self, id: LocalForkId) -> eyre::Result<ForkInfo> {
         self.backend.to_mut().get_fork_info(id)
+    }
+
+    fn save_zk_immutable_storage(&mut self, addr: Address, keys: HashSet<U256>) {
+        self.backend.to_mut().save_zk_immutable_storage(addr, keys)
     }
 
     fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &Env) -> U256 {

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -15,9 +15,8 @@ use eyre::Context;
 use foundry_common::{is_known_system_sender, SYSTEM_TRANSACTION_TYPE};
 pub use foundry_fork_db::{cache::BlockchainDbMeta, BlockchainDb, SharedBackend};
 use foundry_zksync_core::{
-    convert::{ConvertH160, ConvertRU256},
-    ACCOUNT_CODE_STORAGE_ADDRESS, IMMUTABLE_SIMULATOR_STORAGE_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS,
-    L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
+    convert::ConvertH160, ACCOUNT_CODE_STORAGE_ADDRESS, IMMUTABLE_SIMULATOR_STORAGE_ADDRESS,
+    KNOWN_CODES_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
 };
 use itertools::Itertools;
 use revm::{

--- a/crates/forge/tests/it/zk/fork.rs
+++ b/crates/forge/tests/it/zk/fork.rs
@@ -12,3 +12,11 @@ async fn test_zk_setup_fork_failure() {
 
     TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zk_immutable_vars_persist_after_fork() {
+    let runner = TEST_DATA_DEFAULT.runner_zksync();
+    let filter = Filter::new(".*", "ZkForkImmutableVarsTest", ".*");
+
+    TestConfig::with_filter(runner, filter).evm_spec(SpecId::SHANGHAI).run().await;
+}

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -37,13 +37,12 @@ pub use vm::{balance, encode_create_params, nonce};
 
 pub use vm::{SELECTOR_CONTRACT_DEPLOYER_CREATE, SELECTOR_CONTRACT_DEPLOYER_CREATE2};
 pub use zksync_multivm::interface::{Call, CallType};
-use zksync_types::utils::storage_key_for_eth_balance;
-use zksync_types::U256;
 pub use zksync_types::{
     ethabi, ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H256,
     IMMUTABLE_SIMULATOR_STORAGE_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS,
     NONCE_HOLDER_ADDRESS,
 };
+use zksync_types::{utils::storage_key_for_eth_balance, U256};
 pub use zksync_utils::bytecode::hash_bytecode;
 use zksync_web3_rs::{
     eip712::{Eip712Meta, Eip712Transaction, Eip712TransactionRequest, PaymasterParams},
@@ -306,7 +305,9 @@ pub fn try_decode_create(data: &[u8]) -> Result<(H256, Vec<u8>)> {
     Ok((H256(bytecode_hash.0), constructor_args.to_vec()))
 }
 
-/// Gets the mapping key for the `ImmutableSimulator::immutableDataStorage` for a given address and slot.
+/// Gets the mapping key for the `ImmutableSimulator::immutableDataStorage` for a given contract
+/// address and variable slot.
+/// See https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/ImmutableSimulator.sol#L21
 pub fn get_immutable_slot_key(address: Address, slot_index: rU256) -> H256 {
     let immutable_data_storage_key = keccak256(ethabi::encode(&[
         ethabi::Token::Address(address.to_h160()),
@@ -322,8 +323,6 @@ pub fn get_immutable_slot_key(address: Address, slot_index: rU256) -> H256 {
     H256(*immutable_value_key)
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -332,8 +331,13 @@ mod tests {
 
     #[test]
     fn test_get_immutable_slot_key() {
-        let actual_key = get_immutable_slot_key(address!("f9e9ba9ed9b96ab918c74b21dd0f1d5f2ac38a30"), rU256::from(10u32));
-        let expected_key = H256::from_str("db259b642223206a098c9ffaaf8e4bfd2d60060e8365bb349b2ea2b720d9837c").expect("invalid h256");
+        let actual_key = get_immutable_slot_key(
+            address!("f9e9ba9ed9b96ab918c74b21dd0f1d5f2ac38a30"),
+            rU256::from(10u32),
+        );
+        let expected_key =
+            H256::from_str("db259b642223206a098c9ffaaf8e4bfd2d60060e8365bb349b2ea2b720d9837c")
+                .expect("invalid h256");
         assert_eq!(expected_key, actual_key)
     }
 }

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -305,8 +305,9 @@ pub fn try_decode_create(data: &[u8]) -> Result<(H256, Vec<u8>)> {
     Ok((H256(bytecode_hash.0), constructor_args.to_vec()))
 }
 
-/// Gets the mapping key for the `ImmutableSimulator::immutableDataStorage` for a given contract
-/// address and variable slot.
+/// Gets the mapping key for the `ImmutableSimulator::immutableDataStorage`.
+///
+/// This retrieves the key for a given contract address and variable slot.
 /// See https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/ImmutableSimulator.sol#L21
 pub fn get_immutable_slot_key(address: Address, slot_index: rU256) -> H256 {
     let immutable_data_storage_key = keccak256(ethabi::encode(&[

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{hex, Log};
+use alloy_primitives::{hex, FixedBytes, Log};
 use era_test_node::{
     config::node::ShowCalls,
     formatter,
@@ -68,6 +68,8 @@ pub struct ZKVMExecutionResult {
     pub execution_result: rExecutionResult,
     /// Call traces
     pub call_traces: Vec<Call>,
+    /// Immutables recorded via calls to ImmutableSimulator::setImmutables.
+    pub recorded_immutables: rHashMap<H160, rHashMap<rU256, FixedBytes<32>>>,
 }
 
 /// Revm-style result with ZKVM Execution
@@ -112,6 +114,7 @@ where
                     logs: result.logs,
                     call_traces: result.call_traces,
                     execution_result: exec,
+                    recorded_immutables: result.recorded_immutables,
                 });
             }
             (None, exec) => {
@@ -119,6 +122,7 @@ where
                     logs: result.logs,
                     call_traces: result.call_traces,
                     execution_result: exec,
+                    recorded_immutables: result.recorded_immutables,
                 });
             }
             (
@@ -133,11 +137,13 @@ where
                             logs: agg_logs,
                             output: agg_output,
                         },
+                    recorded_immutables: aggregated_recorded_immutables,
                 }),
                 rExecutionResult::Success { reason, gas_used, gas_refunded, logs, output },
             ) => {
                 aggregated_logs.append(&mut result.logs);
                 aggregated_call_traces.append(&mut result.call_traces);
+                aggregated_recorded_immutables.extend(result.recorded_immutables);
                 *agg_reason = reason;
                 *agg_gas_used += gas_used;
                 *agg_gas_refunded += gas_refunded;
@@ -199,6 +205,7 @@ where
         bytecodes,
         modified_storage,
         call_traces,
+        recorded_immutables,
         create_outcome,
         gas_usage,
     } = inspect_inner(tx, storage_ptr, chain_id, ccx, call_ctx);
@@ -270,6 +277,7 @@ where
                     logs,
                     output,
                 },
+                recorded_immutables,
             }
         }
         ExecutionResult::Revert { output } => {
@@ -286,6 +294,7 @@ where
                     gas_used: gas_usage.gas_used(),
                     output: Bytes::from(output),
                 },
+                recorded_immutables,
             }
         }
         ExecutionResult::Halt { reason } => {
@@ -302,6 +311,7 @@ where
                     reason: mapped_reason,
                     gas_used: gas_usage.gas_used(),
                 },
+                recorded_immutables,
             }
         }
     };
@@ -410,6 +420,7 @@ struct InnerZkVmResult {
     call_traces: Vec<Call>,
     create_outcome: Option<InnerCreateOutcome>,
     gas_usage: ZkVmGasUsage,
+    recorded_immutables: rHashMap<H160, rHashMap<rU256, FixedBytes<32>>>,
 }
 
 fn inspect_inner<S: ReadStorage>(
@@ -478,6 +489,7 @@ fn inspect_inner<S: ReadStorage>(
     if let Some(expected_calls) = ccx.expected_calls.as_mut() {
         expected_calls.extend(cheatcode_result.expected_calls);
     }
+    let recorded_immutables = cheatcode_result.recorded_immutables;
 
     // populate gas usage info
     let bootloader_debug = Arc::try_unwrap(bootloader_debug_tracer_result)
@@ -548,11 +560,7 @@ fn inspect_inner<S: ReadStorage>(
                 .expect("failed converting bytecode to factory dep")
         })
         .collect::<HashMap<U256, Vec<U256>>>();
-    let modified_storage = if is_static {
-        Default::default()
-    } else {
-        storage.borrow().modified_storage_keys().clone()
-    };
+    let modified_storage = storage.borrow().modified_storage_keys().clone();
 
     // patch CREATE traces.
     for call in call_traces.iter_mut() {
@@ -589,13 +597,26 @@ fn inspect_inner<S: ReadStorage>(
         None
     };
 
-    InnerZkVmResult {
-        tx_result,
-        bytecodes,
-        modified_storage,
-        call_traces,
-        create_outcome,
-        gas_usage,
+    if is_static {
+        InnerZkVmResult {
+            tx_result,
+            bytecodes: Default::default(),
+            modified_storage: Default::default(),
+            call_traces,
+            create_outcome,
+            gas_usage,
+            recorded_immutables: Default::default(),
+        }
+    } else {
+        InnerZkVmResult {
+            tx_result,
+            bytecodes,
+            modified_storage,
+            call_traces,
+            create_outcome,
+            gas_usage,
+            recorded_immutables,
+        }
     }
 }
 

--- a/crates/zksync/core/src/vm/tracers/cheatcode.rs
+++ b/crates/zksync/core/src/vm/tracers/cheatcode.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use alloy_primitives::{hex, map::HashMap, Address, Bytes, U256 as rU256};
+use alloy_primitives::{hex, map::HashMap, Address, Bytes, FixedBytes, U256 as rU256};
 use foundry_cheatcodes_common::{
     expect::ExpectedCallTracker,
     mock::{MockCallDataContext, MockCallReturnData},
@@ -21,8 +21,8 @@ use zksync_multivm::{
 };
 use zksync_state::interface::{ReadStorage, StoragePtr, WriteStorage};
 use zksync_types::{
-    get_code_key, StorageValue, BOOTLOADER_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H256,
-    SYSTEM_CONTEXT_ADDRESS, U256,
+    ethabi, get_code_key, StorageValue, BOOTLOADER_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, H160, H256,
+    IMMUTABLE_SIMULATOR_STORAGE_ADDRESS, SYSTEM_CONTEXT_ADDRESS, U256,
 };
 use zksync_utils::bytecode::hash_bytecode;
 
@@ -70,6 +70,13 @@ const SELECTOR_BASE_FEE: [u8; 4] = hex!("6ef25c3a");
 /// Selector for `getBlockHashEVM(uint256)`
 const SELECTOR_BLOCK_HASH: [u8; 4] = hex!("80b41246");
 
+/// Selector for setting immutables for an address.
+/// This is used to retrieve the immutables and use them in merging storage
+/// during forks.
+///
+/// Selector for `setImmutables(address, (uint256,bytes32)[])",
+const SELECTOR_IMMUTABLE_SIMULATOR_SET: [u8; 4] = hex!("ad7e232e");
+
 /// Represents the context for [CheatcodeContext]
 #[derive(Debug, Default)]
 pub struct CheatcodeTracerContext<'a> {
@@ -88,7 +95,10 @@ pub struct CheatcodeTracerContext<'a> {
 /// Tracer result to return back to foundry.
 #[derive(Debug, Default)]
 pub struct CheatcodeTracerResult {
+    /// Recorded expected calls.
     pub expected_calls: ExpectedCallTracker,
+    /// Immutables recorded via calls to ImmutableSimulator::setImmutables.
+    pub recorded_immutables: HashMap<H160, HashMap<rU256, FixedBytes<32>>>,
 }
 
 /// Defines the context for a Vm call.
@@ -115,7 +125,7 @@ pub struct CallContext {
     pub is_static: bool,
     /// L1 block hashes to return when `BLOCKHASH` opcode is encountered. This ensures consistency
     /// when returning environment data in L2.
-    pub block_hashes: HashMap<alloy_primitives::U256, alloy_primitives::FixedBytes<32>>,
+    pub block_hashes: HashMap<rU256, FixedBytes<32>>,
 }
 
 /// A tracer to allow for foundry-specific functionality.
@@ -131,6 +141,8 @@ pub struct CheatcodeTracer {
     pub result: Arc<OnceCell<CheatcodeTracerResult>>,
     /// Handle farcall state.
     farcall_handler: FarCallHandler,
+    /// Immutables recorded via calls to ImmutableSimulator::setImmutables.
+    recorded_immutables: HashMap<H160, HashMap<rU256, FixedBytes<32>>>,
 }
 
 impl CheatcodeTracer {
@@ -360,6 +372,60 @@ impl<S: ReadStorage, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for Cheatcode
             }
         }
 
+        // record immutables for an address during creates
+        if self.call_context.is_create {
+            if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
+                let calldata = get_calldata(&state, memory);
+                let current = state.vm_local_state.callstack.current;
+
+                if current.code_address == IMMUTABLE_SIMULATOR_STORAGE_ADDRESS {
+                    if calldata.starts_with(&SELECTOR_IMMUTABLE_SIMULATOR_SET) {
+                        let mut params = ethabi::decode(
+                            &[
+                                ethabi::ParamType::Address,
+                                ethabi::ParamType::Array(Box::new(ethabi::ParamType::Tuple(vec![
+                                    ethabi::ParamType::Uint(256),
+                                    ethabi::ParamType::FixedBytes(32),
+                                ]))),
+                            ],
+                            &calldata[4..],
+                        )
+                        .expect("failed decoding setImmutables parameters");
+
+                        let address =
+                            params.remove(0).into_address().expect("must be valid address");
+                        let immutables =
+                            params.remove(0).into_array().expect("must be valid array");
+                        for immutable in immutables {
+                            let mut imm_tuple =
+                                immutable.into_tuple().expect("must be valid tuple");
+                            let imm_index = imm_tuple
+                                .remove(0)
+                                .into_uint()
+                                .expect("must be valid uint")
+                                .to_ru256();
+                            let imm_value = imm_tuple
+                                .remove(0)
+                                .into_fixed_bytes()
+                                .expect("must be valid fixed bytes");
+                            let imm_value = FixedBytes::<32>::from_slice(&imm_value);
+
+                            self.recorded_immutables
+                                .entry(address)
+                                .and_modify(|entry| {
+                                    entry.insert(imm_index, imm_value);
+                                })
+                                .or_insert_with(|| {
+                                    let mut value = HashMap::default();
+                                    value.insert(imm_index, imm_value);
+                                    value
+                                });
+                        }
+                    }
+                }
+            }
+        }
+
         if let Some(delegate_as) = self.call_context.delegate_as {
             if let Opcode::FarCall(_call) = data.opcode.variant.opcode {
                 let current = state.vm_local_state.callstack.current;
@@ -404,7 +470,11 @@ impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for CheatcodeTracer {
         _stop_reason: zksync_multivm::interface::tracer::VmExecutionStopReason,
     ) {
         let cell = self.result.as_ref();
-        cell.set(CheatcodeTracerResult { expected_calls: self.expected_calls.clone() }).unwrap();
+        cell.set(CheatcodeTracerResult {
+            expected_calls: self.expected_calls.clone(),
+            recorded_immutables: self.recorded_immutables.clone(),
+        })
+        .unwrap();
     }
 }
 

--- a/testdata/zk/ForkImmutableVars.sol
+++ b/testdata/zk/ForkImmutableVars.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+import {Globals} from "./Globals.sol";
+
+
+contract Counter {
+    uint256 public immutable SOME_IMMUTABLE_VARIABLE;
+
+    constructor(uint256 value) {
+        SOME_IMMUTABLE_VARIABLE = value;
+    }
+
+    uint256 public a;
+    function set(uint256 _a) public {
+        a = _a;
+    }
+
+    function get() public view returns (uint) {
+        return a;
+    }
+}
+
+contract ZkForkImmutableVarsTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    uint256 constant ERA_FORK_BLOCK = 19579636;
+    uint256 constant IMMUTABLE_VAR_VALUE = 0xdeadbeef;
+
+    function setUp() public {
+        vm.createSelectFork(Globals.ZKSYNC_MAINNET_URL, ERA_FORK_BLOCK);
+    }
+
+    function testZkImmutableVariablesPersistedAfterFork() public {
+        Counter counter = new Counter(IMMUTABLE_VAR_VALUE);
+        assertEq(IMMUTABLE_VAR_VALUE, counter.SOME_IMMUTABLE_VARIABLE());
+
+        vm.makePersistent(address(counter));
+        assertTrue(vm.isPersistent(address(counter)));
+
+        vm.createSelectFork(Globals.ZKSYNC_MAINNET_URL, ERA_FORK_BLOCK - 100);
+
+        assertEq(IMMUTABLE_VAR_VALUE, counter.SOME_IMMUTABLE_VARIABLE());
+    }
+}

--- a/testdata/zk/ForkImmutableVars.sol
+++ b/testdata/zk/ForkImmutableVars.sol
@@ -5,7 +5,6 @@ import "ds-test/test.sol";
 import "../cheats/Vm.sol";
 import {Globals} from "./Globals.sol";
 
-
 contract Counter {
     uint256 public immutable SOME_IMMUTABLE_VARIABLE;
 
@@ -14,11 +13,12 @@ contract Counter {
     }
 
     uint256 public a;
+
     function set(uint256 _a) public {
         a = _a;
     }
 
-    function get() public view returns (uint) {
+    function get() public view returns (uint256) {
         return a;
     }
 }


### PR DESCRIPTION
# What :computer: 
* Migrate immutable variables set during create, during forks.

# Why :hand:
* Previously we were not importing any immutable variables.

# Evidence :camera:
![image](https://github.com/user-attachments/assets/c3cd09ae-0d63-4252-a961-9ade55cbfbde)


<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
* Immutable storage values are stored via mapping key per contract address and per contract-slot, so it's not possible to obtain or even iterate over the entire `2^256` space in a realistic time. So we recode the `setImmutables()` call and track all immutables set so far per contract address. As any address can be marked persistent at any given moment we currently track all immutables.