### PR TITLE
fix(deny): instant and derivative are unmaintained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,11 @@ ignore = [
     # Used by alloy
     # proc-macro-error is unmaintained
     "RUSTSEC-2024-0370",
+    # instant is unmaintained
+    "RUSTSEC-2024-0384",
+    # Used by boojum
+    # derivative is unmaintained
+    "RUSTSEC-2024-0388",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
# What :computer: 
* Add 2 advisories to the list of ignored advisories

# Why :hand:
* Since these were added recently and are transitive dependencies
