### PR TITLE
feat: Removing `detect_missing_libraries` arg 

### DIFF
--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -82,12 +82,6 @@ pub struct ZkSyncArgs {
     )]
     pub fallback_oz: Option<bool>,
 
-    /// Detect missing libraries, instead of erroring
-    ///
-    /// Currently unused
-    #[clap(long = "zk-detect-missing-libraries")]
-    pub detect_missing_libraries: bool,
-
     /// Set the LLVM optimization parameter `-O[0 | 1 | 2 | 3 | s | z]`.
     /// Use `3` for best performance and `z` for minimal size.
     #[clap(
@@ -164,10 +158,6 @@ impl ZkSyncArgs {
         set_if_some!(self.llvm_options.clone(), zksync.llvm_options);
         set_if_some!(self.force_evmla, zksync.force_evmla);
         set_if_some!(self.fallback_oz, zksync.fallback_oz);
-        set_if_some!(
-            self.detect_missing_libraries.then_some(true),
-            zksync.detect_missing_libraries
-        );
 
         set_if_some!(self.optimizer.then_some(true), zksync.optimizer);
         set_if_some!(

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -59,10 +59,6 @@ pub struct ZkSyncConfig {
     pub force_evmla: bool,
 
     pub llvm_options: Vec<String>,
-    /// Detect missing libraries, instead of erroring
-    ///
-    /// Currently unused
-    pub detect_missing_libraries: bool,
 
     /// Enable optimizer for zkSync
     pub optimizer: bool,
@@ -91,7 +87,6 @@ impl Default for ZkSyncConfig {
             fallback_oz: Default::default(),
             enable_eravm_extensions: Default::default(),
             force_evmla: Default::default(),
-            detect_missing_libraries: Default::default(),
             llvm_options: Default::default(),
             optimizer: true,
             optimizer_mode: '3',
@@ -137,7 +132,6 @@ impl ZkSyncConfig {
             via_ir: Some(via_ir),
             // Set in project paths.
             remappings: Vec::new(),
-            detect_missing_libraries: self.detect_missing_libraries,
             enable_eravm_extensions: self.enable_eravm_extensions,
             force_evmla: self.force_evmla,
             llvm_options: self.llvm_options.clone(),

--- a/crates/zksync/compilers/src/compilers/zksolc/settings.rs
+++ b/crates/zksync/compilers/src/compilers/zksolc/settings.rs
@@ -109,10 +109,6 @@ pub struct ZkSettings {
     #[serde(default)]
     /// Libraries
     pub libraries: Libraries,
-    /// Switch to missing deployable libraries detection mode.
-    /// Contracts are not compiled in this mode, and all compilation artifacts are not included.
-    #[serde(default, rename = "detectMissingLibraries")]
-    pub detect_missing_libraries: bool,
     // zksolc arguments
     /// A flag indicating whether to enable the system contract compilation mode.
     /// Whether to enable EraVM extensions.
@@ -204,7 +200,6 @@ impl Default for ZkSettings {
             via_ir: None,
             libraries: Default::default(),
             remappings: Default::default(),
-            detect_missing_libraries: false,
             enable_eravm_extensions: false,
             llvm_options: Default::default(),
             force_evmla: false,
@@ -244,7 +239,6 @@ impl CompilerSettings for ZkSolcSettings {
                     optimizer,
                     metadata,
                     libraries,
-                    detect_missing_libraries,
                     enable_eravm_extensions,
                     llvm_options,
                     force_evmla,
@@ -262,7 +256,6 @@ impl CompilerSettings for ZkSolcSettings {
             *optimizer == other.settings.optimizer &&
             *metadata == other.settings.metadata &&
             *libraries == other.settings.libraries &&
-            *detect_missing_libraries == other.settings.detect_missing_libraries &&
             *enable_eravm_extensions == other.settings.enable_eravm_extensions &&
             *llvm_options == other.settings.llvm_options &&
             *force_evmla == other.settings.force_evmla &&


### PR DESCRIPTION
# What :computer: 
There are a couple of reasons for removing the arg:
1. This has not worked as expected since we started working on the Solc linking because of (2).
2. The missing libraries are always reported in another format on the output, and you can see them using `--json` (if any)
3. This arg will be removed entirely in the following weeks when we move to version 1.5.8; see [this](https://github.com/matter-labs/foundry-zksync/pull/800/files#diff-6bfe52bab6561edc6796c117419f60e77a296656bda5c199be3f3cf54354249eL403) for more info

# Why :hand:
See https://github.com/matter-labs/foundry-zksync/issues/722#issuecomment-2578813094

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.