### PR TITLE
fix: Add zkout to gitignore template when in zksync forge init mode

### DIFF
--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -152,7 +152,7 @@ impl InitArgs {
                 }
             }
 
-            // install forge-zksync-std
+            // NOTE(zk): install forge-zksync-std
             if zksync && !offline {
                 if root.join("lib/forge-zksync-std").exists() {
                     sh_println!("\"lib/forge-zksync-std\" already exists, skipping install....")?;
@@ -160,6 +160,20 @@ impl InitArgs {
                 } else {
                     let dep = "https://github.com/Moonsong-Labs/forge-zksync-std".parse()?;
                     self.opts.install(&mut config, vec![dep])?;
+                }
+
+                //Add zkout/ to .gitignore under compiler files if it doesn't exist
+                let gitignore_path = root.join(".gitignore");
+                if gitignore_path.exists() {
+                    let mut content = fs::read_to_string(&gitignore_path)?;
+                    if !content.contains("zkout/") {
+                        // Find the compiler files section and add zkout/
+                        if let Some(pos) = content.find("out/") {
+                            let insert_pos = pos + "out/".len();
+                            content.insert_str(insert_pos, "\nzkout/");
+                            fs::write(&gitignore_path, content)?;
+                        }
+                    }
                 }
             }
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3203,3 +3203,16 @@ forgetest_init!(gas_report_include_tests, |prj, cmd| {
             .is_json(),
         );
 });
+
+forgetest_init!(zk_can_init_with_zksync, |prj, cmd| {
+    cmd.args(["init", "--zksync", "--force"]).assert_success();
+
+    // Check that zkout/ is in .gitignore
+    let gitignore_path = prj.root().join(".gitignore");
+    assert!(gitignore_path.exists());
+    let gitignore_contents = std::fs::read_to_string(&gitignore_path).unwrap();
+    assert!(gitignore_contents.contains("zkout/"));
+
+    // Assert that forge-zksync-std is installed
+    assert!(prj.root().join("lib/forge-zksync-std").exists());
+});


### PR DESCRIPTION
# What :computer: 
* Add zkout to gitignore when in `--zksync` mode of `forge init`. The template remains the same to reduce the footprint of zksync and just adding the changes in the block of code where the zksync intervention is. 
* Add test 

# Why :hand:
* Then using `forge init --zksync` the .gitignore remains the same as without the flag. 