### PR TITLE
chore(ci): use 16core runner for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
         run: cargo hack check
 
   zk-cargo-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-github-hosted-16core
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# What :computer: 
* Restore `ubuntu-22.04-github-hosted-16core` runner for `zk-cargo-test`

# Why :hand:
* Tests are timing out