### PR TITLE
fix: retrieve zks_getBytecodeByHash from SharedBackend when forking

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_genesis::GenesisAccount;
 use alloy_network::{AnyRpcBlock, AnyTxEnvelope, TransactionResponse};
-use alloy_primitives::{keccak256, map::HashMap, uint, Address, B256, U256};
+use alloy_primitives::{keccak256, map::HashMap, uint, Address, Bytes, B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockNumberOrTag, Transaction, TransactionRequest};
 use eyre::Context;
@@ -1626,8 +1626,9 @@ impl Database for Backend {
             let provider = try_get_zksync_http_provider(fork_url)
                 .map_err(|err| DatabaseError::AnyRequest(Arc::new(err)))?;
             let result = db.db.do_any_request(async move {
-                let bytes: alloy_primitives::Bytes =
-                    provider.raw_request("zks_getBytecodeByHash".into(), vec![code_hash]).await?;
+                let bytes = provider
+                    .raw_request::<_, Bytes>("zks_getBytecodeByHash".into(), vec![code_hash])
+                    .await?;
                 Ok(Bytecode::new_raw(bytes))
             });
 

--- a/crates/forge/tests/it/zk/fork.rs
+++ b/crates/forge/tests/it/zk/fork.rs
@@ -20,3 +20,11 @@ async fn test_zk_immutable_vars_persist_after_fork() {
 
     TestConfig::with_filter(runner, filter).spec_id(SpecId::SHANGHAI).run().await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zk_consistent_storage_migration_after_fork() {
+    let runner = TEST_DATA_DEFAULT.runner_zksync();
+    let filter = Filter::new(".*", "ZkForkStorageMigrationTest", ".*");
+
+    TestConfig::with_filter(runner, filter).spec_id(SpecId::SHANGHAI).run().await;
+}

--- a/testdata/zk/Fork.t.sol
+++ b/testdata/zk/Fork.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+import {Globals} from "./Globals.sol";
+
+contract Store {
+    uint256 a;
+
+    constructor() payable {}
+
+    function set(uint256 _a) public {
+        a = _a;
+    }
+
+    function get() public view returns (uint256) {
+        return a;
+    }
+}
+
+interface ERC20 {
+    function decimals() external returns (uint8);
+}
+
+contract ZkForkStorageMigrationTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    uint256 constant ETH_FORK_BLOCK = 19225195;
+    uint256 constant ERA_FORK_BLOCK = 48517149;
+
+    uint256 forkEth;
+    uint256 forkEra;
+
+    // Wrapped native token addresses from https://docs.uniswap.org/contracts/v3/reference/deployments/
+    address uniswapEth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address uniswapEra = 0x5AEa5775959fBC2557Cc8789bC1bf90A239D9a91;
+
+    function setUp() public {
+        forkEra = vm.createFork(Globals.ZKSYNC_MAINNET_URL, ERA_FORK_BLOCK);
+        forkEth = vm.createFork(Globals.ETHEREUM_MAINNET_URL, ETH_FORK_BLOCK);
+    }
+
+    function testForkMigrationExecutesChainNativeCalls() public {
+        // assert we have switched to ethereum
+        vm.selectFork(forkEth);
+        assertEq(18, ERC20(uniswapEth).decimals());
+
+        // assert we have switched to era
+        vm.selectFork(forkEra);
+        assertEq(18, ERC20(uniswapEra).decimals());
+    }
+
+    function testForkMigrationConsistentBalanceAfterForkToZkEvm() public {
+        // assert we have switched to ethereum
+        vm.selectFork(forkEth);
+        assertEq(18, ERC20(uniswapEth).decimals());
+
+        // deploy on EVM
+        Store store = new Store{value: 1 ether}();
+        store.set(10);
+        vm.makePersistent(address(store));
+
+        // assert we have switched to era
+        vm.selectFork(forkEra);
+        assertEq(18, ERC20(uniswapEra).decimals());
+
+        // assert balance on zkEVM
+        assertEq(1 ether, address(store).balance);
+    }
+
+    function testForkMigrationConsistentBalanceAfterForkToEvm() public {
+        // assert we have switched to era
+        vm.selectFork(forkEra);
+        assertEq(18, ERC20(uniswapEra).decimals());
+
+        // deploy on zkEVM
+        Store store = new Store{value: 1 ether}();
+        store.set(10);
+        vm.makePersistent(address(store));
+
+        // assert we have switched to ethereum
+        vm.selectFork(forkEth);
+        assertEq(18, ERC20(uniswapEth).decimals());
+
+        // assert balance on EVM
+        assertEq(1 ether, address(store).balance);
+    }
+
+    function testForkMigrationConsistentContractCallsAfterForkToZkEvm() public {
+        // assert we have switched to ethereum
+        vm.selectFork(forkEth);
+        assertEq(18, ERC20(uniswapEth).decimals());
+
+        // deploy on EVM
+        Store store = new Store{value: 1 ether}();
+        store.set(10);
+        vm.makePersistent(address(store));
+
+        // assert we have switched to era
+        vm.selectFork(forkEra);
+        assertEq(18, ERC20(uniswapEra).decimals());
+
+        // assert contract calls on zkEVM
+        assertEq(10, store.get());
+    }
+
+    function testForkMigrationConsistentContractCallsAfterForkToEvm() public {
+        // assert we have switched to era
+        vm.selectFork(forkEra);
+        assertEq(18, ERC20(uniswapEra).decimals());
+
+        // deploy on zkEVM
+        Store store = new Store{value: 1 ether}();
+        store.set(10);
+        vm.makePersistent(address(store));
+
+        // assert we have switched to ethereum
+        vm.selectFork(forkEth);
+        assertEq(18, ERC20(uniswapEth).decimals());
+
+        // assert contract calls on EVM
+        assertEq(10, store.get());
+    }
+}


### PR DESCRIPTION
# What :computer: 
* When removing the custom fork of `foundry-fork-db` we introduced a regression in retrieving the code by hash https://github.com/foundry-rs/foundry-fork-db/commit/402d191fa5c4d12a003f5dca0e5c32611c3476f7#diff-2c068b77d24467c86dd276124445d84fa48752b9c38e5f444a54f7a27ea2e0e7R873
* Adds a test case for verifying that the forks can execute on-chain contracts, and storage migration is performed for EVM <> zkEVM.

# Why :hand:
* When removing the custom fork of `foundry-fork-db` we introduced a regression in retrieving the code by hash https://github.com/foundry-rs/foundry-fork-db/commit/402d191fa5c4d12a003f5dca0e5c32611c3476f7#diff-2c068b77d24467c86dd276124445d84fa48752b9c38e5f444a54f7a27ea2e0e7R873
* Currently no test existed for correctly verifying the forked logic with on-chain constructs and the storage migration.

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->