### PR TITLE
fix: Add transaction type to zk tx in cast send

### DIFF
--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -262,7 +262,7 @@ async fn cast_send<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
 async fn cast_send_zk<P: Provider<T, AnyNetwork>, Z: ZksyncProvider<T>, T: Transport + Clone>(
     provider: P,
     zk_provider: Z,
-    tx: WithOtherFields<TransactionRequest>,
+    mut tx: WithOtherFields<TransactionRequest>,
     zksync_params: ZksyncParams,
     cast_async: bool,
     confs: u64,
@@ -277,6 +277,7 @@ async fn cast_send_zk<P: Provider<T, AnyNetwork>, Z: ZksyncProvider<T>, T: Trans
             paymaster_input: Bytes::from_str(&input).expect("Invalid paymaster input"),
         });
 
+    tx.inner.transaction_type = Some(zksync_types::l2::TransactionType::EIP712Transaction as u8);
     let mut zk_tx: ZkTransactionRequest = tx.inner.clone().into();
     if let Some(paymaster_params) = paymaster_params {
         zk_tx.set_paymaster(paymaster_params);


### PR DESCRIPTION
# What :computer: 
* Insert transaction type into EIP-712 tx from cast send

# Why :hand:
* Lacking of this parameter lead to failures using cast send 