### PR TITLE
fix(ci): migrate to `anvil-zksync-action`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,13 +122,13 @@ jobs:
         - name: Install cargo-nextest
           uses: taiki-e/install-action@nextest
 
-        - name: Run era-test-node
-          uses: dutterbutter/era-test-node-action@v1
+        - name: Run anvil-zksync
+          uses: dutterbutter/anvil-zksync-action@v1.1.0
           with:
             mode: fork
             network: mainnet
             log: info
-            logFilePath: era_test_node.log
+            logFilePath: anvil_zksync.log
             target: x86_64-unknown-linux-gnu
             releaseTag: v0.1.0-alpha.29
         - name: Setup Git config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
           uses: dutterbutter/anvil-zksync-action@v1.1.0
           with:
             mode: fork
-            network: mainnet
+            forkUrl: mainnet
             log: info
             logFilePath: anvil_zksync.log
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,13 +122,13 @@ jobs:
         - name: Install cargo-nextest
           uses: taiki-e/install-action@nextest
 
-        - name: Run anvil-zksync
-          uses: dutterbutter/anvil-zksync-action@v1.1.0
+        - name: Run era-test-node
+          uses: dutterbutter/era-test-node-action@v1
           with:
             mode: fork
             network: mainnet
             log: info
-            logFilePath: anvil_zksync.log
+            logFilePath: era_test_node.log
             target: x86_64-unknown-linux-gnu
             releaseTag: v0.1.0-alpha.29
         - name: Setup Git config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
           uses: taiki-e/install-action@nextest
 
         - name: Run era-test-node
-          uses: dutterbutter/era-test-node-action@v1
+          uses: dutterbutter/era-test-node-action@36ffd2eefd46dc16e7e2a8e1715124400ec0a3ba
           with:
             mode: fork
             network: mainnet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
           uses: dutterbutter/anvil-zksync-action@v1.1.0
           with:
             mode: fork
-            forkUrl: mainnet
+            network: mainnet
             log: info
             logFilePath: anvil_zksync.log
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
# What :computer: 
* Switch to `anvil-zksync-action`

# Why :hand:
* Action was renamed recently and our CI is failing due to that

# Evidence :camera:
https://github.com/matter-labs/foundry-zksync/actions/runs/12235765131/job/34127753305#step:5:26
<img width="870" alt="Screenshot 2024-12-09 at 15 40 22" src="https://github.com/user-attachments/assets/4d290280-3bd1-477f-a423-3372036bfb1f">