### PR TITLE
fix(zk): delay startup migration

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1462,14 +1462,13 @@ where {
             };
             let prev = account.info.nonce;
             account.info.nonce = prev.saturating_sub(1);
-            let nonce = account.info.nonce;
+
+            trace!(target: "cheatcodes", %sender, nonce=account.info.nonce, prev, "corrected nonce");
 
             if self.startup_zk {
                 self.startup_zk = false; // We only do this once.
                 self.select_zk_vm(ecx_inner, None);
             }
-
-            trace!(target: "cheatcodes", %sender, nonce, prev, "corrected nonce");
         }
 
         if call.target_address == CHEATCODE_ADDRESS {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1458,8 +1458,14 @@ where {
             };
             let prev = account.info.nonce;
             account.info.nonce = prev.saturating_sub(1);
+            let nonce = account.info.nonce;
 
-            trace!(target: "cheatcodes", %sender, nonce=account.info.nonce, prev, "corrected nonce");
+            if self.startup_zk {
+                self.startup_zk = false; // We only do this once.
+                self.select_zk_vm(ecx_inner, None);
+            }
+
+            trace!(target: "cheatcodes", %sender, nonce, prev, "corrected nonce");
         }
 
         if call.target_address == CHEATCODE_ADDRESS {
@@ -1957,11 +1963,6 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
         }
         if let Some(gas_price) = self.gas_price.take() {
             ecx.env.tx.gas_price = gas_price;
-        }
-
-        if self.startup_zk && !self.use_zk_vm {
-            self.startup_zk = false; // We only do this once.
-            self.select_zk_vm(ecx, None);
         }
 
         // Record gas for current frame.

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -871,6 +871,8 @@ impl Cheatcodes {
         let mut known_codes_storage: rHashMap<U256, EvmStorageSlot> = Default::default();
         let mut deployed_codes: HashMap<Address, AccountInfo> = Default::default();
 
+        let test_contract = data.db.get_test_contract_address();
+
         for address in data.db.persistent_accounts().into_iter().chain([data.env.tx.caller]) {
             info!(?address, "importing to zk state");
 
@@ -885,6 +887,12 @@ impl Cheatcodes {
 
             let nonce_key = get_nonce_key(address);
             nonce_storage.insert(nonce_key, EvmStorageSlot::new(full_nonce.to_ru256()));
+
+            if test_contract.map(|test_address| address == test_address).unwrap_or_default() {
+                // avoid migrating test contract code
+                tracing::trace!(?address, "ignoring code translation for test contract");
+                continue;
+            }
 
             if let Some(contract) = self.dual_compiled_contracts.iter().find(|contract| {
                 info.code_hash != KECCAK_EMPTY && info.code_hash == contract.evm_bytecode_hash
@@ -936,17 +944,13 @@ impl Cheatcodes {
             journaled_account(data, known_codes_addr).expect("failed to load account");
         known_codes_account.storage.extend(known_codes_storage.clone());
 
-        let test_contract = data.db.get_test_contract_address();
         for (address, info) in deployed_codes {
             let account = journaled_account(data, address).expect("failed to load account");
             let _ = std::mem::replace(&mut account.info.balance, info.balance);
             let _ = std::mem::replace(&mut account.info.nonce, info.nonce);
-            if test_contract.map(|addr| addr == address).unwrap_or_default() {
-                tracing::trace!(?address, "ignoring code translation for test contract");
-            } else {
-                account.info.code_hash = info.code_hash;
-                account.info.code.clone_from(&info.code);
-            }
+
+            account.info.code_hash = info.code_hash;
+            account.info.code.clone_from(&info.code);
         }
     }
 


### PR DESCRIPTION
# What :computer: 
* Move startup migration from `initialize_interp` to `call_with_executor`
* Ignore test contract migration entirely

# Why :hand:
* `initialize_interp` is run at different parts of the program execution depending on the usage, therefore some state would not be properly be observed during the migration. By moving the migration to happen in the test/script execution, we now migrate as late as possible where the pre-execution state is fully initialized
* As part of the delay introduced, the test/script contract would be detected in the codes to migrate, this is undesirable as the test/script contract is not meant to be execute in EraVM