### PR TITLE
fix: remove macos from ci-install-anvil-zksync-check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,9 @@ jobs:
         run: |
           cp ./install-foundry-zksync ./foundryup-zksync/* /tmp/
           cd /tmp
-          ./install-foundry-zksync
+          for i in {1..3}; do
+          ./install-foundry-zksync && break || echo "Retrying in 5 seconds..." && sleep 5
+          done
       
       - name: Verify anvil-zksync installation
         run: anvil-zksync --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,11 +157,7 @@ jobs:
 
   check-ci-install-anvil:
     name: CI install anvil-zksync
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       
@@ -169,9 +165,7 @@ jobs:
         run: |
           cp ./install-foundry-zksync ./foundryup-zksync/* /tmp/
           cd /tmp
-          for i in {1..3}; do
-          ./install-foundry-zksync && break || echo "Retrying in 5 seconds..." && sleep 5
-          done
+          ./install-foundry-zksync
       
       - name: Verify anvil-zksync installation
         run: anvil-zksync --version


### PR DESCRIPTION
# What :computer: 
* Removes macos from ci-check 

# Why :hand:
* macos runners are getting rate limited

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->