### PR TITLE
fix: Display name of zksync verifier

### DIFF
--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -166,7 +166,7 @@ pub enum VerificationProviderType {
     Sourcify,
     Blockscout,
     Oklink,
-    #[value(alias = "zksync")]
+    #[clap(name = "zksync")]
     ZKsync,
 }
 


### PR DESCRIPTION
# What :computer: 
* Fix way zksync verifier was being displayed in --help cmd

# Why :hand:
* It was being wrongly displayed like the following example
```
Verifier options:
      --verifier <VERIFIER>
          The contract verification provider to use

          [default: etherscan]
          [possible values: etherscan, sourcify, blockscout, oklink, z-ksync]
```