### PR TITLE
fix: fix foundry-zksync-install CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,6 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: Install foundry-zksync
-          run: cp ./install-foundry-zksync /tmp/ && cd /tmp && ./install-foundry-zksync
+          run: ./install-foundry-zksync
         - name: Verify installation
           run: forge --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,6 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: Install foundry-zksync
-          run: |
-            cd /tmp && curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
+          run: cp ./install-foundry-zksync /tmp/ && cd /tmp && ./install-foundry-zksync
         - name: Verify installation
           run: forge --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,6 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: Install foundry-zksync
-          run: ./install-foundry-zksync
+          run: cp ./install-foundry-zksync ./foundryup-zksync/* /tmp/ && cd /tmp && ./install-foundry-zksync
         - name: Verify installation
           run: forge --version

--- a/install-foundry-zksync
+++ b/install-foundry-zksync
@@ -6,9 +6,13 @@ set -e
 INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/foundryup-zksync/install"
 FOUNDRYUP_ZKSYNC_URL="https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/foundryup-zksync/foundryup-zksync"
 
-# Download the install script
-echo "Downloading the install script..."
-curl -L "$INSTALL_SCRIPT_URL" -o install
+if [ -n "${CI}" ]; then
+    echo "Using local install script..."
+else
+    # Download the install script
+    echo "Downloading the install script..."
+    curl -L "$INSTALL_SCRIPT_URL" -o install
+fi
 
 echo "Making install script executable..."
 chmod +x ./install
@@ -36,8 +40,12 @@ else
     echo "No shell configuration file detected. Please source your shell manually or start a new terminal session."
 fi
 
-echo "Downloading foundryup-zksync..."
-curl -L "$FOUNDRYUP_ZKSYNC_URL" -o foundryup-zksync
+if [ -n "${CI}" ]; then
+    echo "Using local foundryup-zksync script..."
+else
+    echo "Downloading foundryup-zksync..."
+    curl -L "$FOUNDRYUP_ZKSYNC_URL" -o foundryup-zksync
+fi
 
 echo "Making foundryup-zksync executable..."
 chmod +x ./foundryup-zksync

--- a/install-foundry-zksync
+++ b/install-foundry-zksync
@@ -19,11 +19,11 @@ echo "Running the installation script..."
 # Extract the exact path from the install.log
 # Use sed to precisely capture the path after 'source' and before the next apostrophe
 SHELL_CONFIG_FILE=$(sed -n "s/.*Run 'source \(.*\)'.*/\1/p" install.log)
+FOUNDRY_BIN_DIR="${XDG_CONFIG_HOME:-$HOME}/.foundry/bin"
 
 if [ -n "$SHELL_CONFIG_FILE" ]; then
     if [ -n "${CI}" ]; then
         # Add manually to $PATH in CI mode as GHA does not work with `.`
-        FOUNDRY_BIN_DIR="${XDG_CONFIG_HOME:-$HOME}/.foundry/bin"
         echo "adding '${FOUNDRY_BIN_DIR}' to PATH and GITHUB_PATH"
         export PATH="$PATH:$FOUNDRY_BIN_DIR"
         echo "${FOUNDRY_BIN_DIR}" >> $GITHUB_PATH
@@ -54,7 +54,7 @@ echo "Cleanup completed."
 echo "Installation completed successfully!"
 
 echo "Verifying installation..."
-if "$HOME/.foundry/bin/forge" --version | grep -q "0.0.2"; then
+if "${FOUNDRY_BIN_DIR}/forge" --version | grep -q "0.0.2"; then
     echo "Forge version 0.0.2 is successfully installed."
 else
     echo "Installation verification failed. Forge is not properly installed."


### PR DESCRIPTION
# What :computer: 
* Fixes CI to use current copies of install scripts for running the GHA test, in CI mode.
* Download remote scripts if not in CI mode.

# Why :hand:
* Fails on https://github.com/matter-labs/foundry-zksync/actions/runs/11930290475/job/33250797676?pr=608 due to https://github.com/matter-labs/foundry-zksync/pull/733 as the test was being run for `main` branch.

