### PR TITLE
chore: perform startup zkEVM storage migration just before test contract execution

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -978,7 +978,6 @@ impl Cheatcodes {
             journaled_account(data, known_codes_addr).expect("failed to load account");
         known_codes_account.storage.extend(known_codes_storage.clone());
 
-        let test_contract = data.db.get_test_contract_address();
         for (address, info) in deployed_codes {
             let account = journaled_account(data, address).expect("failed to load account");
             let _ = std::mem::replace(&mut account.info.balance, info.balance);

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -660,7 +660,7 @@ impl Cheatcodes {
         let mut persisted_factory_deps = HashMap::new();
         persisted_factory_deps.insert(zk_bytecode_hash, zk_deployed_bytecode);
 
-        let zk_startup_migration = config.use_zk.then(|| ZkStartupMigration::Defer);
+        let zk_startup_migration = config.use_zk.then_some(ZkStartupMigration::Defer);
 
         Self {
             fs_commit: true,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -410,8 +410,8 @@ impl ArbitraryStorage {
 /// List of transactions that can be broadcasted.
 pub type BroadcastableTransactions = VecDeque<BroadcastableTransaction>;
 
-/// Setting for migrating the database to zkEVM storage. The migration is performed on the DB via
-/// the inspector so must only be performed once.
+/// Setting for migrating the database to zkEVM storage when starting in ZKsync mode.
+/// The migration is performed on the DB via the inspector so must only be performed once.
 #[derive(Debug, Default, Clone)]
 pub enum ZkStartupMigration {
     /// Defer database migration to a later execution point.
@@ -427,8 +427,8 @@ pub enum ZkStartupMigration {
 }
 
 impl ZkStartupMigration {
-    /// Check if startup migration is allowed. Migration is not allowed, if marked to be skipped or
-    /// has already been performed.
+    /// Check if startup migration is allowed. Migration is disallowed if it's to be defered or has
+    /// already been performed.
     pub fn is_allowed(&self) -> bool {
         matches!(self, Self::Allow)
     }
@@ -438,7 +438,7 @@ impl ZkStartupMigration {
         *self = Self::Allow
     }
 
-    /// Mark the migration as finished.
+    /// Mark the migration as completed. It must not be performed again.
     pub fn done(&mut self) {
         *self = Self::Done
     }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -427,7 +427,7 @@ pub enum ZkStartupMigration {
 }
 
 impl ZkStartupMigration {
-    /// Check if startup migration is allowed. Migration is disallowed if it's to be defered or has
+    /// Check if startup migration is allowed. Migration is disallowed if it's to be deferred or has
     /// already been performed.
     pub fn is_allowed(&self) -> bool {
         matches!(self, Self::Allow)

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -427,7 +427,7 @@ impl ZkStartupMigration {
     /// Check if startup migration is allowed. Migration is not allowed, if marked to be skipped or
     /// has already been performed.
     pub fn is_allowed(&self) -> bool {
-        matches!(self, ZkStartupMigration::Allow)
+        matches!(self, Self::Allow)
     }
 
     /// Allow migrating the the DB to zkEVM storage.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -146,11 +146,9 @@ impl ContractRunner<'_> {
 
         // Test contract has already been deployed so we can migrate the database to zkEVM storage
         // in the next runner execution.
-        if self.executor.use_zk {
-            if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
-                debug!("test contract deployed, allowing startup storage migration");
-                cheatcodes.zk_startup_migration.allow();
-            }
+        if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
+            debug!("test contract deployed, allowing startup storage migration");
+            cheatcodes.zk_startup_migration.allow();
         }
 
         // Optionally call the `setUp` function

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -144,6 +144,15 @@ impl ContractRunner<'_> {
 
         self.executor.deploy_create2_deployer()?;
 
+        // Test contract has already been deployed so we can migrate the database to zkEVM storage
+        // in the next runner execution.
+        if self.executor.use_zk {
+            if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
+                debug!("test contract deployed, allowing startup storage migration");
+                cheatcodes.zk_startup_migration.allow();
+            }
+        }
+
         // Optionally call the `setUp` function
         let result = if call_setup {
             trace!("calling setUp");

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -147,8 +147,10 @@ impl ContractRunner<'_> {
         // Test contract has already been deployed so we can migrate the database to zkEVM storage
         // in the next runner execution.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
-            debug!("test contract deployed, allowing startup storage migration");
-            cheatcodes.zk_startup_migration.allow();
+            if let Some(zk_startup_migration) = &mut cheatcodes.zk_startup_migration {
+                debug!("test contract deployed, allowing startup storage migration");
+                zk_startup_migration.allow();
+            }
         }
 
         // Optionally call the `setUp` function

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -166,8 +166,10 @@ impl ScriptRunner {
         // Script has already been deployed so we can migrate the database to zkEVM storage
         // in the next runner execution.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
-            debug!("script deployed, allowing startup storage migration");
-            cheatcodes.zk_startup_migration.allow();
+            if let Some(zk_startup_migration) = &mut cheatcodes.zk_startup_migration {
+                debug!("script deployed, allowing startup storage migration");
+                zk_startup_migration.allow();
+            }
         }
 
         // Optionally call the `setUp` function

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -163,6 +163,13 @@ impl ScriptRunner {
 
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)));
 
+        // Script has already been deployed so we can migrate the database to zkEVM storage
+        // in the next runner execution.
+        if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
+            debug!("script deployed, allowing startup storage migration");
+            cheatcodes.zk_startup_migration.allow();
+        }
+
         // Optionally call the `setUp` function
         let (success, gas_used, labeled_addresses, transactions) = if !setup {
             (true, 0, Default::default(), Some(library_transactions))


### PR DESCRIPTION
# What :computer: 
* Perform startup storage migration in zksync mode after test contract deployment and just before test contract execution. This allows migrating any storage changes like nonce/balance that are performed before test execution.
* Removes the `startup_zk` in favor of a more granular migration point.

# Why :hand:
* As per #731 we have certain scenarios where it's required that the test contract already be deployed for the sound functioning of our tests and scripts.
* `startup_zk` was introduced as a quick and dirty solution.

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->