### PR TITLE
fix: add retry logic to prevent race condition during anvil-zksync installation failure for macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,9 @@ jobs:
         run: |
           cp ./install-foundry-zksync ./foundryup-zksync/* /tmp/
           cd /tmp
-          ./install-foundry-zksync
+          for i in {1..3}; do
+          ./install-foundry-zksync && break || echo "Retrying in 5 seconds..." && sleep 5
+          done
       
       - name: Verify anvil-zksync installation
         run: anvil-zksync --version


### PR DESCRIPTION
# What :computer: 
* First thing updated with this PR
* Second thing updated with this PR
* Third thing updated with this PR

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->