### PR TITLE
feat: Add binary attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
     permissions:
       # Required to post the release
       contents: write
+      # For attestations
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -155,6 +158,7 @@ jobs:
               file "$bin" || true
               ldd "$bin" || true
               $bin --version || true
+              echo "${name}_bin_path=${bin}" >> $GITHUB_ENV
           done
 
       - name: Archive binaries
@@ -204,6 +208,13 @@ jobs:
           files: |
             ${{ steps.artifacts.outputs.file_name }}
             ${{ steps.man.outputs.foundry_man }}
+
+      - name: Binaries attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            ${{ env.cast_bin_path }}
+            ${{ env.forge_bin_path }}
 
       # If this is a nightly release, it also updates the release
       # tagged `nightly` for compatibility with `foundryup`


### PR DESCRIPTION
# What :computer: 

Adds binary attestations for releases (for now, only for binaries).
See [action](https://github.com/actions/attest-build-provenance)

# Why :hand:

Allows to verify the validity of the binary. See [gh attestation verify](https://cli.github.com/manual/gh_attestation_verify)

Upstream [also does attestations](https://github.com/foundry-rs/foundry/attestations) and the implementation is taken from upstream as well.
