### PR TITLE
ci: automate stable releases with release-plz

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -1,0 +1,15 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  release:
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-plz.yaml@v1
+    secrets:
+      gh_token: ${{ secrets.RELEASE_TOKEN }}
+      cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }}
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*-zksync.*"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+dependencies_update = true                   # Whether to run `cargo update` in the release PR
+pr_name = "release: zksync-foundry {{version}}" # template for the PR name
+pr_labels = ["release", "automated"]         # Set PR labels
+changelog_update = false                     # Disable individual changelog updates for all packages.
+git_tag_enable = false                       # Disable individual tags for all packages.
+git_release_enable = false                   # Disable individual releases for all packages.
+semver_check = true                          # Enable API breaking changes checks with cargo-semver-checks.
+
+# Use one main package for a common tag for all workspace crates
+[[package]]
+name = "forge"
+git_tag_enable = true                              # Enable one common tag for all crates
+git_tag_name = "v{{version}}"                      # Tag name

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 dependencies_update = true                   # Whether to run `cargo update` in the release PR
-pr_name = "release: zksync-foundry {{version}}" # template for the PR name
+pr_name = "release: foundry-zksync {{version}}" # template for the PR name
 pr_labels = ["release", "automated"]         # Set PR labels
 changelog_update = false                     # Disable individual changelog updates for all packages.
 git_tag_enable = false                       # Disable individual tags for all packages.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,14 +1,15 @@
 [workspace]
-dependencies_update = true                   # Whether to run `cargo update` in the release PR
+publish = false                                 # Do not publish to crates.io for now
+dependencies_update = true                      # Whether to run `cargo update` in the release PR
 pr_name = "release: foundry-zksync {{version}}" # template for the PR name
-pr_labels = ["release", "automated"]         # Set PR labels
-changelog_update = false                     # Disable individual changelog updates for all packages.
-git_tag_enable = false                       # Disable individual tags for all packages.
-git_release_enable = false                   # Disable individual releases for all packages.
-semver_check = false                          # Enable API breaking changes checks with cargo-semver-checks.
+pr_labels = ["release", "automated"]            # Set PR labels
+changelog_update = false                        # Disable individual changelog updates for all packages.
+git_tag_enable = false                          # Disable individual tags for all packages.
+git_release_enable = false                      # Disable individual releases for all packages.
+semver_check = false                            # Enable API breaking changes checks with cargo-semver-checks.
 
 # Use one main package for a common tag for all workspace crates
 [[package]]
 name = "forge"
-git_tag_enable = true                              # Enable one common tag for all crates
-git_tag_name = "0.2.0-zksync.{{version}}"                      # Tag name
+git_tag_enable = true                     # Enable one common tag for all crates
+git_tag_name = "0.2.0-zksync.{{version}}" # Tag name

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,10 +5,10 @@ pr_labels = ["release", "automated"]         # Set PR labels
 changelog_update = false                     # Disable individual changelog updates for all packages.
 git_tag_enable = false                       # Disable individual tags for all packages.
 git_release_enable = false                   # Disable individual releases for all packages.
-semver_check = true                          # Enable API breaking changes checks with cargo-semver-checks.
+semver_check = false                          # Enable API breaking changes checks with cargo-semver-checks.
 
 # Use one main package for a common tag for all workspace crates
 [[package]]
 name = "forge"
 git_tag_enable = true                              # Enable one common tag for all crates
-git_tag_name = "v{{version}}"                      # Tag name
+git_tag_name = "0.2.0-zksync.{{version}}"                      # Tag name


### PR DESCRIPTION
# What :computer: 

* Automate stable releases with release-plz

When a new commit is merged to `main` branch, a special `release-plz` workflow will be started that will do two things:
1. If new change is merged - create or update a release PR for the next release with the new info from this commit identifying new semantic version, updating `Cargo.toml`.
2. If this PR is merged, then new tag `v*.*.*` will be created that will initiate a new `zksync-foundry` release workflow that will create a new version release.

> Changelog updates by `release-plz` as well as GitHub releases generated by this tool, and release of crates to `crates.io` are switched off for now (until requested) because ZKsync foundry is using its own changelog and release flow with binaries in `release.yaml` workflow.

# Why :hand:

Fixes https://github.com/matter-labs/foundry-zksync/issues/750