### PR TITLE
fix: insert transaction type into EIP-712 transactions

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -43,10 +43,8 @@ use std::{
     collections::{HashSet, VecDeque},
     marker::PhantomData,
     path::PathBuf,
-    str::FromStr,
     sync::Arc,
 };
-use zksync_types::H256;
 
 merge_impl_figment_convert!(CreateArgs, opts, eth);
 
@@ -156,7 +154,7 @@ impl CreateArgs {
 
             let artifact = remove_zk_contract(&mut zk_output, &target_path, &self.contract.name)?;
 
-            let ZkContractArtifact { bytecode, hash, factory_dependencies, abi, .. } = artifact;
+            let ZkContractArtifact { bytecode, factory_dependencies, abi, .. } = artifact;
 
             let abi = abi.expect("Abi not found");
             let bin = bytecode.expect("Bytecode not found");

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -180,7 +180,6 @@ impl CreateArgs {
                     eyre::bail!("Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time\n{}", link_refs)
                 }
             };
-            let bytecode_hash = H256::from_str(&hash.expect("Contract hash not found"))?;
 
             // Add arguments to constructor
             let config = self.eth.try_load_config_emit_warnings()?;
@@ -659,8 +658,6 @@ impl CreateArgs {
 
             self.verify_preflight_check(constructor_args.clone(), chain).await?;
         }
-
-        println!("{:?}", deployer.tx);
 
         // Deploy the actual contract
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -16,7 +16,7 @@ use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
 use alloy_transport::Transport;
 use alloy_zksync::network::{
-    transaction_request::TransactionRequest as ZkTransactionRequest, Zksync,
+    transaction_request::TransactionRequest as ZkTransactionRequest, tx_type::TxType, Zksync,
 };
 use eyre::{bail, Context, Result};
 use forge_verify::provider::VerificationProviderType;
@@ -119,7 +119,9 @@ pub async fn send_transaction(
             debug!("sending transaction: {:?}", tx);
 
             if let Some(zk) = zk {
-                let mut zk_tx: ZkTransactionRequest = tx.inner.clone().into();
+                let mut inner = tx.inner.clone();
+                inner.transaction_type = Some(TxType::Eip712 as u8);
+                let mut zk_tx: ZkTransactionRequest = inner.into();
                 if !zk.factory_deps.is_empty() {
                     zk_tx.set_factory_deps(zk.factory_deps.iter().map(Bytes::from_iter).collect());
                 }


### PR DESCRIPTION
# What :computer: 

Insert transaction type into EIP-712 transactions.

# Why :hand:

Transactions for create are failing with rpc errors due to missing transaction type. We stopped inserting the value on: https://github.com/matter-labs/foundry-zksync/pull/608

Closes https://github.com/matter-labs/foundry-zksync/issues/738

# Evidence :camera:

Deployment on sepolia via create/script (previously failing) succeeds


<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->

TODO: Era test node latest release does not fail with the missing type, we need to see how we can add a test for this.