### PR TITLE
feat: reintroduce backend.inspect

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -14,10 +14,13 @@ use alloy_rpc_types::TransactionRequest;
 use foundry_fork_db::DatabaseError;
 use revm::{
     db::DatabaseRef,
-    primitives::{Account, AccountInfo, Bytecode, Env, EnvWithHandlerCfg, HashMap as Map, SpecId},
+    primitives::{
+        Account, AccountInfo, Bytecode, Env, EnvWithHandlerCfg, HashMap as Map, ResultAndState,
+        SpecId,
+    },
     Database, DatabaseCommit, JournaledState,
 };
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{any::Any, borrow::Cow, collections::BTreeMap};
 
 /// A wrapper around `Backend` that ensures only `revm::DatabaseRef` functions are called.
 ///
@@ -51,6 +54,30 @@ impl<'a> CowBackend<'a> {
     /// Creates a new `CowBackend` with the given `Backend`.
     pub fn new(backend: &'a Backend) -> Self {
         Self { backend: Cow::Borrowed(backend), is_initialized: false, spec_id: SpecId::LATEST }
+    }
+
+    /// Executes the configured transaction of the `env` without committing state changes
+    ///
+    /// Note: in case there are any cheatcodes executed that modify the environment, this will
+    /// update the given `env` with the new values.
+    #[instrument(name = "inspect", level = "debug", skip_all)]
+    pub fn inspect<I: InspectorExt>(
+        &mut self,
+        env: &mut EnvWithHandlerCfg,
+        inspector: &mut I,
+        inspect_ctx: Box<dyn Any>,
+    ) -> eyre::Result<ResultAndState> {
+        // this is a new call to inspect with a new env, so even if we've cloned the backend
+        // already, we reset the initialized state
+        self.is_initialized = false;
+        self.spec_id = env.handler_cfg.spec_id;
+
+        self.backend.strategy.runner.clone().inspect(
+            self.backend.to_mut(),
+            env,
+            inspector,
+            inspect_ctx,
+        )
     }
 
     pub fn new_borrowed(backend: &'a Backend) -> Self {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -73,7 +73,7 @@ pub async fn send_transaction(
 ) -> Result<TxHash> {
     let zk_tx_meta =
         if let SendTransactionKind::Raw(tx, _) | SendTransactionKind::Unlocked(tx) = &mut kind {
-            foundry_strategy_zksync::try_get_zksync_transaction_context(&tx.other)
+            foundry_strategy_zksync::try_get_zksync_transaction_metadata(&tx.other)
         } else {
             None
         };

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -73,7 +73,7 @@ pub async fn send_transaction(
 ) -> Result<TxHash> {
     let zk_tx_meta =
         if let SendTransactionKind::Raw(tx, _) | SendTransactionKind::Unlocked(tx) = &mut kind {
-            foundry_strategy_zksync::get_zksync_transaction_metadata(&tx.other)
+            foundry_strategy_zksync::try_get_zksync_transaction_context(&tx.other)
         } else {
             None
         };

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -257,7 +257,10 @@ impl ScriptRunner {
         other_fields: Option<OtherFields>,
     ) -> Result<ScriptResult> {
         if let Some(other_fields) = other_fields {
-            self.executor.set_transaction_other_fields(other_fields);
+            self.executor.strategy.runner.zksync_set_transaction_context(
+                self.executor.strategy.context.as_mut(),
+                other_fields,
+            );
         }
 
         if let Some(to) = to {

--- a/crates/strategy/zksync/src/backend.rs
+++ b/crates/strategy/zksync/src/backend.rs
@@ -86,7 +86,7 @@ impl BackendStrategyRunner for ZksyncBackendStrategyRunner {
         inspector: &mut dyn InspectorExt,
         inspect_ctx: Box<dyn Any>,
     ) -> Result<ResultAndState> {
-        if !is_zksync_cainspect_context(&inspect_ctx) {
+        if !is_zksync_inspect_context(&inspect_ctx) {
             return self.evm.inspect(backend, env, inspector, inspect_ctx);
         }
 

--- a/crates/strategy/zksync/src/backend.rs
+++ b/crates/strategy/zksync/src/backend.rs
@@ -1,8 +1,13 @@
 use std::{any::Any, collections::hash_map::Entry};
 
 use alloy_primitives::{map::HashMap, Address, U256};
-use foundry_evm::backend::strategy::{
-    BackendStrategy, BackendStrategyContext, BackendStrategyRunnerExt,
+use eyre::Result;
+use foundry_evm::{
+    backend::{
+        strategy::{BackendStrategy, BackendStrategyContext, BackendStrategyRunnerExt},
+        Backend,
+    },
+    InspectorExt,
 };
 use foundry_evm_core::backend::{
     strategy::{
@@ -12,18 +17,37 @@ use foundry_evm_core::backend::{
     BackendInner, Fork, ForkDB, FoundryEvmInMemoryDB,
 };
 use foundry_zksync_core::{
-    convert::ConvertH160, ACCOUNT_CODE_STORAGE_ADDRESS, IMMUTABLE_SIMULATOR_STORAGE_ADDRESS,
-    KNOWN_CODES_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
+    convert::ConvertH160, vm::ZkEnv, PaymasterParams, ACCOUNT_CODE_STORAGE_ADDRESS,
+    IMMUTABLE_SIMULATOR_STORAGE_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS, L2_BASE_TOKEN_ADDRESS,
+    NONCE_HOLDER_ADDRESS,
 };
-use revm::{db::CacheDB, primitives::HashSet, DatabaseRef, JournaledState};
+use revm::{
+    db::CacheDB,
+    primitives::{EnvWithHandlerCfg, HashSet, ResultAndState},
+    DatabaseRef, JournaledState,
+};
 use serde::{Deserialize, Serialize};
 use tracing::trace;
+use zksync_types::H256;
+
+/// Represents additional data for ZK transactions.
+#[derive(Clone, Debug, Default)]
+pub struct ZksyncInspectContext {
+    /// Factory Deps for ZK transactions.
+    pub factory_deps: Vec<Vec<u8>>,
+    /// Paymaster data for ZK transactions.
+    pub paymaster_data: Option<PaymasterParams>,
+    /// Zksync environment.
+    pub zk_env: ZkEnv,
+}
 
 /// Context for [ZksyncBackendStrategyRunner].
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone)]
 pub struct ZksyncBackendStrategyContext {
     /// Store storage keys per contract address for immutable variables.
     persistent_immutable_keys: HashMap<Address, HashSet<U256>>,
+    /// Store persisted factory dependencies.
+    persisted_factory_deps: HashMap<H256, Vec<u8>>,
 }
 
 impl BackendStrategyContext for ZksyncBackendStrategyContext {
@@ -53,6 +77,32 @@ impl BackendStrategyRunner for ZksyncBackendStrategyRunner {
 
     fn new_cloned(&self) -> Box<dyn BackendStrategyRunner> {
         Box::new(self.clone())
+    }
+
+    fn inspect(
+        &self,
+        backend: &mut Backend,
+        env: &mut EnvWithHandlerCfg,
+        _inspector: &mut dyn InspectorExt,
+        inspect_ctx: Box<dyn Any>,
+    ) -> Result<ResultAndState> {
+        let mut persisted_factory_deps =
+            get_context(backend.strategy.context.as_mut()).persisted_factory_deps.clone();
+
+        let inspect_ctx = get_inspect_context(inspect_ctx);
+        let result = foundry_zksync_core::vm::transact(
+            Some(&mut persisted_factory_deps),
+            Some(inspect_ctx.factory_deps),
+            inspect_ctx.paymaster_data,
+            env,
+            &inspect_ctx.zk_env,
+            backend,
+        );
+
+        let ctx = get_context(backend.strategy.context.as_mut());
+        ctx.persisted_factory_deps = persisted_factory_deps;
+
+        result
     }
 
     /// When creating or switching forks, we update the AccountInfo of the contract.
@@ -366,4 +416,8 @@ impl ZksyncBackendMerge {
 
 fn get_context(ctx: &mut dyn BackendStrategyContext) -> &mut ZksyncBackendStrategyContext {
     ctx.as_any_mut().downcast_mut().expect("expected ZksyncBackendStrategyContext")
+}
+
+fn get_inspect_context(ctx: Box<dyn Any>) -> Box<ZksyncInspectContext> {
+    ctx.downcast().expect("expected ZksyncInspectContext")
 }

--- a/crates/strategy/zksync/src/backend.rs
+++ b/crates/strategy/zksync/src/backend.rs
@@ -86,7 +86,7 @@ impl BackendStrategyRunner for ZksyncBackendStrategyRunner {
         inspector: &mut dyn InspectorExt,
         inspect_ctx: Box<dyn Any>,
     ) -> Result<ResultAndState> {
-        if !is_zksync_inspect_context(&inspect_ctx) {
+        if !is_zksync_inspect_context(inspect_ctx.as_ref()) {
             return self.evm.inspect(backend, env, inspector, inspect_ctx);
         }
 

--- a/crates/strategy/zksync/src/cheatcode.rs
+++ b/crates/strategy/zksync/src/cheatcode.rs
@@ -34,7 +34,7 @@ use foundry_zksync_core::{
     vm::ZkEnv,
     PaymasterParams, ZkPaymasterData, ZkTransactionMetadata, ACCOUNT_CODE_STORAGE_ADDRESS,
     CONTRACT_DEPLOYER_ADDRESS, DEFAULT_CREATE2_DEPLOYER_ZKSYNC, H256, KNOWN_CODES_STORAGE_ADDRESS,
-    L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
+    L2_BASE_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS, ZKSYNC_TRANSACTION_OTHER_FIELDS_KEY,
 };
 use itertools::Itertools;
 use revm::{
@@ -54,9 +54,6 @@ use zksync_types::{
     utils::{decompose_full_nonce, nonces_to_full_nonce},
     CURRENT_VIRTUAL_BLOCK_INFO_POSITION, SYSTEM_CONTEXT_ADDRESS,
 };
-
-/// Key used to set transaction metadata in other fields.
-pub const ZKSYNC_TRANSACTION_OTHER_FIELDS_KEY: &str = "zksync";
 
 macro_rules! fmt_err {
     ($msg:literal $(,)?) => {

--- a/crates/strategy/zksync/src/executor.rs
+++ b/crates/strategy/zksync/src/executor.rs
@@ -232,12 +232,12 @@ impl ExecutorStrategyExt for ZksyncExecutorStrategyRunner {
         other_fields: OtherFields,
     ) {
         let ctx = get_context(ctx);
-        let transaction_context = try_get_zksync_transaction_context(&other_fields);
+        let transaction_context = try_get_zksync_transaction_metadata(&other_fields);
         ctx.transaction_context = transaction_context;
     }
 }
 
-pub fn try_get_zksync_transaction_context(
+pub fn try_get_zksync_transaction_metadata(
     other_fields: &OtherFields,
 ) -> Option<ZkTransactionMetadata> {
     other_fields

--- a/crates/strategy/zksync/src/lib.rs
+++ b/crates/strategy/zksync/src/lib.rs
@@ -12,5 +12,6 @@ mod executor;
 pub use backend::ZksyncBackendStrategyRunner;
 pub use cheatcode::ZksyncCheatcodeInspectorStrategyRunner;
 pub use executor::{
-    try_get_zksync_transaction_context, ZksyncExecutorStrategyBuilder, ZksyncExecutorStrategyRunner,
+    try_get_zksync_transaction_metadata, ZksyncExecutorStrategyBuilder,
+    ZksyncExecutorStrategyRunner,
 };

--- a/crates/strategy/zksync/src/lib.rs
+++ b/crates/strategy/zksync/src/lib.rs
@@ -12,5 +12,5 @@ mod executor;
 pub use backend::ZksyncBackendStrategyRunner;
 pub use cheatcode::ZksyncCheatcodeInspectorStrategyRunner;
 pub use executor::{
-    get_zksync_transaction_metadata, ZksyncExecutorStrategyBuilder, ZksyncExecutorStrategyRunner,
+    try_get_zksync_transaction_context, ZksyncExecutorStrategyBuilder, ZksyncExecutorStrategyRunner,
 };

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -84,6 +84,10 @@ pub struct ZkPaymasterData {
     pub input: Bytes,
 }
 
+/// Key used to set transaction metadata in other fields of [WithOtherFields<TransactionRequest>].
+/// This is used when broadcasting in a test, and when a script reads the broadcasted transactions.
+pub const ZKSYNC_TRANSACTION_OTHER_FIELDS_KEY: &str = "zksync";
+
 /// Represents additional data for ZK transactions.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
# What :computer: 
* Reintroduces `Backed::inspect` that was [previously](https://github.com/matter-labs/foundry-zksync/pull/781/files#diff-e258baeeb7d2b9b22b21a0ac880919e2cc0bc4163a07624df515c61c577ec0cdL824) removed due to re-entrancy issues.
* An additional `inspect_ctx: Box<dyn Any>` is now added to `Backend::inspect` to tightly couple any zk-specific data we'd need to pass. 
  * It's not set in `ctx` as it must **not** be persisted beyond the call (and also immediately used), which isn't guaranteed due to the additional indirection via `Backend::inspect`.
  * Additionally, we cannot modify a `CowBackend` to set `inspect_ctx` on the inner backend context as it will always clone the `&Backend` immediately.
  * The issues above are solvable by inlining `inspect` calls directly in executor (as was done previously) but then we diverge from foundry code.

# Why :hand:
* Stay close to foundry code.

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->