### PR TITLE
fix: Encode correctly paymaster input

### DIFF
--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, path::PathBuf};
 
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{hex, Address, Bytes};
 use clap::Parser;
 use foundry_compilers::zksolc::settings::{ZkSolcError, ZkSolcWarning};
 use foundry_config::ZkSyncConfig;
@@ -115,7 +115,8 @@ pub struct ZkSyncArgs {
     #[clap(
         long = "zk-paymaster-input",
         value_name = "PAYMASTER_INPUT",
-        visible_alias = "paymaster-input"
+        visible_alias = "paymaster-input",
+        value_parser = parse_hex_bytes
     )]
     pub paymaster_input: Option<Bytes>,
 
@@ -184,4 +185,8 @@ impl ZkSyncArgs {
 
         zksync
     }
+}
+
+fn parse_hex_bytes(s: &str) -> Result<Bytes, String> {
+    hex::decode(s).map(Bytes::from).map_err(|e| format!("Invalid hex string: {e}"))
 }

--- a/crates/forge/tests/it/zk/paymaster.rs
+++ b/crates/forge/tests/it/zk/paymaster.rs
@@ -37,7 +37,7 @@ async fn test_zk_contract_paymaster() {
 }
 
 // Tests the deployment of contracts using a paymaster for fee abstraction
-forgetest_async!(deploy_with_paymaster, |prj, cmd| {
+forgetest_async!(test_zk_deploy_with_paymaster, |prj, cmd| {
     setup_deploy_prj(&mut prj);
     let node = ZkSyncNode::start();
     let url = node.url();

--- a/crates/forge/tests/it/zk/paymaster.rs
+++ b/crates/forge/tests/it/zk/paymaster.rs
@@ -3,7 +3,7 @@
 use foundry_test_utils::{
     forgetest_async,
     util::{self, OutputExt},
-    TestProject,
+    TestProject, ZkSyncNode,
 };
 
 use crate::test_helpers::run_zk_script_test;
@@ -35,6 +35,95 @@ async fn test_zk_contract_paymaster() {
     cmd.args(["test", "--zk-startup", "--via-ir", "--match-contract", "TestPaymasterFlow"]);
     assert!(cmd.assert_success().get_output().stdout_lossy().contains("Suite result: ok"));
 }
+
+// Tests the deployment of contracts using a paymaster for fee abstraction
+forgetest_async!(deploy_with_paymaster, |prj, cmd| {
+    setup_deploy_prj(&mut prj);
+    let node = ZkSyncNode::start();
+    let url = node.url();
+
+    let private_key =
+        ZkSyncNode::rich_wallets().next().map(|(_, pk, _)| pk).expect("No rich wallets available");
+
+    // Install required dependencies
+    cmd.args([
+        "install",
+        "OpenZeppelin/openzeppelin-contracts",
+        "cyfrin/zksync-contracts",
+        "--no-commit",
+        "--shallow",
+    ])
+    .assert_success();
+    cmd.forge_fuse();
+
+    // Deploy the paymaster contract first
+    let paymaster_deployment = cmd
+        .forge_fuse()
+        .args([
+            "create",
+            "./src/MyPaymaster.sol:MyPaymaster",
+            "--rpc-url",
+            url.as_str(),
+            "--private-key",
+            private_key,
+            "--via-ir",
+            "--value",
+            "1000000000000000000",
+            "--zksync",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    // Extract the deployed paymaster address
+    let re = regex::Regex::new(r"Deployed to: (0x[a-fA-F0-9]{40})").unwrap();
+    let paymaster_address = re
+        .captures(&paymaster_deployment)
+        .and_then(|caps| caps.get(1))
+        .map(|addr| addr.as_str())
+        .expect("Failed to extract paymaster address");
+
+    // Test successful deployment with valid paymaster input
+    let greeter_deployment = cmd.forge_fuse()
+        .args([
+            "create",
+            "./src/Greeter.sol:Greeter",
+            "--rpc-url",
+            url.as_str(),
+            "--private-key",
+            private_key,
+            "--zk-paymaster-address",
+            paymaster_address,
+            "--zk-paymaster-input",
+            "0x8c5a344500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
+            "--via-ir",
+            "--zksync"
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    // Verify successful deployment
+    assert!(greeter_deployment.contains("Deployed to:"));
+
+    // Test deployment failure with invalid paymaster input
+    cmd.forge_fuse()
+        .args([
+            "create",
+            "./src/Greeter.sol:Greeter",
+            "--rpc-url",
+            url.as_str(),
+            "--private-key",
+            private_key,
+            "--zk-paymaster-address",
+            paymaster_address,
+            "--zk-paymaster-input",
+            "0x0000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
+            "--via-ir",
+            "--zksync"
+        ])
+        .assert_failure();
+});
 
 forgetest_async!(paymaster_script_test, |prj, cmd| {
     setup_deploy_prj(&mut prj);


### PR DESCRIPTION
# What :computer: 
* With the removal of zksync-web3-rs crate the way clap was treating the incoming paymaster input was leading to an error encoding the bytes. 
