### PR TITLE
fix: enable persistence only once per test contract deployment

### DIFF
--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -428,9 +428,6 @@ impl Executor {
     #[instrument(name = "call", level = "debug", skip_all)]
     pub fn call_with_env(&self, mut env: EnvWithHandlerCfg) -> eyre::Result<RawCallResult> {
         let mut inspector = self.inspector().clone();
-        if let Some(cheatcodes) = inspector.cheatcodes.as_mut() {
-            cheatcodes.zk_persist_nonce_update.persist_next();
-        }
         let mut backend = CowBackend::new_borrowed(self.backend());
         let result = match &self.zk_tx {
             None => backend.inspect(&mut env, &mut inspector)?,
@@ -453,9 +450,6 @@ impl Executor {
     #[instrument(name = "transact", level = "debug", skip_all)]
     pub fn transact_with_env(&mut self, mut env: EnvWithHandlerCfg) -> eyre::Result<RawCallResult> {
         let mut inspector = self.inspector.clone();
-        if let Some(cheatcodes) = inspector.cheatcodes.as_mut() {
-            cheatcodes.zk_persist_nonce_update.persist_next();
-        }
         let backend = &mut self.backend;
         let result_and_state = match self.zk_tx.take() {
             None => backend.inspect(&mut env, &mut inspector)?,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -148,12 +148,16 @@ impl ContractRunner<'_> {
         self.executor.deploy_create2_deployer()?;
 
         // Test contract has already been deployed so we can migrate the database to zkEVM storage
-        // in the next runner execution.
+        // in the next runner execution. Additionally we can allow persisting the next nonce update
+        // to simulate EVM behavior where only the test contract deployment increments the
+        // nonce.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
             if let Some(zk_startup_migration) = &mut cheatcodes.zk_startup_migration {
                 debug!("test contract deployed, allowing startup storage migration");
                 zk_startup_migration.allow();
             }
+            debug!("test contract deployed, allowing persisting next nonce update");
+            cheatcodes.zk_persist_nonce_update.persist_next();
         }
 
         // Optionally call the `setUp` function

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -171,12 +171,16 @@ impl ScriptRunner {
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)));
 
         // Script has already been deployed so we can migrate the database to zkEVM storage
-        // in the next runner execution.
+        // in the next runner execution. Additionally we can allow persisting the next nonce update
+        // to simulate EVM behavior where only the test contract deployment increments the
+        // nonce.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
             if let Some(zk_startup_migration) = &mut cheatcodes.zk_startup_migration {
                 debug!("script deployed, allowing startup storage migration");
                 zk_startup_migration.allow();
             }
+            debug!("script deployed, allowing persisting next nonce update");
+            cheatcodes.zk_persist_nonce_update.persist_next();
         }
 
         // Optionally call the `setUp` function


### PR DESCRIPTION
# What :computer: 
* enable persistence only once per test contract deployment

# Why :hand:
* If done in executor, the test function invocation would enable the nonce update persistence once again once setUp is performed.


<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->