### PR TITLE
feat: fix re-entrancy in strategies

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -1,6 +1,6 @@
 use super::Result;
 use crate::{
-    strategy::{CheatcodeInspectorStrategy, EvmCheatcodeInspectorStrategy},
+    strategy::{new_evm_strategy, Strategy},
     Vm::Rpc,
 };
 use alloy_primitives::{map::AddressHashMap, U256};
@@ -57,7 +57,7 @@ pub struct CheatsConfig {
     /// Version of the script/test contract which is currently running.
     pub running_version: Option<Version>,
     /// The behavior strategy.
-    pub strategy: Box<dyn CheatcodeInspectorStrategy>,
+    pub strategy: Strategy,
     /// Whether to enable legacy (non-reverting) assertions.
     pub assertions_revert: bool,
     /// Optional seed for the RNG algorithm.
@@ -73,7 +73,7 @@ impl CheatsConfig {
         available_artifacts: Option<ContractsByArtifact>,
         running_contract: Option<String>,
         running_version: Option<Version>,
-        strategy: Box<dyn CheatcodeInspectorStrategy>,
+        strategy: Strategy,
     ) -> Self {
         let mut allowed_paths = vec![config.root.0.clone()];
         allowed_paths.extend(config.libs.clone());
@@ -234,7 +234,7 @@ impl Default for CheatsConfig {
             available_artifacts: Default::default(),
             running_contract: Default::default(),
             running_version: Default::default(),
-            strategy: Box::new(EvmCheatcodeInspectorStrategy::default()),
+            strategy: new_evm_strategy(),
             assertions_revert: true,
             seed: None,
         }
@@ -253,7 +253,7 @@ mod tests {
             None,
             None,
             None,
-            Box::new(EvmCheatcodeInspectorStrategy::default()),
+            new_evm_strategy(),
         )
     }
 

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -1,8 +1,5 @@
 use super::Result;
-use crate::{
-    strategy::{new_evm_strategy, Strategy},
-    Vm::Rpc,
-};
+use crate::{strategy::CheatcodeInspectorStrategy, Vm::Rpc};
 use alloy_primitives::{map::AddressHashMap, U256};
 use foundry_common::{fs::normalize_path, ContractsByArtifact};
 use foundry_compilers::{utils::canonicalize, ProjectPathsConfig};
@@ -57,7 +54,7 @@ pub struct CheatsConfig {
     /// Version of the script/test contract which is currently running.
     pub running_version: Option<Version>,
     /// The behavior strategy.
-    pub strategy: Strategy,
+    pub strategy: CheatcodeInspectorStrategy,
     /// Whether to enable legacy (non-reverting) assertions.
     pub assertions_revert: bool,
     /// Optional seed for the RNG algorithm.
@@ -73,7 +70,7 @@ impl CheatsConfig {
         available_artifacts: Option<ContractsByArtifact>,
         running_contract: Option<String>,
         running_version: Option<Version>,
-        strategy: Strategy,
+        strategy: CheatcodeInspectorStrategy,
     ) -> Self {
         let mut allowed_paths = vec![config.root.0.clone()];
         allowed_paths.extend(config.libs.clone());
@@ -234,7 +231,7 @@ impl Default for CheatsConfig {
             available_artifacts: Default::default(),
             running_contract: Default::default(),
             running_version: Default::default(),
-            strategy: new_evm_strategy(),
+            strategy: CheatcodeInspectorStrategy::new_evm(),
             assertions_revert: true,
             seed: None,
         }
@@ -253,7 +250,7 @@ mod tests {
             None,
             None,
             None,
-            new_evm_strategy(),
+            CheatcodeInspectorStrategy::new_evm(),
         )
     }
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -64,7 +64,7 @@ impl Cheatcode for getNonce_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
 
-        ccx.state.strategy.inner.clone().cheatcode_get_nonce(ccx, *account)
+        ccx.state.strategy.runner.clone().cheatcode_get_nonce(ccx, *account)
     }
 }
 
@@ -350,7 +350,7 @@ impl Cheatcode for getBlobhashesCall {
 impl Cheatcode for rollCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newHeight } = self;
-        ccx.state.strategy.inner.clone().cheatcode_roll(ccx, *newHeight)
+        ccx.state.strategy.runner.clone().cheatcode_roll(ccx, *newHeight)
     }
 }
 
@@ -372,7 +372,7 @@ impl Cheatcode for txGasPriceCall {
 impl Cheatcode for warpCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newTimestamp } = self;
-        ccx.state.strategy.inner.clone().cheatcode_warp(ccx, *newTimestamp)
+        ccx.state.strategy.runner.clone().cheatcode_warp(ccx, *newTimestamp)
     }
 }
 
@@ -407,7 +407,7 @@ impl Cheatcode for dealCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account: address, newBalance: new_balance } = *self;
 
-        ccx.state.strategy.inner.clone().cheatcode_deal(ccx, address, new_balance)
+        ccx.state.strategy.runner.clone().cheatcode_deal(ccx, address, new_balance)
     }
 }
 
@@ -415,14 +415,14 @@ impl Cheatcode for etchCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { target, newRuntimeBytecode } = self;
 
-        ccx.state.strategy.inner.clone().cheatcode_etch(ccx, *target, newRuntimeBytecode)
+        ccx.state.strategy.runner.clone().cheatcode_etch(ccx, *target, newRuntimeBytecode)
     }
 }
 
 impl Cheatcode for resetNonceCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
-        ccx.state.strategy.inner.clone().cheatcode_reset_nonce(ccx, *account)
+        ccx.state.strategy.runner.clone().cheatcode_reset_nonce(ccx, *account)
     }
 }
 
@@ -430,7 +430,7 @@ impl Cheatcode for setNonceCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account, newNonce } = *self;
 
-        ccx.state.strategy.inner.clone().cheatcode_set_nonce(ccx, account, newNonce)
+        ccx.state.strategy.runner.clone().cheatcode_set_nonce(ccx, account, newNonce)
     }
 }
 
@@ -438,7 +438,7 @@ impl Cheatcode for setNonceUnsafeCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account, newNonce } = *self;
 
-        ccx.state.strategy.inner.clone().cheatcode_set_nonce_unsafe(ccx, account, newNonce)
+        ccx.state.strategy.runner.clone().cheatcode_set_nonce_unsafe(ccx, account, newNonce)
     }
 }
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -64,7 +64,7 @@ impl Cheatcode for getNonce_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
 
-        ccx.with_strategy(|strategy, ccx| strategy.cheatcode_get_nonce(ccx, *account))
+        ccx.state.strategy.inner.clone().cheatcode_get_nonce(ccx, *account)
     }
 }
 
@@ -350,7 +350,7 @@ impl Cheatcode for getBlobhashesCall {
 impl Cheatcode for rollCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newHeight } = self;
-        ccx.with_strategy(|strategy, ccx| strategy.cheatcode_roll(ccx, *newHeight))
+        ccx.state.strategy.inner.clone().cheatcode_roll(ccx, *newHeight)
     }
 }
 
@@ -372,7 +372,7 @@ impl Cheatcode for txGasPriceCall {
 impl Cheatcode for warpCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newTimestamp } = self;
-        ccx.with_strategy(|strategy, ccx| strategy.cheatcode_warp(ccx, *newTimestamp))
+        ccx.state.strategy.inner.clone().cheatcode_warp(ccx, *newTimestamp)
     }
 }
 
@@ -407,7 +407,7 @@ impl Cheatcode for dealCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account: address, newBalance: new_balance } = *self;
 
-        ccx.with_strategy(|strategy, ccx| strategy.cheatcode_deal(ccx, address, new_balance))
+        ccx.state.strategy.inner.clone().cheatcode_deal(ccx, address, new_balance)
     }
 }
 
@@ -415,14 +415,14 @@ impl Cheatcode for etchCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { target, newRuntimeBytecode } = self;
 
-        ccx.with_strategy(|strategy, ccx| strategy.cheatcode_etch(ccx, *target, newRuntimeBytecode))
+        ccx.state.strategy.inner.clone().cheatcode_etch(ccx, *target, newRuntimeBytecode)
     }
 }
 
 impl Cheatcode for resetNonceCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account } = self;
-        ccx.with_strategy(|strategy, ccx| strategy.cheatcode_reset_nonce(ccx, *account))
+        ccx.state.strategy.inner.clone().cheatcode_reset_nonce(ccx, *account)
     }
 }
 
@@ -430,7 +430,7 @@ impl Cheatcode for setNonceCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account, newNonce } = *self;
 
-        ccx.with_strategy(|strategy, ccx| strategy.cheatcode_set_nonce(ccx, account, newNonce))
+        ccx.state.strategy.inner.clone().cheatcode_set_nonce(ccx, account, newNonce)
     }
 }
 
@@ -438,9 +438,7 @@ impl Cheatcode for setNonceUnsafeCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { account, newNonce } = *self;
 
-        ccx.with_strategy(|strategy, ccx| {
-            strategy.cheatcode_set_nonce_unsafe(ccx, account, newNonce)
-        })
+        ccx.state.strategy.inner.clone().cheatcode_set_nonce_unsafe(ccx, account, newNonce)
     }
 }
 

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -125,7 +125,11 @@ impl Cheatcode for selectForkCall {
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
 
-        ccx.with_strategy(|strategy, ccx| strategy.zksync_select_fork_vm(ccx.ecx, *forkId));
+        ccx.state.strategy.inner.zksync_select_fork_vm(
+            ccx.state.strategy.context.as_mut(),
+            ccx.ecx,
+            *forkId,
+        );
         ccx.ecx.db.select_fork(*forkId, &mut ccx.ecx.env, &mut ccx.ecx.journaled_state)?;
 
         Ok(Default::default())
@@ -281,7 +285,11 @@ fn create_select_fork(ccx: &mut CheatsCtxt, url_or_alias: &str, block: Option<u6
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
     let id = ccx.ecx.db.create_fork(fork)?;
-    ccx.with_strategy(|strategy, ccx| strategy.zksync_select_fork_vm(ccx.ecx, id));
+    ccx.state.strategy.inner.zksync_select_fork_vm(
+        ccx.state.strategy.context.as_mut(),
+        ccx.ecx,
+        id,
+    );
     ccx.ecx.db.select_fork(id, &mut ccx.ecx.env, &mut ccx.ecx.journaled_state)?;
     Ok(id.abi_encode())
 }

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -125,7 +125,7 @@ impl Cheatcode for selectForkCall {
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
 
-        ccx.state.strategy.inner.zksync_select_fork_vm(
+        ccx.state.strategy.runner.zksync_select_fork_vm(
             ccx.state.strategy.context.as_mut(),
             ccx.ecx,
             *forkId,
@@ -285,7 +285,7 @@ fn create_select_fork(ccx: &mut CheatsCtxt, url_or_alias: &str, block: Option<u6
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
     let id = ccx.ecx.db.create_fork(fork)?;
-    ccx.state.strategy.inner.zksync_select_fork_vm(
+    ccx.state.strategy.runner.zksync_select_fork_vm(
         ccx.state.strategy.context.as_mut(),
         ccx.ecx,
         id,

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -15,7 +15,7 @@ impl Cheatcode for clearMockedCallsCall {
 impl Cheatcode for mockCall_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { callee, data, returnData } = self;
-        ccx.state.strategy.inner.clone().cheatcode_mock_call(ccx, *callee, data, returnData)
+        ccx.state.strategy.runner.clone().cheatcode_mock_call(ccx, *callee, data, returnData)
     }
 }
 
@@ -83,7 +83,7 @@ impl Cheatcode for mockCalls_1Call {
 impl Cheatcode for mockCallRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { callee, data, revertData } = self;
-        ccx.state.strategy.inner.clone().cheatcode_mock_call_revert(ccx, *callee, data, revertData)
+        ccx.state.strategy.runner.clone().cheatcode_mock_call_revert(ccx, *callee, data, revertData)
     }
 }
 

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -15,9 +15,7 @@ impl Cheatcode for clearMockedCallsCall {
 impl Cheatcode for mockCall_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { callee, data, returnData } = self;
-        ccx.with_strategy(|strategy, ccx| {
-            strategy.cheatcode_mock_call(ccx, *callee, data, returnData)
-        })
+        ccx.state.strategy.inner.clone().cheatcode_mock_call(ccx, *callee, data, returnData)
     }
 }
 
@@ -85,9 +83,7 @@ impl Cheatcode for mockCalls_1Call {
 impl Cheatcode for mockCallRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { callee, data, revertData } = self;
-        ccx.with_strategy(|strategy, ccx| {
-            strategy.cheatcode_mock_call_revert(ccx, *callee, data, revertData)
-        })
+        ccx.state.strategy.inner.clone().cheatcode_mock_call_revert(ccx, *callee, data, revertData)
     }
 }
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -283,7 +283,7 @@ impl Cheatcode for getArtifactPathByDeployedCodeCall {
 impl Cheatcode for getCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { artifactPath: path } = self;
-        state.strategy.inner.get_artifact_code(state, path, false)
+        state.strategy.runner.get_artifact_code(state, path, false)
     }
 }
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -283,7 +283,7 @@ impl Cheatcode for getArtifactPathByDeployedCodeCall {
 impl Cheatcode for getCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { artifactPath: path } = self;
-        state.with_strategy(|strategy, state| strategy.get_artifact_code(state, path, false))
+        state.strategy.inner.get_artifact_code(state, path, false)
     }
 }
 

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -17,7 +17,6 @@ extern crate tracing;
 
 use alloy_primitives::Address;
 use foundry_evm_core::backend::DatabaseExt;
-use inspector::Strategy;
 use revm::{ContextPrecompiles, InnerEvmContext};
 use spec::Status;
 
@@ -174,16 +173,5 @@ impl CheatsCtxt<'_, '_, '_, '_> {
     #[inline]
     pub(crate) fn is_precompile(&self, address: &Address) -> bool {
         self.precompiles.contains(address)
-    }
-
-    pub(crate) fn with_strategy<F, R>(&mut self, mut f: F) -> R
-    where
-        F: FnMut(Strategy, &mut Self) -> R,
-    {
-        let mut strategy = self.state.strategy.take();
-        let result = f(strategy.as_mut().expect("failed acquiring strategy").as_mut(), self);
-        self.state.strategy = strategy;
-
-        result
     }
 }

--- a/crates/cheatcodes/src/strategy.rs
+++ b/crates/cheatcodes/src/strategy.rs
@@ -26,7 +26,7 @@ pub trait CheatcodeInspectorStrategyContext: Debug + Send + Sync + Any {
 
 impl CheatcodeInspectorStrategyContext for () {
     fn new_cloned(&self) -> Box<dyn CheatcodeInspectorStrategyContext> {
-        Box::new(self.clone())
+        Box::new(*self)
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
@@ -195,6 +195,7 @@ pub trait CheatcodeInspectorStrategy: Debug + Send + Sync + CheatcodeInspectorSt
     );
 
     /// Record broadcastable transaction during CALL.
+    #[allow(clippy::too_many_arguments)]
     fn record_broadcastable_call_transactions(
         &self,
         _ctx: &mut dyn CheatcodeInspectorStrategyContext,

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -15,7 +15,11 @@ impl Cheatcode for zkVmCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { enable } = *self;
 
-        ccx.with_strategy(|strategy, ccx| strategy.zksync_cheatcode_select_zk_vm(ccx.ecx, enable));
+        ccx.state.strategy.inner.zksync_cheatcode_select_zk_vm(
+            ccx.state.strategy.context.as_mut(),
+            ccx.ecx,
+            enable,
+        );
 
         Ok(Default::default())
     }
@@ -23,23 +27,28 @@ impl Cheatcode for zkVmCall {
 
 impl Cheatcode for zkVmSkipCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        ccx.with_strategy(|strategy, _ccx| strategy.zksync_cheatcode_skip_zkvm())
+        ccx.state.strategy.inner.zksync_cheatcode_skip_zkvm(ccx.state.strategy.context.as_mut())
     }
 }
 
 impl Cheatcode for zkUsePaymasterCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { paymaster_address, paymaster_input } = self;
-        ccx.with_strategy(|strategy, _ccx| {
-            strategy.zksync_cheatcode_set_paymaster(*paymaster_address, paymaster_input)
-        })
+        ccx.state.strategy.inner.zksync_cheatcode_set_paymaster(
+            ccx.state.strategy.context.as_mut(),
+            *paymaster_address,
+            paymaster_input,
+        )
     }
 }
 
 impl Cheatcode for zkUseFactoryDepCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { name } = self;
-        ccx.with_strategy(|strategy, _ccx| strategy.zksync_cheatcode_use_factory_deps(name.clone()))
+        ccx.state
+            .strategy
+            .inner
+            .zksync_cheatcode_use_factory_deps(ccx.state.strategy.context.as_mut(), name.clone())
     }
 }
 
@@ -54,17 +63,16 @@ impl Cheatcode for zkRegisterContractCall {
             zkDeployedBytecode,
         } = self;
 
-        ccx.with_strategy(|strategy, _ccx| {
-            strategy.zksync_cheatcode_register_contract(
-                name.clone(),
-                zkBytecodeHash.0.into(),
-                zkDeployedBytecode.to_vec(),
-                vec![], //TODO: add argument to cheatcode
-                *evmBytecodeHash,
-                evmDeployedBytecode.to_vec(),
-                evmBytecode.to_vec(),
-            )
-        })
+        ccx.state.strategy.inner.zksync_cheatcode_register_contract(
+            ccx.state.strategy.context.as_mut(),
+            name.clone(),
+            zkBytecodeHash.0.into(),
+            zkDeployedBytecode.to_vec(),
+            vec![], //TODO: add argument to cheatcode
+            *evmBytecodeHash,
+            evmDeployedBytecode.to_vec(),
+            evmBytecode.to_vec(),
+        )
     }
 }
 

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -15,7 +15,7 @@ impl Cheatcode for zkVmCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { enable } = *self;
 
-        ccx.state.strategy.inner.zksync_cheatcode_select_zk_vm(
+        ccx.state.strategy.runner.zksync_cheatcode_select_zk_vm(
             ccx.state.strategy.context.as_mut(),
             ccx.ecx,
             enable,
@@ -27,14 +27,14 @@ impl Cheatcode for zkVmCall {
 
 impl Cheatcode for zkVmSkipCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        ccx.state.strategy.inner.zksync_cheatcode_skip_zkvm(ccx.state.strategy.context.as_mut())
+        ccx.state.strategy.runner.zksync_cheatcode_skip_zkvm(ccx.state.strategy.context.as_mut())
     }
 }
 
 impl Cheatcode for zkUsePaymasterCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { paymaster_address, paymaster_input } = self;
-        ccx.state.strategy.inner.zksync_cheatcode_set_paymaster(
+        ccx.state.strategy.runner.zksync_cheatcode_set_paymaster(
             ccx.state.strategy.context.as_mut(),
             *paymaster_address,
             paymaster_input,
@@ -47,7 +47,7 @@ impl Cheatcode for zkUseFactoryDepCall {
         let Self { name } = self;
         ccx.state
             .strategy
-            .inner
+            .runner
             .zksync_cheatcode_use_factory_deps(ccx.state.strategy.context.as_mut(), name.clone())
     }
 }
@@ -63,7 +63,7 @@ impl Cheatcode for zkRegisterContractCall {
             zkDeployedBytecode,
         } = self;
 
-        ccx.state.strategy.inner.zksync_cheatcode_register_contract(
+        ccx.state.strategy.runner.zksync_cheatcode_register_contract(
             ccx.state.strategy.context.as_mut(),
             name.clone(),
             zkBytecodeHash.0.into(),

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -316,14 +316,14 @@ impl SessionSource {
         let env =
             self.config.evm_opts.evm_env().await.expect("Could not instantiate fork environment");
 
-        let strategy = utils::get_executor_strategy(&self.config.foundry_config);
+        let mut strategy = utils::get_executor_strategy(&self.config.foundry_config);
 
         // Create an in-memory backend
         let backend = match self.config.backend.take() {
             Some(backend) => backend,
             None => {
                 let fork = self.config.evm_opts.get_fork(&self.config.foundry_config, env.clone());
-                let backend = Backend::spawn(fork, strategy.new_backend_strategy());
+                let backend = Backend::spawn(fork, strategy.inner.new_backend_strategy());
                 self.config.backend = Some(backend.clone());
                 backend
             }
@@ -339,7 +339,7 @@ impl SessionSource {
                         None,
                         None,
                         Some(self.solc.version.clone()),
-                        strategy.new_cheatcode_inspector_strategy(),
+                        strategy.inner.new_cheatcode_inspector_strategy(strategy.context.as_mut()),
                     )
                     .into(),
                 )

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -323,7 +323,7 @@ impl SessionSource {
             Some(backend) => backend,
             None => {
                 let fork = self.config.evm_opts.get_fork(&self.config.foundry_config, env.clone());
-                let backend = Backend::spawn(fork, strategy.inner.new_backend_strategy());
+                let backend = Backend::spawn(fork, strategy.runner.new_backend_strategy());
                 self.config.backend = Some(backend.clone());
                 backend
             }
@@ -339,7 +339,7 @@ impl SessionSource {
                         None,
                         None,
                         Some(self.solc.version.clone()),
-                        strategy.inner.new_cheatcode_inspector_strategy(strategy.context.as_mut()),
+                        strategy.runner.new_cheatcode_inspector_strategy(strategy.context.as_mut()),
                     )
                     .into(),
                 )

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -9,8 +9,8 @@ use foundry_common::{
     shell,
 };
 use foundry_config::{Chain, Config};
-use foundry_evm::executors::strategy::{EvmExecutorStrategy, ExecutorStrategy};
-use foundry_strategy_zksync::ZksyncExecutorStrategy;
+use foundry_evm::executors::strategy::{new_evm_strategy, Strategy};
+use foundry_strategy_zksync::new_zkysnc_strategy;
 use serde::de::DeserializeOwned;
 use std::{
     ffi::OsStr,
@@ -93,13 +93,13 @@ pub fn get_provider(config: &Config) -> Result<RetryProvider> {
     get_provider_builder(config)?.build()
 }
 
-pub fn get_executor_strategy(config: &Config) -> Box<dyn ExecutorStrategy> {
+pub fn get_executor_strategy(config: &Config) -> Strategy {
     if config.zksync.should_compile() {
         info!("using zksync strategy");
-        Box::new(ZksyncExecutorStrategy::default())
+        new_zkysnc_strategy()
     } else {
         info!("using evm strategy");
-        Box::new(EvmExecutorStrategy::default())
+        new_evm_strategy()
     }
 }
 

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -9,8 +9,8 @@ use foundry_common::{
     shell,
 };
 use foundry_config::{Chain, Config};
-use foundry_evm::executors::strategy::{new_evm_strategy, Strategy};
-use foundry_strategy_zksync::new_zkysnc_strategy;
+use foundry_evm::executors::strategy::ExecutorStrategy;
+use foundry_strategy_zksync::ZksyncExecutorStrategyBuilder;
 use serde::de::DeserializeOwned;
 use std::{
     ffi::OsStr,
@@ -93,13 +93,13 @@ pub fn get_provider(config: &Config) -> Result<RetryProvider> {
     get_provider_builder(config)?.build()
 }
 
-pub fn get_executor_strategy(config: &Config) -> Strategy {
+pub fn get_executor_strategy(config: &Config) -> ExecutorStrategy {
     if config.zksync.should_compile() {
         info!("using zksync strategy");
-        new_zkysnc_strategy()
+        ExecutorStrategy::new_zksync()
     } else {
         info!("using evm strategy");
-        new_evm_strategy()
+        ExecutorStrategy::new_evm()
     }
 }
 

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -1,6 +1,6 @@
 //! A wrapper around `Backend` that is clone-on-write used for fuzzing.
 
-use super::{strategy::BackendStrategy, BackendError, ForkInfo};
+use super::{strategy::Strategy, BackendError, ForkInfo};
 use crate::{
     backend::{
         diagnostic::RevertDiagnostic, Backend, DatabaseExt, LocalForkId, RevertStateSnapshotAction,
@@ -92,8 +92,8 @@ impl DatabaseExt for CowBackend<'_> {
         self.backend.to_mut().get_fork_info(id)
     }
 
-    fn get_strategy(&mut self) -> &mut dyn BackendStrategy {
-        self.backend.to_mut().strategy.as_mut()
+    fn get_strategy(&mut self) -> &mut Strategy {
+        &mut self.backend.to_mut().strategy
     }
 
     fn snapshot_state(&mut self, journaled_state: &JournaledState, env: &Env) -> U256 {

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -1,6 +1,6 @@
 //! A wrapper around `Backend` that is clone-on-write used for fuzzing.
 
-use super::{strategy::Strategy, BackendError, ForkInfo};
+use super::{strategy::BackendStrategy, BackendError, ForkInfo};
 use crate::{
     backend::{
         diagnostic::RevertDiagnostic, Backend, DatabaseExt, LocalForkId, RevertStateSnapshotAction,
@@ -92,7 +92,7 @@ impl DatabaseExt for CowBackend<'_> {
         self.backend.to_mut().get_fork_info(id)
     }
 
-    fn get_strategy(&mut self) -> &mut Strategy {
+    fn get_strategy(&mut self) -> &mut BackendStrategy {
         &mut self.backend.to_mut().strategy
     }
 

--- a/crates/evm/core/src/backend/strategy.rs
+++ b/crates/evm/core/src/backend/strategy.rs
@@ -19,7 +19,7 @@ pub trait BackendStrategyContext: Debug + Send + Sync + Any {
 
 impl BackendStrategyContext for () {
     fn new_cloned(&self) -> Box<dyn BackendStrategyContext> {
-        Box::new(self.clone())
+        Box::new(())
     }
 
     fn as_any_ref(&self) -> &dyn Any {

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -2,7 +2,7 @@ use crate::{executors::Executor, inspectors::InspectorStackBuilder};
 use foundry_evm_core::backend::Backend;
 use revm::primitives::{Env, EnvWithHandlerCfg, SpecId};
 
-use super::strategy::Strategy;
+use super::strategy::ExecutorStrategy;
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
 /// [`revm::Inspector`]s, such as [`Cheatcodes`].
@@ -76,7 +76,7 @@ impl ExecutorBuilder {
 
     /// Builds the executor as configured.
     #[inline]
-    pub fn build(self, env: Env, db: Backend, strategy: Strategy) -> Executor {
+    pub fn build(self, env: Env, db: Backend, strategy: ExecutorStrategy) -> Executor {
         let Self { mut stack, gas_limit, spec_id, legacy_assertions } = self;
         if stack.block.is_none() {
             stack.block = Some(env.block.clone());

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -2,7 +2,7 @@ use crate::{executors::Executor, inspectors::InspectorStackBuilder};
 use foundry_evm_core::backend::Backend;
 use revm::primitives::{Env, EnvWithHandlerCfg, SpecId};
 
-use super::strategy::ExecutorStrategy;
+use super::strategy::Strategy;
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
 /// [`revm::Inspector`]s, such as [`Cheatcodes`].
@@ -76,7 +76,7 @@ impl ExecutorBuilder {
 
     /// Builds the executor as configured.
     #[inline]
-    pub fn build(self, env: Env, db: Backend, strategy: Box<dyn ExecutorStrategy>) -> Executor {
+    pub fn build(self, env: Env, db: Backend, strategy: Strategy) -> Executor {
         let Self { mut stack, gas_limit, spec_id, legacy_assertions } = self;
         if stack.block.is_none() {
             stack.block = Some(env.block.clone());

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -37,7 +37,7 @@ use revm::{
     },
 };
 use std::borrow::Cow;
-use strategy::ExecutorStrategy;
+use strategy::Strategy;
 
 mod builder;
 pub use builder::ExecutorBuilder;
@@ -93,7 +93,7 @@ pub struct Executor {
     /// Whether `failed()` should be called on the test contract to determine if the test failed.
     legacy_assertions: bool,
 
-    strategy: Option<Box<dyn ExecutorStrategy>>,
+    strategy: Strategy,
 }
 
 impl Clone for Executor {
@@ -104,7 +104,7 @@ impl Clone for Executor {
             inspector: self.inspector.clone(),
             gas_limit: self.gas_limit,
             legacy_assertions: self.legacy_assertions,
-            strategy: self.strategy.as_ref().map(|s| s.new_cloned()),
+            strategy: self.strategy.clone(),
         }
     }
 }
@@ -124,7 +124,7 @@ impl Executor {
         inspector: InspectorStack,
         gas_limit: u64,
         legacy_assertions: bool,
-        strategy: Box<dyn ExecutorStrategy>,
+        strategy: Strategy,
     ) -> Self {
         // Need to create a non-empty contract on the cheatcodes address so `extcodesize` checks
         // do not fail.
@@ -139,7 +139,7 @@ impl Executor {
             },
         );
 
-        Self { backend, env, inspector, gas_limit, legacy_assertions, strategy: Some(strategy) }
+        Self { backend, env, inspector, gas_limit, legacy_assertions, strategy }
     }
 
     fn clone_with_backend(&self, backend: Backend) -> Self {
@@ -150,7 +150,7 @@ impl Executor {
             self.inspector().clone(),
             self.gas_limit,
             self.legacy_assertions,
-            self.strategy.as_ref().map(|s| s.new_cloned()).expect("failed acquiring strategy"),
+            self.strategy.clone(),
         )
     }
 
@@ -214,21 +214,10 @@ impl Executor {
         Ok(())
     }
 
-    pub fn with_strategy<F, R>(&mut self, mut f: F) -> R
-    where
-        F: FnMut(&mut dyn ExecutorStrategy, &mut Self) -> R,
-    {
-        let mut strategy = self.strategy.take();
-        let result = f(strategy.as_mut().expect("failed acquiring strategy").as_mut(), self);
-        self.strategy = strategy;
-
-        result
-    }
-
     /// Set the balance of an account.
     pub fn set_balance(&mut self, address: Address, amount: U256) -> BackendResult<()> {
         trace!(?address, ?amount, "setting account balance");
-        self.with_strategy(|strategy, executor| strategy.set_balance(executor, address, amount))
+        self.strategy.inner.clone().set_balance(self, address, amount)
     }
 
     /// Gets the balance of an account
@@ -238,7 +227,7 @@ impl Executor {
 
     /// Set the nonce of an account.
     pub fn set_nonce(&mut self, address: Address, nonce: u64) -> BackendResult<()> {
-        self.with_strategy(|strategy, executor| strategy.set_nonce(executor, address, nonce))
+        self.strategy.inner.clone().set_nonce(self, address, nonce)
     }
 
     /// Returns the nonce of an account.
@@ -271,10 +260,7 @@ impl Executor {
 
     #[inline]
     pub fn set_transaction_other_fields(&mut self, other_fields: OtherFields) {
-        self.strategy
-            .as_mut()
-            .expect("failed acquiring strategy")
-            .set_inspect_context(other_fields);
+        self.strategy.inner.set_inspect_context(self.strategy.context.as_mut(), other_fields);
     }
 
     /// Deploys a contract and commits the new state to the underlying database.
@@ -457,12 +443,12 @@ impl Executor {
         backend.is_initialized = false;
         backend.spec_id = env.spec_id();
 
-        let result = self
-            .strategy
-            .as_ref()
-            .expect("failed acquiring strategy")
-            .new_cloned()
-            .call_inspect(&mut backend, &mut env, &mut inspector)?;
+        let result = self.strategy.inner.call_inspect(
+            self.strategy.context.as_ref(),
+            &mut backend,
+            &mut env,
+            &mut inspector,
+        )?;
 
         convert_executed_result(
             env.clone(),
@@ -475,24 +461,27 @@ impl Executor {
     /// Execute the transaction configured in `env.tx`.
     #[instrument(name = "transact", level = "debug", skip_all)]
     pub fn transact_with_env(&mut self, mut env: EnvWithHandlerCfg) -> eyre::Result<RawCallResult> {
-        self.with_strategy(|strategy, executor| {
-            let mut inspector = executor.inspector.clone();
-            let backend = &mut executor.backend;
-            backend.initialize(&env);
+        let mut inspector = self.inspector.clone();
+        let backend = &mut self.backend;
+        backend.initialize(&env);
 
-            let result_and_state =
-                strategy.transact_inspect(backend, &mut env, &executor.env, &mut inspector)?;
+        let result_and_state = self.strategy.inner.transact_inspect(
+            self.strategy.context.as_mut(),
+            backend,
+            &mut env,
+            &self.env,
+            &mut inspector,
+        )?;
 
-            let mut result = convert_executed_result(
-                env.clone(),
-                inspector,
-                result_and_state,
-                backend.has_state_snapshot_failure(),
-            )?;
+        let mut result = convert_executed_result(
+            env.clone(),
+            inspector,
+            result_and_state,
+            backend.has_state_snapshot_failure(),
+        )?;
 
-            executor.commit(&mut result);
-            Ok(result)
-        })
+        self.commit(&mut result);
+        Ok(result)
     }
 
     /// Commit the changeset to the database and adjust `self.inspector_config` values according to

--- a/crates/evm/evm/src/executors/strategy.rs
+++ b/crates/evm/evm/src/executors/strategy.rs
@@ -24,7 +24,7 @@ pub trait ExecutorStrategyContext: Debug + Send + Sync + Any {
 
 impl ExecutorStrategyContext for () {
     fn new_cloned(&self) -> Box<dyn ExecutorStrategyContext> {
-        Box::new(self.clone())
+        Box::new(*self)
     }
 
     fn as_any_ref(&self) -> &dyn Any {

--- a/crates/evm/evm/src/executors/strategy.rs
+++ b/crates/evm/evm/src/executors/strategy.rs
@@ -29,7 +29,7 @@ pub trait ExecutorStrategyContext: Debug + Send + Sync + Any {
 
 impl ExecutorStrategyContext for () {
     fn new_cloned(&self) -> Box<dyn ExecutorStrategyContext> {
-        Box::new(*self)
+        Box::new(())
     }
 
     fn as_any_ref(&self) -> &dyn Any {

--- a/crates/evm/evm/src/executors/strategy.rs
+++ b/crates/evm/evm/src/executors/strategy.rs
@@ -1,14 +1,11 @@
-use std::fmt::Debug;
+use std::{any::Any, fmt::Debug};
 
 use alloy_primitives::{Address, U256};
 use alloy_serde::OtherFields;
 use eyre::{Context, Result};
-use foundry_cheatcodes::strategy::{CheatcodeInspectorStrategy, EvmCheatcodeInspectorStrategy};
+use foundry_cheatcodes::strategy::EvmCheatcodeInspectorStrategy;
 use foundry_evm_core::{
-    backend::{
-        strategy::{BackendStrategy, EvmBackendStrategy},
-        BackendResult, DatabaseExt,
-    },
+    backend::{BackendResult, DatabaseExt},
     InspectorExt,
 };
 use foundry_zksync_compiler::DualCompiledContracts;
@@ -19,56 +16,99 @@ use revm::{
 
 use super::Executor;
 
+pub trait ExecutorStrategyContext: Debug + Send + Sync + Any {
+    fn new_cloned(&self) -> Box<dyn ExecutorStrategyContext>;
+    fn as_any_ref(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl ExecutorStrategyContext for () {
+    fn new_cloned(&self) -> Box<dyn ExecutorStrategyContext> {
+        Box::new(self.clone())
+    }
+
+    fn as_any_ref(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct Strategy {
+    pub inner: Box<dyn ExecutorStrategy>,
+    pub context: Box<dyn ExecutorStrategyContext>,
+}
+
+pub fn new_evm_strategy() -> Strategy {
+    Strategy { inner: Box::new(EvmExecutorStrategy::default()), context: Box::new(()) }
+}
+
+impl Clone for Strategy {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.new_cloned(), context: self.context.new_cloned() }
+    }
+}
+
 pub trait ExecutorStrategy: Debug + Send + Sync + ExecutorStrategyExt {
     fn name(&self) -> &'static str;
 
     fn new_cloned(&self) -> Box<dyn ExecutorStrategy>;
 
     fn set_balance(
-        &mut self,
+        &self,
         executor: &mut Executor,
         address: Address,
         amount: U256,
     ) -> BackendResult<()>;
 
-    fn set_nonce(
-        &mut self,
-        executor: &mut Executor,
-        address: Address,
-        nonce: u64,
-    ) -> BackendResult<()>;
+    fn set_nonce(&self, executor: &mut Executor, address: Address, nonce: u64)
+        -> BackendResult<()>;
 
-    fn set_inspect_context(&mut self, other_fields: OtherFields);
+    fn set_inspect_context(&self, ctx: &mut dyn ExecutorStrategyContext, other_fields: OtherFields);
 
     fn call_inspect(
         &self,
+        ctx: &dyn ExecutorStrategyContext,
         db: &mut dyn DatabaseExt,
         env: &mut EnvWithHandlerCfg,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<ResultAndState>;
 
     fn transact_inspect(
-        &mut self,
+        &self,
+        ctx: &mut dyn ExecutorStrategyContext,
         db: &mut dyn DatabaseExt,
         env: &mut EnvWithHandlerCfg,
         _executor_env: &EnvWithHandlerCfg,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<ResultAndState>;
 
-    fn new_backend_strategy(&self) -> Box<dyn BackendStrategy>;
-    fn new_cheatcode_inspector_strategy(&self) -> Box<dyn CheatcodeInspectorStrategy>;
+    fn new_backend_strategy(&self) -> foundry_evm_core::backend::strategy::Strategy;
+    fn new_cheatcode_inspector_strategy(
+        &self,
+        ctx: &dyn ExecutorStrategyContext,
+    ) -> foundry_cheatcodes::strategy::Strategy;
 
     // TODO perhaps need to create fresh strategies as well
 }
 
 pub trait ExecutorStrategyExt {
     fn zksync_set_dual_compiled_contracts(
-        &mut self,
+        &self,
+        _ctx: &mut dyn ExecutorStrategyContext,
         _dual_compiled_contracts: DualCompiledContracts,
     ) {
     }
 
-    fn zksync_set_fork_env(&mut self, _fork_url: &str, _env: &Env) -> Result<()> {
+    fn zksync_set_fork_env(
+        &self,
+        _ctx: &mut dyn ExecutorStrategyContext,
+        _fork_url: &str,
+        _env: &Env,
+    ) -> Result<()> {
         Ok(())
     }
 }
@@ -85,7 +125,12 @@ impl ExecutorStrategy for EvmExecutorStrategy {
         Box::new(self.clone())
     }
 
-    fn set_inspect_context(&mut self, _other_fields: OtherFields) {}
+    fn set_inspect_context(
+        &self,
+        _ctx: &mut dyn ExecutorStrategyContext,
+        _other_fields: OtherFields,
+    ) {
+    }
 
     /// Executes the configured test call of the `env` without committing state changes.
     ///
@@ -93,6 +138,7 @@ impl ExecutorStrategy for EvmExecutorStrategy {
     /// update the given `env` with the new values.
     fn call_inspect(
         &self,
+        _ctx: &dyn ExecutorStrategyContext,
         db: &mut dyn DatabaseExt,
         env: &mut EnvWithHandlerCfg,
         inspector: &mut dyn InspectorExt,
@@ -112,7 +158,8 @@ impl ExecutorStrategy for EvmExecutorStrategy {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     fn transact_inspect(
-        &mut self,
+        &self,
+        _ctx: &mut dyn ExecutorStrategyContext,
         db: &mut dyn DatabaseExt,
         env: &mut EnvWithHandlerCfg,
         _executor_env: &EnvWithHandlerCfg,
@@ -128,7 +175,7 @@ impl ExecutorStrategy for EvmExecutorStrategy {
     }
 
     fn set_balance(
-        &mut self,
+        &self,
         executor: &mut Executor,
         address: Address,
         amount: U256,
@@ -142,7 +189,7 @@ impl ExecutorStrategy for EvmExecutorStrategy {
     }
 
     fn set_nonce(
-        &mut self,
+        &self,
         executor: &mut Executor,
         address: Address,
         nonce: u64,
@@ -154,13 +201,25 @@ impl ExecutorStrategy for EvmExecutorStrategy {
         Ok(())
     }
 
-    fn new_backend_strategy(&self) -> Box<dyn BackendStrategy> {
-        Box::new(EvmBackendStrategy)
+    fn new_backend_strategy(&self) -> foundry_evm_core::backend::strategy::Strategy {
+        foundry_evm_core::backend::strategy::new_evm_strategy()
     }
 
-    fn new_cheatcode_inspector_strategy(&self) -> Box<dyn CheatcodeInspectorStrategy> {
-        Box::new(EvmCheatcodeInspectorStrategy::default())
+    fn new_cheatcode_inspector_strategy(
+        &self,
+        _ctx: &dyn ExecutorStrategyContext,
+    ) -> foundry_cheatcodes::strategy::Strategy {
+        foundry_cheatcodes::strategy::Strategy {
+            inner: Box::new(EvmCheatcodeInspectorStrategy::default()),
+            context: Box::new(()),
+        }
     }
 }
 
 impl ExecutorStrategyExt for EvmExecutorStrategy {}
+
+impl Clone for Box<dyn ExecutorStrategy> {
+    fn clone(&self) -> Self {
+        self.new_cloned()
+    }
+}

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -6,7 +6,7 @@ use foundry_evm_traces::{InternalTraceMode, TraceMode};
 use revm::primitives::{Env, SpecId};
 use std::ops::{Deref, DerefMut};
 
-use super::strategy::Strategy;
+use super::strategy::ExecutorStrategy;
 
 /// A default executor with tracing enabled
 pub struct TracingExecutor {
@@ -21,9 +21,9 @@ impl TracingExecutor {
         debug: bool,
         decode_internal: bool,
         alphanet: bool,
-        strategy: Strategy,
+        strategy: ExecutorStrategy,
     ) -> Self {
-        let db = Backend::spawn(fork, strategy.inner.new_backend_strategy());
+        let db = Backend::spawn(fork, strategy.runner.new_backend_strategy());
         let trace_mode =
             TraceMode::Call.with_debug(debug).with_decode_internal(if decode_internal {
                 InternalTraceMode::Full

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -6,7 +6,7 @@ use foundry_evm_traces::{InternalTraceMode, TraceMode};
 use revm::primitives::{Env, SpecId};
 use std::ops::{Deref, DerefMut};
 
-use super::strategy::ExecutorStrategy;
+use super::strategy::Strategy;
 
 /// A default executor with tracing enabled
 pub struct TracingExecutor {
@@ -21,9 +21,9 @@ impl TracingExecutor {
         debug: bool,
         decode_internal: bool,
         alphanet: bool,
-        strategy: Box<dyn ExecutorStrategy>,
+        strategy: Strategy,
     ) -> Self {
-        let db = Backend::spawn(fork, strategy.new_backend_strategy());
+        let db = Backend::spawn(fork, strategy.inner.new_backend_strategy());
         let trace_mode =
             TraceMode::Call.with_debug(debug).with_decode_internal(if decode_internal {
                 InternalTraceMode::Full

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -368,7 +368,7 @@ impl TestArgs {
         // Prepare the test builder.
         let config = Arc::new(config);
 
-        strategy.inner.zksync_set_dual_compiled_contracts(
+        strategy.runner.zksync_set_dual_compiled_contracts(
             strategy.context.as_mut(),
             dual_compiled_contracts.unwrap_or_default(),
         );

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -368,7 +368,10 @@ impl TestArgs {
         // Prepare the test builder.
         let config = Arc::new(config);
 
-        strategy.zksync_set_dual_compiled_contracts(dual_compiled_contracts.unwrap_or_default());
+        strategy.inner.zksync_set_dual_compiled_contracts(
+            strategy.context.as_mut(),
+            dual_compiled_contracts.unwrap_or_default(),
+        );
 
         let runner = MultiContractRunnerBuilder::new(config.clone())
             .set_debug(should_debug)

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -18,7 +18,7 @@ use foundry_config::Config;
 use foundry_evm::{
     backend::Backend,
     decode::RevertDecoder,
-    executors::{strategy::Strategy, ExecutorBuilder},
+    executors::{strategy::ExecutorStrategy, ExecutorBuilder},
     fork::CreateFork,
     inspectors::CheatsConfig,
     opts::EvmOpts,
@@ -85,7 +85,7 @@ pub struct MultiContractRunner {
     /// Library addresses used to link contracts.
     pub libraries: Libraries,
     /// Execution strategy.
-    pub strategy: Strategy,
+    pub strategy: ExecutorStrategy,
 }
 
 impl MultiContractRunner {
@@ -178,7 +178,7 @@ impl MultiContractRunner {
         trace!("running all tests");
 
         // The DB backend that serves all the data.
-        let db = Backend::spawn(self.fork.take(), self.strategy.inner.new_backend_strategy());
+        let db = Backend::spawn(self.fork.take(), self.strategy.runner.new_backend_strategy());
 
         let find_timer = Instant::now();
         let contracts = self.matching_contracts(filter).collect::<Vec<_>>();
@@ -250,7 +250,7 @@ impl MultiContractRunner {
             Some(self.known_contracts.clone()),
             Some(artifact_id.name.clone()),
             Some(artifact_id.version.clone()),
-            self.strategy.inner.new_cheatcode_inspector_strategy(self.strategy.context.as_ref()),
+            self.strategy.runner.new_cheatcode_inspector_strategy(self.strategy.context.as_ref()),
         );
 
         let trace_mode = TraceMode::default()
@@ -407,7 +407,7 @@ impl MultiContractRunnerBuilder {
         zk_output: Option<ZkProjectCompileOutput>,
         env: revm::primitives::Env,
         evm_opts: EvmOpts,
-        strategy: Strategy,
+        strategy: ExecutorStrategy,
     ) -> Result<MultiContractRunner> {
         let mut known_contracts = ContractsByArtifact::default();
         let output = output.with_stripped_file_prefixes(root);

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -18,7 +18,7 @@ use foundry_config::Config;
 use foundry_evm::{
     backend::Backend,
     decode::RevertDecoder,
-    executors::{strategy::ExecutorStrategy, ExecutorBuilder},
+    executors::{strategy::Strategy, ExecutorBuilder},
     fork::CreateFork,
     inspectors::CheatsConfig,
     opts::EvmOpts,
@@ -85,7 +85,7 @@ pub struct MultiContractRunner {
     /// Library addresses used to link contracts.
     pub libraries: Libraries,
     /// Execution strategy.
-    pub strategy: Box<dyn ExecutorStrategy>,
+    pub strategy: Strategy,
 }
 
 impl MultiContractRunner {
@@ -178,7 +178,7 @@ impl MultiContractRunner {
         trace!("running all tests");
 
         // The DB backend that serves all the data.
-        let db = Backend::spawn(self.fork.take(), self.strategy.new_backend_strategy());
+        let db = Backend::spawn(self.fork.take(), self.strategy.inner.new_backend_strategy());
 
         let find_timer = Instant::now();
         let contracts = self.matching_contracts(filter).collect::<Vec<_>>();
@@ -250,7 +250,7 @@ impl MultiContractRunner {
             Some(self.known_contracts.clone()),
             Some(artifact_id.name.clone()),
             Some(artifact_id.version.clone()),
-            self.strategy.new_cheatcode_inspector_strategy(),
+            self.strategy.inner.new_cheatcode_inspector_strategy(self.strategy.context.as_ref()),
         );
 
         let trace_mode = TraceMode::default()
@@ -270,7 +270,7 @@ impl MultiContractRunner {
             .spec(self.evm_spec)
             .gas_limit(self.evm_opts.gas_limit())
             .legacy_assertions(self.config.legacy_assertions)
-            .build(self.env.clone(), db, self.strategy.new_cloned());
+            .build(self.env.clone(), db, self.strategy.clone());
 
         if !enabled!(tracing::Level::TRACE) {
             span_name = get_contract_name(&identifier);
@@ -407,7 +407,7 @@ impl MultiContractRunnerBuilder {
         zk_output: Option<ZkProjectCompileOutput>,
         env: revm::primitives::Env,
         evm_opts: EvmOpts,
-        strategy: Box<dyn ExecutorStrategy>,
+        strategy: Strategy,
     ) -> Result<MultiContractRunner> {
         let mut known_contracts = ContractsByArtifact::default();
         let output = output.with_stripped_file_prefixes(root);

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -151,11 +151,7 @@ impl ContractRunner<'_> {
         // nonce.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
             debug!("test contract deployed");
-            cheatcodes
-                .strategy
-                .as_mut()
-                .expect("failed acquiring strategy")
-                .base_contract_deployed();
+            cheatcodes.strategy.inner.base_contract_deployed(cheatcodes.strategy.context.as_mut());
         }
 
         // Optionally call the `setUp` function

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -151,7 +151,7 @@ impl ContractRunner<'_> {
         // nonce.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
             debug!("test contract deployed");
-            cheatcodes.strategy.inner.base_contract_deployed(cheatcodes.strategy.context.as_mut());
+            cheatcodes.strategy.runner.base_contract_deployed(cheatcodes.strategy.context.as_mut());
         }
 
         // Optionally call the `setUp` function

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -3,7 +3,7 @@
 use alloy_chains::NamedChain;
 use alloy_primitives::U256;
 use forge::{
-    executors::strategy::EvmExecutorStrategy, revm::primitives::SpecId, MultiContractRunner,
+    executors::strategy::new_evm_strategy, revm::primitives::SpecId, MultiContractRunner,
     MultiContractRunnerBuilder, TestOptions, TestOptionsBuilder,
 };
 use foundry_cli::utils;
@@ -360,7 +360,9 @@ impl ForgeTestData {
         let sender = zk_config.sender;
 
         let mut strategy = utils::get_executor_strategy(&zk_config);
-        strategy.zksync_set_dual_compiled_contracts(dual_compiled_contracts);
+        strategy
+            .inner
+            .zksync_set_dual_compiled_contracts(strategy.context.as_mut(), dual_compiled_contracts);
         let mut builder = self.base_runner();
         builder.config = Arc::new(zk_config);
         builder
@@ -382,7 +384,7 @@ impl ForgeTestData {
                 None,
                 opts.local_evm_env(),
                 opts,
-                Box::new(EvmExecutorStrategy::default()),
+                new_evm_strategy(),
             )
             .unwrap()
     }
@@ -399,14 +401,7 @@ impl ForgeTestData {
 
         self.base_runner()
             .with_fork(fork)
-            .build(
-                self.project.root(),
-                self.output.clone(),
-                None,
-                env,
-                opts,
-                Box::new(EvmExecutorStrategy::default()),
-            )
+            .build(self.project.root(), self.output.clone(), None, env, opts, new_evm_strategy())
             .unwrap()
     }
 }

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -3,7 +3,7 @@
 use alloy_chains::NamedChain;
 use alloy_primitives::U256;
 use forge::{
-    executors::strategy::new_evm_strategy, revm::primitives::SpecId, MultiContractRunner,
+    executors::strategy::ExecutorStrategy, revm::primitives::SpecId, MultiContractRunner,
     MultiContractRunnerBuilder, TestOptions, TestOptionsBuilder,
 };
 use foundry_cli::utils;
@@ -384,7 +384,7 @@ impl ForgeTestData {
                 None,
                 opts.local_evm_env(),
                 opts,
-                new_evm_strategy(),
+                ExecutorStrategy::new_evm(),
             )
             .unwrap()
     }
@@ -401,7 +401,14 @@ impl ForgeTestData {
 
         self.base_runner()
             .with_fork(fork)
-            .build(self.project.root(), self.output.clone(), None, env, opts, new_evm_strategy())
+            .build(
+                self.project.root(),
+                self.output.clone(),
+                None,
+                env,
+                opts,
+                ExecutorStrategy::new_evm(),
+            )
             .unwrap()
     }
 }

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -361,7 +361,7 @@ impl ForgeTestData {
 
         let mut strategy = utils::get_executor_strategy(&zk_config);
         strategy
-            .inner
+            .runner
             .zksync_set_dual_compiled_contracts(strategy.context.as_mut(), dual_compiled_contracts);
         let mut builder = self.base_runner();
         builder.config = Arc::new(zk_config);

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -598,7 +598,7 @@ impl ScriptConfig {
                 Some(db) => db.clone(),
                 None => {
                     let fork = self.evm_opts.get_fork(&self.config, env.clone());
-                    let backend = Backend::spawn(fork, strategy.inner.new_backend_strategy());
+                    let backend = Backend::spawn(fork, strategy.runner.new_backend_strategy());
                     self.backends.insert(fork_url.clone(), backend.clone());
                     backend
                 }
@@ -607,7 +607,7 @@ impl ScriptConfig {
             // It's only really `None`, when we don't pass any `--fork-url`. And if so, there is
             // no need to cache it, since there won't be any onchain simulation that we'd need
             // to cache the backend for.
-            Backend::spawn(None, strategy.inner.new_backend_strategy())
+            Backend::spawn(None, strategy.runner.new_backend_strategy())
         };
 
         // We need to enable tracing to decode contract names: local or external.
@@ -624,13 +624,13 @@ impl ScriptConfig {
         if let Some((known_contracts, script_wallets, target, dual_compiled_contracts)) =
             cheats_data
         {
-            strategy.inner.zksync_set_dual_compiled_contracts(
+            strategy.runner.zksync_set_dual_compiled_contracts(
                 strategy.context.as_mut(),
                 dual_compiled_contracts,
             );
 
             if let Some(fork_url) = &self.evm_opts.fork_url {
-                strategy.inner.zksync_set_fork_env(strategy.context.as_mut(), fork_url, &env)?;
+                strategy.runner.zksync_set_fork_env(strategy.context.as_mut(), fork_url, &env)?;
             }
 
             builder = builder.inspectors(|stack| {
@@ -643,7 +643,7 @@ impl ScriptConfig {
                             Some(target.name),
                             Some(target.version),
                             strategy
-                                .inner
+                                .runner
                                 .new_cheatcode_inspector_strategy(strategy.context.as_ref()),
                         )
                         .into(),

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -598,7 +598,7 @@ impl ScriptConfig {
                 Some(db) => db.clone(),
                 None => {
                     let fork = self.evm_opts.get_fork(&self.config, env.clone());
-                    let backend = Backend::spawn(fork, strategy.new_backend_strategy());
+                    let backend = Backend::spawn(fork, strategy.inner.new_backend_strategy());
                     self.backends.insert(fork_url.clone(), backend.clone());
                     backend
                 }
@@ -607,7 +607,7 @@ impl ScriptConfig {
             // It's only really `None`, when we don't pass any `--fork-url`. And if so, there is
             // no need to cache it, since there won't be any onchain simulation that we'd need
             // to cache the backend for.
-            Backend::spawn(None, strategy.new_backend_strategy())
+            Backend::spawn(None, strategy.inner.new_backend_strategy())
         };
 
         // We need to enable tracing to decode contract names: local or external.
@@ -624,10 +624,13 @@ impl ScriptConfig {
         if let Some((known_contracts, script_wallets, target, dual_compiled_contracts)) =
             cheats_data
         {
-            strategy.zksync_set_dual_compiled_contracts(dual_compiled_contracts);
+            strategy.inner.zksync_set_dual_compiled_contracts(
+                strategy.context.as_mut(),
+                dual_compiled_contracts,
+            );
 
             if let Some(fork_url) = &self.evm_opts.fork_url {
-                strategy.zksync_set_fork_env(fork_url, &env)?;
+                strategy.inner.zksync_set_fork_env(strategy.context.as_mut(), fork_url, &env)?;
             }
 
             builder = builder.inspectors(|stack| {
@@ -639,7 +642,9 @@ impl ScriptConfig {
                             Some(known_contracts),
                             Some(target.name),
                             Some(target.version),
-                            strategy.new_cheatcode_inspector_strategy(),
+                            strategy
+                                .inner
+                                .new_cheatcode_inspector_strategy(strategy.context.as_ref()),
                         )
                         .into(),
                     )

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -174,11 +174,7 @@ impl ScriptRunner {
         // nonce.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
             debug!("script deployed");
-            cheatcodes
-                .strategy
-                .as_mut()
-                .expect("failed acquiring strategy")
-                .base_contract_deployed();
+            cheatcodes.strategy.inner.base_contract_deployed(cheatcodes.strategy.context.as_mut());
         }
 
         // Optionally call the `setUp` function

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -174,7 +174,7 @@ impl ScriptRunner {
         // nonce.
         if let Some(cheatcodes) = &mut self.executor.inspector.cheatcodes {
             debug!("script deployed");
-            cheatcodes.strategy.inner.base_contract_deployed(cheatcodes.strategy.context.as_mut());
+            cheatcodes.strategy.runner.base_contract_deployed(cheatcodes.strategy.context.as_mut());
         }
 
         // Optionally call the `setUp` function

--- a/crates/strategy/zksync/src/backend.rs
+++ b/crates/strategy/zksync/src/backend.rs
@@ -12,9 +12,8 @@ use foundry_evm_core::backend::{
     BackendInner, Fork, ForkDB, FoundryEvmInMemoryDB,
 };
 use foundry_zksync_core::{
-    convert::ConvertH160, PaymasterParams, ACCOUNT_CODE_STORAGE_ADDRESS,
-    IMMUTABLE_SIMULATOR_STORAGE_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS,
-    NONCE_HOLDER_ADDRESS,
+    convert::ConvertH160, ACCOUNT_CODE_STORAGE_ADDRESS, IMMUTABLE_SIMULATOR_STORAGE_ADDRESS,
+    KNOWN_CODES_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
 };
 use revm::{db::CacheDB, primitives::HashSet, DatabaseRef, JournaledState};
 use serde::{Deserialize, Serialize};

--- a/crates/strategy/zksync/src/executor.rs
+++ b/crates/strategy/zksync/src/executor.rs
@@ -195,7 +195,6 @@ impl ExecutorStrategyExt for ZksyncExecutorStrategy {
     ) {
         let ctx = get_context(ctx);
         ctx.dual_compiled_contracts = dual_compiled_contracts;
-        println!("SAVE {}", ctx.dual_compiled_contracts.len());
     }
 
     fn zksync_set_fork_env(

--- a/crates/strategy/zksync/src/executor.rs
+++ b/crates/strategy/zksync/src/executor.rs
@@ -2,12 +2,13 @@ use alloy_primitives::{Address, U256};
 use alloy_rpc_types::serde_helpers::OtherFields;
 use alloy_zksync::provider::{zksync_provider, ZksyncProvider};
 use eyre::Result;
-use foundry_cheatcodes::strategy::CheatcodeInspectorStrategy;
 
 use foundry_evm::{
-    backend::{strategy::BackendStrategy, BackendResult, DatabaseExt},
+    backend::{BackendResult, DatabaseExt},
     executors::{
-        strategy::{EvmExecutorStrategy, ExecutorStrategy, ExecutorStrategyExt},
+        strategy::{
+            EvmExecutorStrategy, ExecutorStrategy, ExecutorStrategyContext, ExecutorStrategyExt,
+        },
         Executor,
     },
     InspectorExt,
@@ -21,17 +22,44 @@ use revm::{
 use zksync_types::H256;
 
 use crate::{
-    cheatcode::ZKSYNC_TRANSACTION_OTHER_FIELDS_KEY, ZksyncBackendStrategy,
-    ZksyncCheatcodeInspectorStrategy,
+    backend::ZksyncBackendStrategyContext,
+    cheatcode::{ZksyncCheatcodeInspectorStrategyContext, ZKSYNC_TRANSACTION_OTHER_FIELDS_KEY},
+    ZksyncBackendStrategy, ZksyncCheatcodeInspectorStrategy,
 };
 
 #[derive(Debug, Default, Clone)]
-pub struct ZksyncExecutorStrategy {
-    evm: EvmExecutorStrategy,
+pub struct ZksyncExecutorStrategyContext {
     inspect_context: Option<ZkTransactionMetadata>,
     persisted_factory_deps: HashMap<H256, Vec<u8>>,
     dual_compiled_contracts: DualCompiledContracts,
     zk_env: ZkEnv,
+}
+
+impl ExecutorStrategyContext for ZksyncExecutorStrategyContext {
+    fn new_cloned(&self) -> Box<dyn ExecutorStrategyContext> {
+        Box::new(self.clone())
+    }
+
+    fn as_any_ref(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ZksyncExecutorStrategy {
+    evm: EvmExecutorStrategy,
+}
+
+fn get_context_ref(ctx: &dyn ExecutorStrategyContext) -> &ZksyncExecutorStrategyContext {
+    ctx.as_any_ref().downcast_ref().expect("expected ZksyncExecutorStrategyContext")
+}
+
+fn get_context(ctx: &mut dyn ExecutorStrategyContext) -> &mut ZksyncExecutorStrategyContext {
+    ctx.as_any_mut().downcast_mut().expect("expected ZksyncExecutorStrategyContext")
 }
 
 impl ExecutorStrategy for ZksyncExecutorStrategy {
@@ -43,13 +71,18 @@ impl ExecutorStrategy for ZksyncExecutorStrategy {
         Box::new(self.clone())
     }
 
-    fn set_inspect_context(&mut self, other_fields: OtherFields) {
+    fn set_inspect_context(
+        &self,
+        ctx: &mut dyn ExecutorStrategyContext,
+        other_fields: OtherFields,
+    ) {
+        let ctx = get_context(ctx);
         let maybe_context = get_zksync_transaction_metadata(&other_fields);
-        self.inspect_context = maybe_context;
+        ctx.inspect_context = maybe_context;
     }
 
     fn set_balance(
-        &mut self,
+        &self,
         executor: &mut Executor,
         address: Address,
         amount: U256,
@@ -63,7 +96,7 @@ impl ExecutorStrategy for ZksyncExecutorStrategy {
     }
 
     fn set_nonce(
-        &mut self,
+        &self,
         executor: &mut Executor,
         address: Address,
         nonce: u64,
@@ -81,45 +114,60 @@ impl ExecutorStrategy for ZksyncExecutorStrategy {
         Ok(())
     }
 
-    fn new_backend_strategy(&self) -> Box<dyn BackendStrategy> {
-        Box::new(ZksyncBackendStrategy::default())
+    fn new_backend_strategy(&self) -> foundry_evm_core::backend::strategy::Strategy {
+        foundry_evm_core::backend::strategy::Strategy {
+            inner: Box::new(ZksyncBackendStrategy::default()),
+            context: Box::new(ZksyncBackendStrategyContext::default()),
+        }
     }
 
-    fn new_cheatcode_inspector_strategy(&self) -> Box<dyn CheatcodeInspectorStrategy> {
-        Box::new(ZksyncCheatcodeInspectorStrategy::new(
-            self.dual_compiled_contracts.clone(),
-            self.zk_env.clone(),
-        ))
+    fn new_cheatcode_inspector_strategy(
+        &self,
+        ctx: &dyn ExecutorStrategyContext,
+    ) -> foundry_cheatcodes::strategy::Strategy {
+        let ctx = get_context_ref(ctx);
+        foundry_cheatcodes::strategy::Strategy {
+            inner: Box::new(ZksyncCheatcodeInspectorStrategy::default()),
+            context: Box::new(ZksyncCheatcodeInspectorStrategyContext::new(
+                ctx.dual_compiled_contracts.clone(),
+                ctx.zk_env.clone(),
+            )),
+        }
     }
 
     fn call_inspect(
         &self,
+        ctx: &dyn ExecutorStrategyContext,
         db: &mut dyn DatabaseExt,
         env: &mut EnvWithHandlerCfg,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<ResultAndState> {
-        match self.inspect_context.as_ref() {
-            None => self.evm.call_inspect(db, env, inspector),
+        let ctx_zk = get_context_ref(ctx);
+        match ctx_zk.inspect_context.as_ref() {
+            None => self.evm.call_inspect(ctx, db, env, inspector),
             Some(zk_tx) => foundry_zksync_core::vm::transact(
-                Some(&mut self.persisted_factory_deps.clone()),
+                Some(&mut ctx_zk.persisted_factory_deps.clone()),
                 Some(zk_tx.factory_deps.clone()),
                 zk_tx.paymaster_data.clone(),
                 env,
-                &self.zk_env,
+                &ctx_zk.zk_env,
                 db,
             ),
         }
     }
 
     fn transact_inspect(
-        &mut self,
+        &self,
+        ctx: &mut dyn ExecutorStrategyContext,
         db: &mut dyn DatabaseExt,
         env: &mut EnvWithHandlerCfg,
         executor_env: &EnvWithHandlerCfg,
         inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<ResultAndState> {
-        match self.inspect_context.take() {
-            None => self.evm.transact_inspect(db, env, executor_env, inspector),
+        let ctx_zk = get_context(ctx);
+
+        match ctx_zk.inspect_context.take() {
+            None => self.evm.transact_inspect(ctx, db, env, executor_env, inspector),
             Some(zk_tx) => {
                 // apply fork-related env instead of cheatcode handler
                 // since it won't be set by zkEVM
@@ -127,11 +175,11 @@ impl ExecutorStrategy for ZksyncExecutorStrategy {
                 env.tx.gas_price = executor_env.tx.gas_price;
 
                 foundry_zksync_core::vm::transact(
-                    Some(&mut self.persisted_factory_deps),
+                    Some(&mut ctx_zk.persisted_factory_deps),
                     Some(zk_tx.factory_deps),
                     zk_tx.paymaster_data,
                     env,
-                    &self.zk_env,
+                    &ctx_zk.zk_env,
                     db,
                 )
             }
@@ -141,13 +189,23 @@ impl ExecutorStrategy for ZksyncExecutorStrategy {
 
 impl ExecutorStrategyExt for ZksyncExecutorStrategy {
     fn zksync_set_dual_compiled_contracts(
-        &mut self,
+        &self,
+        ctx: &mut dyn ExecutorStrategyContext,
         dual_compiled_contracts: DualCompiledContracts,
     ) {
-        self.dual_compiled_contracts = dual_compiled_contracts;
+        let ctx = get_context(ctx);
+        ctx.dual_compiled_contracts = dual_compiled_contracts;
+        println!("SAVE {}", ctx.dual_compiled_contracts.len());
     }
 
-    fn zksync_set_fork_env(&mut self, fork_url: &str, env: &Env) -> Result<()> {
+    fn zksync_set_fork_env(
+        &self,
+        ctx: &mut dyn ExecutorStrategyContext,
+        fork_url: &str,
+        env: &Env,
+    ) -> Result<()> {
+        let ctx = get_context(ctx);
+
         let provider = zksync_provider().with_recommended_fillers().on_http(fork_url.parse()?);
         let block_number = env.block.number.try_into()?;
         // TODO(zk): switch to getFeeParams call when it is implemented for anvil-zksync
@@ -158,7 +216,7 @@ impl ExecutorStrategyExt for ZksyncExecutorStrategy {
         .flatten();
 
         if let Some(block_details) = maybe_block_details {
-            self.zk_env = ZkEnv {
+            ctx.zk_env = ZkEnv {
                 l1_gas_price: block_details
                     .l1_gas_price
                     .try_into()
@@ -191,4 +249,11 @@ pub fn get_zksync_transaction_metadata(
         .transpose()
         .ok()
         .flatten()
+}
+
+pub fn new_zkysnc_strategy() -> foundry_evm::executors::strategy::Strategy {
+    foundry_evm::executors::strategy::Strategy {
+        inner: Box::new(ZksyncExecutorStrategy::default()),
+        context: Box::new(ZksyncExecutorStrategyContext::default()),
+    }
 }

--- a/crates/strategy/zksync/src/lib.rs
+++ b/crates/strategy/zksync/src/lib.rs
@@ -11,4 +11,4 @@ mod executor;
 
 pub use backend::ZksyncBackendStrategy;
 pub use cheatcode::ZksyncCheatcodeInspectorStrategy;
-pub use executor::{get_zksync_transaction_metadata, ZksyncExecutorStrategy};
+pub use executor::{get_zksync_transaction_metadata, new_zkysnc_strategy, ZksyncExecutorStrategy};

--- a/crates/strategy/zksync/src/lib.rs
+++ b/crates/strategy/zksync/src/lib.rs
@@ -9,6 +9,8 @@ mod backend;
 mod cheatcode;
 mod executor;
 
-pub use backend::ZksyncBackendStrategy;
-pub use cheatcode::ZksyncCheatcodeInspectorStrategy;
-pub use executor::{get_zksync_transaction_metadata, new_zkysnc_strategy, ZksyncExecutorStrategy};
+pub use backend::ZksyncBackendStrategyRunner;
+pub use cheatcode::ZksyncCheatcodeInspectorStrategyRunner;
+pub use executor::{
+    get_zksync_transaction_metadata, ZksyncExecutorStrategyBuilder, ZksyncExecutorStrategyRunner,
+};

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -240,7 +240,7 @@ impl VerifyBytecodeArgs {
                 gen_blk_num,
                 etherscan_metadata.evm_version()?.unwrap_or(EvmVersion::default()),
                 evm_opts,
-                strategy.new_cloned(),
+                strategy.clone(),
             )
             .await?;
 
@@ -444,7 +444,7 @@ impl VerifyBytecodeArgs {
                 simulation_block - 1, // env.fork_block_number
                 etherscan_metadata.evm_version()?.unwrap_or(EvmVersion::default()),
                 evm_opts,
-                strategy.new_cloned(),
+                strategy.clone(),
             )
             .await?;
             env.block.number = U256::from(simulation_block);

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -14,7 +14,7 @@ use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVer
 use foundry_config::Config;
 use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
-    executors::{strategy::ExecutorStrategy, TracingExecutor},
+    executors::{strategy::Strategy, TracingExecutor},
     opts::EvmOpts,
 };
 use reqwest::Url;
@@ -325,7 +325,7 @@ pub async fn get_tracing_executor(
     fork_blk_num: u64,
     evm_version: EvmVersion,
     evm_opts: EvmOpts,
-    strategy: Box<dyn ExecutorStrategy>,
+    strategy: Strategy,
 ) -> Result<(Env, TracingExecutor)> {
     fork_config.fork_block_number = Some(fork_blk_num);
     fork_config.evm_version = evm_version;

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -14,7 +14,7 @@ use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVer
 use foundry_config::Config;
 use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
-    executors::{strategy::Strategy, TracingExecutor},
+    executors::{strategy::ExecutorStrategy, TracingExecutor},
     opts::EvmOpts,
 };
 use reqwest::Url;
@@ -325,7 +325,7 @@ pub async fn get_tracing_executor(
     fork_blk_num: u64,
     evm_version: EvmVersion,
     evm_opts: EvmOpts,
-    strategy: Strategy,
+    strategy: ExecutorStrategy,
 ) -> Result<(Env, TracingExecutor)> {
     fork_config.fork_block_number = Some(fork_blk_num);
     fork_config.evm_version = evm_version;

--- a/crates/zksync/compiler/src/zksolc/mod.rs
+++ b/crates/zksync/compiler/src/zksolc/mod.rs
@@ -299,4 +299,9 @@ impl DualCompiledContracts {
     pub fn push(&mut self, contract: DualCompiledContract) {
         self.contracts.push(contract);
     }
+
+    /// Retrieves the length of the collection.
+    pub fn len(&self) -> usize {
+        self.contracts.len()
+    }
 }

--- a/crates/zksync/compiler/src/zksolc/mod.rs
+++ b/crates/zksync/compiler/src/zksolc/mod.rs
@@ -304,4 +304,9 @@ impl DualCompiledContracts {
     pub fn len(&self) -> usize {
         self.contracts.len()
     }
+
+    /// Retrieves if the collection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.contracts.is_empty()
+    }
 }


### PR DESCRIPTION
# What :computer: 
* Fixes re-entrancy issue by separating the context from the strategy.
* `Strategy` is split into `Runner` and `Context`, which can be partially borrowed. 
* `Runner` implements all methods with immutable `&self` and takes the `&mut Context` to mutate.
* `Context` is implemented via `Any` and is downcastable and specific to each implementation.
* In places where `self` parameter is passed into the strategy objects:
  *  `&mut Context` may be omitted as it's available via `self.strategy.context`. 
  * The stateless `self.strategy.runner` can be cloned and dissociated from `self`: `self.strategy.runner.clone().foo(self)`.

# Why :hand:
* Required for re-entrancy

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->