### PR TITLE
refactor: Move custom cheatcode logic into a generic handler

### DIFF
--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -15,7 +15,9 @@ impl Cheatcode for clearMockedCallsCall {
 impl Cheatcode for mockCall_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { callee, data, returnData } = self;
-        ccx.state.strategy.runner.clone().cheatcode_mock_call(ccx, *callee, data, returnData)
+        let _ = make_acc_non_empty(callee, ccx.ecx)?;
+        mock_call(ccx.state, callee, data, None, returnData, InstructionResult::Return);
+        Ok(Default::default())
     }
 }
 
@@ -83,7 +85,10 @@ impl Cheatcode for mockCalls_1Call {
 impl Cheatcode for mockCallRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { callee, data, revertData } = self;
-        ccx.state.strategy.runner.clone().cheatcode_mock_call_revert(ccx, *callee, data, revertData)
+
+        let _ = make_acc_non_empty(callee, ccx.ecx)?;
+        mock_call(ccx.state, callee, data, None, revertData, InstructionResult::Revert);
+        Ok(Default::default())
     }
 }
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -283,7 +283,7 @@ impl Cheatcode for getArtifactPathByDeployedCodeCall {
 impl Cheatcode for getCodeCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { artifactPath: path } = self;
-        state.strategy.runner.get_artifact_code(state, path, false)
+        Ok(get_artifact_code(state, path, false)?.abi_encode())
     }
 }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2256,7 +2256,8 @@ fn apply_dispatch(
     }
 
     // Apply the cheatcode.
-    let mut result = cheat.dyn_apply(ccx, executor);
+    let runner = ccx.state.strategy.runner.new_cloned();
+    let mut result = runner.apply_full(cheat, ccx, executor);
 
     // Format the error message to include the cheatcode name.
     if let Err(e) = &mut result {

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -96,12 +96,14 @@ pub(crate) trait Cheatcode: CheatcodeDef + DynCheatcode {
     }
 }
 
-pub(crate) trait DynCheatcode: 'static {
+pub trait DynCheatcode: 'static + std::any::Any {
     fn cheatcode(&self) -> &'static spec::Cheatcode<'static>;
 
     fn as_debug(&self) -> &dyn std::fmt::Debug;
 
     fn dyn_apply(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result;
+
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 impl<T: Cheatcode> DynCheatcode for T {
@@ -118,6 +120,11 @@ impl<T: Cheatcode> DynCheatcode for T {
     #[inline]
     fn dyn_apply(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
         self.apply_full(ccx, executor)
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/crates/cheatcodes/src/strategy.rs
+++ b/crates/cheatcodes/src/strategy.rs
@@ -1,21 +1,18 @@
 use std::{any::Any, fmt::Debug, sync::Arc};
 
-use alloy_primitives::{Address, Bytes, FixedBytes, TxKind, U256};
+use alloy_primitives::{Address, TxKind};
 use alloy_rpc_types::{TransactionInput, TransactionRequest};
-use alloy_sol_types::SolValue;
 use foundry_evm_core::backend::LocalForkId;
 use revm::{
-    interpreter::{CallInputs, CallOutcome, CreateOutcome, InstructionResult, Interpreter},
-    primitives::{Bytecode, SignedAuthorization, KECCAK_EMPTY},
+    interpreter::{CallInputs, CallOutcome, CreateOutcome, Interpreter},
+    primitives::SignedAuthorization,
 };
 
 use crate::{
-    evm::{self, journaled_account, mock::make_acc_non_empty, DealRecord},
     inspector::{check_if_fixed_gas_limit, CommonCreateInput, Ecx, InnerEcx},
-    mock_call,
     script::Broadcast,
     BroadcastableTransaction, BroadcastableTransactions, Cheatcodes, CheatcodesExecutor,
-    CheatsConfig, CheatsCtxt, Result,
+    CheatsConfig, CheatsCtxt, DynCheatcode, Result,
 };
 
 /// Represents the context for [CheatcodeInspectorStrategy].
@@ -73,129 +70,17 @@ pub trait CheatcodeInspectorStrategyRunner:
 
     fn new_cloned(&self) -> Box<dyn CheatcodeInspectorStrategyRunner>;
 
-    /// Get nonce.
-    fn get_nonce(&self, ccx: &mut CheatsCtxt, address: Address) -> Result<u64> {
-        let account = ccx.ecx.journaled_state.load_account(address, &mut ccx.ecx.db)?;
-        Ok(account.info.nonce)
+    fn apply_full(
+        &self,
+        cheatcode: &dyn DynCheatcode,
+        ccx: &mut CheatsCtxt,
+        executor: &mut dyn CheatcodesExecutor,
+    ) -> Result {
+        cheatcode.dyn_apply(ccx, executor)
     }
 
     /// Called when the main test or script contract is deployed.
     fn base_contract_deployed(&self, _ctx: &mut dyn CheatcodeInspectorStrategyContext) {}
-
-    /// Cheatcode: roll.
-    fn cheatcode_roll(&self, ccx: &mut CheatsCtxt, new_height: U256) -> Result {
-        ccx.ecx.env.block.number = new_height;
-        Ok(Default::default())
-    }
-
-    /// Cheatcode: warp.
-    fn cheatcode_warp(&self, ccx: &mut CheatsCtxt, new_timestamp: U256) -> Result {
-        ccx.ecx.env.block.timestamp = new_timestamp;
-        Ok(Default::default())
-    }
-
-    /// Cheatcode: deal.
-    fn cheatcode_deal(&self, ccx: &mut CheatsCtxt, address: Address, new_balance: U256) -> Result {
-        let account = journaled_account(ccx.ecx, address)?;
-        let old_balance = std::mem::replace(&mut account.info.balance, new_balance);
-        let record = DealRecord { address, old_balance, new_balance };
-        ccx.state.eth_deals.push(record);
-        Ok(Default::default())
-    }
-
-    /// Cheatcode: etch.
-    fn cheatcode_etch(
-        &self,
-        ccx: &mut CheatsCtxt,
-        target: Address,
-        new_runtime_bytecode: &Bytes,
-    ) -> Result {
-        ensure_not_precompile!(&target, ccx);
-        ccx.ecx.load_account(target)?;
-        let bytecode = Bytecode::new_raw(Bytes::copy_from_slice(new_runtime_bytecode));
-        ccx.ecx.journaled_state.set_code(target, bytecode);
-        Ok(Default::default())
-    }
-
-    /// Cheatcode: getNonce.
-    fn cheatcode_get_nonce(&self, ccx: &mut CheatsCtxt, address: Address) -> Result {
-        evm::get_nonce(ccx, &address)
-    }
-
-    /// Cheatcode: resetNonce.
-    fn cheatcode_reset_nonce(&self, ccx: &mut CheatsCtxt, account: Address) -> Result {
-        let account = journaled_account(ccx.ecx, account)?;
-        // Per EIP-161, EOA nonces start at 0, but contract nonces
-        // start at 1. Comparing by code_hash instead of code
-        // to avoid hitting the case where account's code is None.
-        let empty = account.info.code_hash == KECCAK_EMPTY;
-        let nonce = if empty { 0 } else { 1 };
-        account.info.nonce = nonce;
-        debug!(target: "cheatcodes", nonce, "reset");
-        Ok(Default::default())
-    }
-
-    /// Cheatcode: setNonce.
-    fn cheatcode_set_nonce(
-        &self,
-        ccx: &mut CheatsCtxt,
-        account: Address,
-        new_nonce: u64,
-    ) -> Result {
-        let account = journaled_account(ccx.ecx, account)?;
-        // nonce must increment only
-        let current = account.info.nonce;
-        ensure!(
-            new_nonce >= current,
-            "new nonce ({new_nonce}) must be strictly equal to or higher than the \
-             account's current nonce ({current})"
-        );
-        account.info.nonce = new_nonce;
-        Ok(Default::default())
-    }
-
-    /// Cheatcode: setNonceUnsafe.
-    fn cheatcode_set_nonce_unsafe(
-        &self,
-        ccx: &mut CheatsCtxt,
-        account: Address,
-        new_nonce: u64,
-    ) -> Result {
-        let account = journaled_account(ccx.ecx, account)?;
-        account.info.nonce = new_nonce;
-        Ok(Default::default())
-    }
-
-    /// Mocks a call to return with a value.
-    fn cheatcode_mock_call(
-        &self,
-        ccx: &mut CheatsCtxt,
-        callee: Address,
-        data: &Bytes,
-        return_data: &Bytes,
-    ) -> Result {
-        let _ = make_acc_non_empty(&callee, ccx.ecx)?;
-        mock_call(ccx.state, &callee, data, None, return_data, InstructionResult::Return);
-        Ok(Default::default())
-    }
-
-    /// Mocks a call to revert with a value.
-    fn cheatcode_mock_call_revert(
-        &self,
-        ccx: &mut CheatsCtxt,
-        callee: Address,
-        data: &Bytes,
-        revert_data: &Bytes,
-    ) -> Result {
-        let _ = make_acc_non_empty(&callee, ccx.ecx)?;
-        mock_call(ccx.state, &callee, data, None, revert_data, InstructionResult::Revert);
-        Ok(Default::default())
-    }
-
-    /// Retrieve artifact code.
-    fn get_artifact_code(&self, state: &Cheatcodes, path: &str, deployed: bool) -> Result {
-        Ok(crate::fs::get_artifact_code(state, path, deployed)?.abi_encode())
-    }
 
     /// Record broadcastable transaction during CREATE.
     fn record_broadcastable_create_transactions(
@@ -242,53 +127,6 @@ pub trait CheatcodeInspectorStrategyRunner:
 
 /// We define this in our fork
 pub trait CheatcodeInspectorStrategyExt {
-    fn zksync_cheatcode_skip_zkvm(
-        &self,
-        _ctx: &mut dyn CheatcodeInspectorStrategyContext,
-    ) -> Result {
-        Ok(Default::default())
-    }
-
-    fn zksync_cheatcode_set_paymaster(
-        &self,
-        _ctx: &mut dyn CheatcodeInspectorStrategyContext,
-        _paymaster_address: Address,
-        _paymaster_input: &Bytes,
-    ) -> Result {
-        Ok(Default::default())
-    }
-
-    fn zksync_cheatcode_use_factory_deps(
-        &self,
-        _ctx: &mut dyn CheatcodeInspectorStrategyContext,
-        _name: String,
-    ) -> Result {
-        Ok(Default::default())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn zksync_cheatcode_register_contract(
-        &self,
-        _ctx: &mut dyn CheatcodeInspectorStrategyContext,
-        _name: String,
-        _zk_bytecode_hash: FixedBytes<32>,
-        _zk_deployed_bytecode: Vec<u8>,
-        _zk_factory_deps: Vec<Vec<u8>>,
-        _evm_bytecode_hash: FixedBytes<32>,
-        _evm_deployed_bytecode: Vec<u8>,
-        _evm_bytecode: Vec<u8>,
-    ) -> Result {
-        Ok(Default::default())
-    }
-
-    fn zksync_cheatcode_select_zk_vm(
-        &self,
-        _ctx: &mut dyn CheatcodeInspectorStrategyContext,
-        _data: InnerEcx,
-        _enable: bool,
-    ) {
-    }
-
     fn zksync_record_create_address(
         &self,
         _ctx: &mut dyn CheatcodeInspectorStrategyContext,

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -12,67 +12,42 @@ pub(crate) mod assume;
 pub(crate) mod expect;
 
 impl Cheatcode for zkVmCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        let Self { enable } = *self;
-
-        ccx.state.strategy.runner.zksync_cheatcode_select_zk_vm(
-            ccx.state.strategy.context.as_mut(),
-            ccx.ecx,
-            enable,
-        );
-
+    fn apply_stateful(&self, _ccx: &mut CheatsCtxt) -> Result {
+        // Does nothing by default.
+        // ZK-related logic is implemented in the corresponding strategy object.
         Ok(Default::default())
     }
 }
 
 impl Cheatcode for zkVmSkipCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        ccx.state.strategy.runner.zksync_cheatcode_skip_zkvm(ccx.state.strategy.context.as_mut())
+    fn apply_stateful(&self, _ccx: &mut CheatsCtxt) -> Result {
+        // Does nothing by default.
+        // ZK-related logic is implemented in the corresponding strategy object.
+        Ok(Default::default())
     }
 }
 
 impl Cheatcode for zkUsePaymasterCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        let Self { paymaster_address, paymaster_input } = self;
-        ccx.state.strategy.runner.zksync_cheatcode_set_paymaster(
-            ccx.state.strategy.context.as_mut(),
-            *paymaster_address,
-            paymaster_input,
-        )
+    fn apply_stateful(&self, _ccx: &mut CheatsCtxt) -> Result {
+        // Does nothing by default.
+        // ZK-related logic is implemented in the corresponding strategy object.
+        Ok(Default::default())
     }
 }
 
 impl Cheatcode for zkUseFactoryDepCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        let Self { name } = self;
-        ccx.state
-            .strategy
-            .runner
-            .zksync_cheatcode_use_factory_deps(ccx.state.strategy.context.as_mut(), name.clone())
+    fn apply_stateful(&self, _ccx: &mut CheatsCtxt) -> Result {
+        // Does nothing by default.
+        // ZK-related logic is implemented in the corresponding strategy object.
+        Ok(Default::default())
     }
 }
 
 impl Cheatcode for zkRegisterContractCall {
-    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        let Self {
-            name,
-            evmBytecodeHash,
-            evmDeployedBytecode,
-            evmBytecode,
-            zkBytecodeHash,
-            zkDeployedBytecode,
-        } = self;
-
-        ccx.state.strategy.runner.zksync_cheatcode_register_contract(
-            ccx.state.strategy.context.as_mut(),
-            name.clone(),
-            zkBytecodeHash.0.into(),
-            zkDeployedBytecode.to_vec(),
-            vec![], //TODO: add argument to cheatcode
-            *evmBytecodeHash,
-            evmDeployedBytecode.to_vec(),
-            evmBytecode.to_vec(),
-        )
+    fn apply_stateful(&self, _ccx: &mut CheatsCtxt) -> Result {
+        // Does nothing by default.
+        // ZK-related logic is implemented in the corresponding strategy object.
+        Ok(Default::default())
     }
 }
 


### PR DESCRIPTION
# What :computer: 

Creates a generic handler for cheat codes that wraps custom execution logic.

# Why :hand:

It is more generic than a static set of methods in a trait. Reduces the diff with upstream.

# Evidence :camera:

Trust me bro.