### PR TITLE
chore: print unsupported architecture

### DIFF
--- a/foundryup-zksync/foundryup-zksync
+++ b/foundryup-zksync/foundryup-zksync
@@ -207,7 +207,7 @@ EOF
             architecture="aarch64"
             ;;
         *)
-            err "Unsupported architecture detected!"
+            err "Unsupported architecture '$arch' detected!"
             ;;
     esac
 


### PR DESCRIPTION
# What :computer: 
* Improved error message about unsupported architecture

# Why :hand:
* For better user experience

# Evidence :camera:
<img width="632" alt="image" src="https://github.com/user-attachments/assets/c919fb4e-66eb-4cd8-8eac-78d217478305" />
