### PR TITLE
fix: resolves issues with installing anvil-zksync with rosetta

### DIFF
--- a/foundryup-zksync/foundryup-zksync
+++ b/foundryup-zksync/foundryup-zksync
@@ -192,6 +192,10 @@ EOF
         "Darwin")
             os="apple-darwin"
             arch=$(arch)
+            if [[ "$arch" == "i386" ]]; then
+              # Rosetta reports as i386, but we treat it as x86_64
+              arch="x86_64"
+            fi
             ;;
         *)
             err "anvil-zksync only supports Linux and MacOS! Detected OS: $uname_str"


### PR DESCRIPTION
# What :computer: 
* Updates script to account for `i386` detected arch

# Why :hand:
* Users running with rosetta get "Unsupported architecture" error, this resolves the issue 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
