### PR TITLE
fix: use dedicated gas limit for each tx in inspect_batch

### DIFF
--- a/crates/forge/tests/it/zk/factory_deps.rs
+++ b/crates/forge/tests/it/zk/factory_deps.rs
@@ -10,7 +10,6 @@ use foundry_test_utils::{
 use crate::{config::TestConfig, test_helpers::TEST_DATA_DEFAULT};
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "disabled since #476"]
 async fn test_zk_can_deploy_large_factory_deps() {
     let runner = TEST_DATA_DEFAULT.runner_zksync();
     {
@@ -19,20 +18,17 @@ async fn test_zk_can_deploy_large_factory_deps() {
     }
 }
 
-forgetest_async!(
-    #[ignore = "disabled since #476"]
-    script_zk_can_deploy_large_factory_deps,
-    |prj, cmd| {
-        util::initialize(prj.root());
+forgetest_async!(script_zk_can_deploy_large_factory_deps, |prj, cmd| {
+    util::initialize(prj.root());
 
-        prj.add_source(
-            "LargeContracts.sol",
-            include_str!("../../../../../testdata/zk/LargeContracts.sol"),
-        )
-        .unwrap();
-        prj.add_script(
-            "LargeContracts.s.sol",
-            r#"
+    prj.add_source(
+        "LargeContracts.sol",
+        include_str!("../../../../../testdata/zk/LargeContracts.sol"),
+    )
+    .unwrap();
+    prj.add_script(
+        "LargeContracts.s.sol",
+        r#"
 import "forge-std/Script.sol";
 import "../src/LargeContracts.sol";
 
@@ -43,39 +39,42 @@ contract ZkLargeFactoryDependenciesScript is Script {
     }
 }
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let node = ZkSyncNode::start();
+    let node = ZkSyncNode::start();
 
-        cmd.arg("script").args([
-            "--zk-startup",
-            "./script/LargeContracts.s.sol",
-            "--broadcast",
-            "--private-key",
-            "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e",
-            "--chain",
-            "260",
-            "--gas-estimate-multiplier",
-            "310",
-            "--rpc-url",
-            node.url().as_str(),
-            "--slow",
-            "--evm-version",
-            "shanghai",
-        ]);
-        cmd.assert_success()
-            .get_output()
-            .stdout_lossy()
-            .contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL");
+    // foundry default gas-limit is not enough to pay for factory deps in our current
+    // default environment
+    let gas_limit = u32::MAX >> 1;
 
-        let run_latest = foundry_common::fs::json_files(prj.root().join("broadcast").as_path())
-            .find(|file| file.ends_with("run-latest.json"))
-            .expect("No broadcast artifacts");
+    cmd.arg("script").args([
+        "--zk-startup",
+        "./script/LargeContracts.s.sol",
+        "--broadcast",
+        "--private-key",
+        "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e",
+        "--chain",
+        "260",
+        "--gas-estimate-multiplier",
+        "310",
+        "--rpc-url",
+        node.url().as_str(),
+        "--slow",
+        "--gas-limit",
+        &gas_limit.to_string(),
+    ]);
+    cmd.assert_success()
+        .get_output()
+        .stdout_lossy()
+        .contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL");
 
-        let content = foundry_common::fs::read_to_string(run_latest).unwrap();
+    let run_latest = foundry_common::fs::json_files(prj.root().join("broadcast").as_path())
+        .find(|file| file.ends_with("run-latest.json"))
+        .expect("No broadcast artifacts");
 
-        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
-        assert_eq!(json["transactions"].as_array().expect("broadcastable txs").len(), 1);
-    }
-);
+    let content = foundry_common::fs::read_to_string(run_latest).unwrap();
+
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(json["transactions"].as_array().expect("broadcastable txs").len(), 3);
+});

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -27,8 +27,8 @@ use zksync_multivm::{
 };
 use zksync_state::interface::{ReadStorage, StoragePtr, WriteStorage};
 use zksync_types::{
-    get_nonce_key, l2::L2Tx, PackedEthSignature, StorageKey, Transaction,
-    ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, NONCE_HOLDER_ADDRESS,
+    get_nonce_key, l2::L2Tx, transaction_request::PaymasterParams, PackedEthSignature, StorageKey,
+    Transaction, ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, NONCE_HOLDER_ADDRESS,
 };
 use zksync_utils::{be_words_to_bytes, h256_to_account_address, h256_to_u256, u256_to_h256};
 
@@ -39,8 +39,8 @@ use std::{
 };
 
 use crate::{
-    convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertU256},
-    is_system_address,
+    convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
+    fix_l2_gas_limit, fix_l2_gas_price, is_system_address,
     vm::{
         db::{ZKVMData, DEFAULT_CHAIN_ID},
         env::{create_l1_batch_env, create_system_env},
@@ -96,14 +96,14 @@ where
     let mut aggregated_result: Option<ZKVMExecutionResult> = None;
 
     for (idx, mut tx) in txns.into_iter().enumerate() {
-        let gas_used = aggregated_result
-            .as_ref()
-            .map(|r| r.execution_result.gas_used())
-            .map(U256::from)
-            .unwrap_or_default();
-
-        //deducted gas used so far
-        tx.common_data.fee.gas_limit -= gas_used;
+        // cap gas limit so that we do not set a number greater than
+        // remaining sender balance
+        let (new_gas_limit, _) = gas_params(
+            ecx,
+            tx.common_data.initiator_address.to_address(),
+            &tx.common_data.paymaster_params,
+        );
+        tx.common_data.fee.gas_limit = new_gas_limit;
 
         info!("executing batched tx ({}/{})", idx + 1, total_txns);
         let mut result = inspect(tx, ecx, ccx, call_ctx.clone())?;
@@ -392,6 +392,37 @@ where
     }
 
     Ok(execution_result)
+}
+
+/// Assign gas parameters that satisfy zkSync's fee model.
+pub fn gas_params<DB>(
+    ecx: &mut EvmContext<DB>,
+    caller: Address,
+    paymaster_params: &PaymasterParams,
+) -> (U256, U256)
+where
+    DB: Database,
+    <DB as Database>::Error: Debug,
+{
+    let value = ecx.env.tx.value.to_u256();
+    let use_paymaster = !paymaster_params.paymaster.is_zero();
+
+    // Get balance of either paymaster or caller depending on who's paying
+    let address = if use_paymaster {
+        Address::from_slice(paymaster_params.paymaster.as_bytes())
+    } else {
+        caller
+    };
+    let balance = ZKVMData::new(ecx).get_balance(address);
+
+    if balance.is_zero() {
+        error!("balance is 0 for {}, transaction will fail", address.to_h160());
+    }
+
+    let max_fee_per_gas = fix_l2_gas_price(ecx.env.tx.gas_price.to_u256());
+
+    let gas_limit = fix_l2_gas_limit(ecx.env.tx.gas_limit.into(), max_fee_per_gas, value, balance);
+    (gas_limit, max_fee_per_gas)
 }
 
 #[allow(dead_code)]
@@ -732,15 +763,7 @@ where
 /// Maximum size allowed for factory_deps during create.
 /// We batch factory_deps till this upper limit if there are multiple deps.
 /// These batches are then deployed individually.
-///
-/// TODO: This feature is disabled by default via `usize::MAX` due to inconsistencies
-/// with determining a value that works in all cases.
-static MAX_FACTORY_DEPENDENCIES_SIZE_BYTES: LazyLock<usize> = LazyLock::new(|| {
-    std::env::var("MAX_FACTORY_DEPENDENCIES_SIZE_BYTES")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(usize::MAX)
-});
+const MAX_FACTORY_DEPENDENCIES_SIZE_BYTES: usize = 100_000;
 
 /// Batch factory deps on the basis of size.
 ///
@@ -751,7 +774,7 @@ pub fn batch_factory_dependencies(mut factory_deps: Vec<Vec<u8>>) -> Vec<Vec<Vec
     let factory_deps_count = factory_deps.len();
     let factory_deps_sizes = factory_deps.iter().map(|dep| dep.len()).collect_vec();
     let factory_deps_total_size = factory_deps_sizes.iter().sum::<usize>();
-    tracing::debug!(count=factory_deps_count, total=factory_deps_total_size, sizes=?factory_deps_sizes, max=*MAX_FACTORY_DEPENDENCIES_SIZE_BYTES, "optimizing factory_deps");
+    tracing::debug!(count=factory_deps_count, total=factory_deps_total_size, sizes=?factory_deps_sizes, max=MAX_FACTORY_DEPENDENCIES_SIZE_BYTES, "optimizing factory_deps");
 
     let mut batches = vec![];
     let mut current_batch = vec![];
@@ -762,7 +785,7 @@ pub fn batch_factory_dependencies(mut factory_deps: Vec<Vec<u8>>) -> Vec<Vec<Vec
     for dep in factory_deps {
         let len = dep.len();
         let new_len = current_batch_len + len;
-        if new_len > *MAX_FACTORY_DEPENDENCIES_SIZE_BYTES && !current_batch.is_empty() {
+        if new_len > MAX_FACTORY_DEPENDENCIES_SIZE_BYTES && !current_batch.is_empty() {
             batches.push(current_batch);
             current_batch = vec![];
             current_batch_len = 0;

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -32,11 +32,7 @@ use zksync_types::{
 };
 use zksync_utils::{be_words_to_bytes, h256_to_account_address, h256_to_u256, u256_to_h256};
 
-use std::{
-    collections::HashMap,
-    fmt::Debug,
-    sync::{Arc, LazyLock},
-};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use crate::{
     convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -32,7 +32,11 @@ use zksync_types::{
 };
 use zksync_utils::{be_words_to_bytes, h256_to_account_address, h256_to_u256, u256_to_h256};
 
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{Arc, LazyLock},
+};
 
 use crate::{
     convert::{ConvertAddress, ConvertH160, ConvertH256, ConvertRU256, ConvertU256},
@@ -756,10 +760,15 @@ where
         .unwrap_or_default()
 }
 
-/// Default maximum size allowed for factory_deps during create.
+/// Maximum size allowed for factory_deps during create.
 /// We batch factory_deps till this upper limit if there are multiple deps.
 /// These batches are then deployed individually.
-const DEFAULT_MAX_FACTORY_DEPENDENCIES_SIZE_BYTES: usize = 100_000;
+static MAX_FACTORY_DEPENDENCIES_SIZE_BYTES: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("MAX_FACTORY_DEPENDENCIES_SIZE_BYTES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(100_000)
+});
 
 /// Batch factory deps on the basis of size.
 ///
@@ -767,14 +776,10 @@ const DEFAULT_MAX_FACTORY_DEPENDENCIES_SIZE_BYTES: usize = 100_000;
 /// on the basis of the max factory dependencies size and deploy all but the last batch
 /// via empty transactions, with the last one deployed normally via create.
 pub fn batch_factory_dependencies(mut factory_deps: Vec<Vec<u8>>) -> Vec<Vec<Vec<u8>>> {
-    let max_factory_deps_size_bytes = std::env::var("MAX_FACTORY_DEPENDENCIES_SIZE_BYTES")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_MAX_FACTORY_DEPENDENCIES_SIZE_BYTES);
     let factory_deps_count = factory_deps.len();
     let factory_deps_sizes = factory_deps.iter().map(|dep| dep.len()).collect_vec();
     let factory_deps_total_size = factory_deps_sizes.iter().sum::<usize>();
-    tracing::debug!(count=factory_deps_count, total=factory_deps_total_size, sizes=?factory_deps_sizes, max=max_factory_deps_size_bytes, "optimizing factory_deps");
+    tracing::debug!(count=factory_deps_count, total=factory_deps_total_size, sizes=?factory_deps_sizes, max=*MAX_FACTORY_DEPENDENCIES_SIZE_BYTES, "optimizing factory_deps");
 
     let mut batches = vec![];
     let mut current_batch = vec![];
@@ -785,7 +790,7 @@ pub fn batch_factory_dependencies(mut factory_deps: Vec<Vec<u8>>) -> Vec<Vec<Vec
     for dep in factory_deps {
         let len = dep.len();
         let new_len = current_batch_len + len;
-        if new_len > max_factory_deps_size_bytes && !current_batch.is_empty() {
+        if new_len > *MAX_FACTORY_DEPENDENCIES_SIZE_BYTES && !current_batch.is_empty() {
             batches.push(current_batch);
             current_batch = vec![];
             current_batch_len = 0;

--- a/crates/zksync/core/src/vm/runner.rs
+++ b/crates/zksync/core/src/vm/runner.rs
@@ -5,7 +5,7 @@ use revm::{
     primitives::{Address, CreateScheme, Env, ResultAndState, TransactTo, B256, U256 as rU256},
     Database, EvmContext, InnerEvmContext,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 use zksync_basic_types::H256;
 use zksync_types::{
     ethabi, fee::Fee, l2::L2Tx, transaction_request::PaymasterParams, CONTRACT_DEPLOYER_ADDRESS,
@@ -16,10 +16,9 @@ use std::{cmp::min, fmt::Debug};
 
 use crate::{
     convert::{ConvertAddress, ConvertH160, ConvertRU256, ConvertU256},
-    fix_l2_gas_limit, fix_l2_gas_price,
     vm::{
         db::ZKVMData,
-        inspect::{inspect, inspect_as_batch, ZKVMExecutionResult, ZKVMResult},
+        inspect::{gas_params, inspect, inspect_as_batch, ZKVMExecutionResult, ZKVMResult},
         tracers::cheatcode::{CallContext, CheatcodeTracerContext},
     },
 };
@@ -268,37 +267,6 @@ where
     };
 
     inspect(tx, ecx, &mut ccx, call_ctx)
-}
-
-/// Assign gas parameters that satisfy zkSync's fee model.
-fn gas_params<DB>(
-    ecx: &mut EvmContext<DB>,
-    caller: Address,
-    paymaster_params: &PaymasterParams,
-) -> (U256, U256)
-where
-    DB: Database,
-    <DB as Database>::Error: Debug,
-{
-    let value = ecx.env.tx.value.to_u256();
-    let use_paymaster = !paymaster_params.paymaster.is_zero();
-
-    // Get balance of either paymaster or caller depending on who's paying
-    let address = if use_paymaster {
-        Address::from_slice(paymaster_params.paymaster.as_bytes())
-    } else {
-        caller
-    };
-    let balance = ZKVMData::new(ecx).get_balance(address);
-
-    if balance.is_zero() {
-        error!("balance is 0 for {}, transaction will fail", address.to_h160());
-    }
-
-    let max_fee_per_gas = fix_l2_gas_price(ecx.env.tx.gas_price.to_u256());
-
-    let gas_limit = fix_l2_gas_limit(ecx.env.tx.gas_limit.into(), max_fee_per_gas, value, balance);
-    (gas_limit, max_fee_per_gas)
 }
 
 /// Prepares calldata to invoke deployer contract.


### PR DESCRIPTION
# What :computer: 
Use dedicated gas limit for each tx in inspect_batch.

# Why :hand:
After marking factory dependencies and obtaining the amount of pubdata to be published to the L1, the bootloader [checks](https://github.com/matter-labs/era-contracts/blob/aafee035db892689df3f7afe4b89fd6467a39313/system-contracts/bootloader/bootloader.yul#L1586) If there will be enough gas to pay for it. If there's not, it will `nearCallPanic()`.
This combined with a very big `gasPerPubdata` default and the fact that we shared the gas limit among all batches made the script run revert on cases with large factory deps. We need to use a full gas-limit for each tx on the batch.

Closes https://github.com/matter-labs/foundry-zksync/issues/650

# Evidence :camera:
Previously failing `can_deploy_factory_deps` tests now pass.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
Something related to this problem is the very high `gasPerPubdata` that the local vm has by default and the fact that when forking an url, the  `fair_l2_gas_price` and `l1_gas_price` values from the fork that would lead to real-world `gasPerPubdata` values are not copied correctly to the local environment. This is a problem to be addressed on a future PR.