### PR TITLE
fix: Respect priority fee and max fee per gas for broadcasting txs with scripts

### DIFF
--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -286,7 +286,7 @@ async fn cast_send_zk<P: Provider<T, AnyNetwork>, Z: ZksyncProvider<T>, T: Trans
         zk_tx.set_paymaster_params(paymaster_params);
     }
 
-    foundry_zksync_core::estimate_gas(&mut zk_tx, &zk_provider).await?;
+    foundry_zksync_core::estimate_gas(&mut zk_tx, &zk_provider, 130).await?;
 
     let cast = ZkCast::new(zk_provider, Cast::new(provider));
     let pending_tx = cast.send_zk(zk_tx).await?;

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -286,7 +286,7 @@ async fn cast_send_zk<P: Provider<T, AnyNetwork>, Z: ZksyncProvider<T>, T: Trans
         zk_tx.set_paymaster_params(paymaster_params);
     }
 
-    foundry_zksync_core::estimate_gas(&mut zk_tx, &zk_provider, 130).await?;
+    foundry_zksync_core::estimate_fee(&mut zk_tx, &zk_provider, 130).await?;
 
     let cast = ZkCast::new(zk_provider, Cast::new(provider));
     let pending_tx = cast.send_zk(zk_tx).await?;

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -286,7 +286,7 @@ async fn cast_send_zk<P: Provider<T, AnyNetwork>, Z: ZksyncProvider<T>, T: Trans
         zk_tx.set_paymaster_params(paymaster_params);
     }
 
-    foundry_zksync_core::estimate_fee(&mut zk_tx, &zk_provider, 130).await?;
+    foundry_zksync_core::estimate_fee(&mut zk_tx, &zk_provider, 130, None).await?;
 
     let cast = ZkCast::new(zk_provider, Cast::new(provider));
     let pending_tx = cast.send_zk(zk_tx).await?;

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -692,7 +692,7 @@ impl CreateArgs {
         deployer.tx.set_gas_price(gas_price);
 
         // estimate fee
-        foundry_zksync_core::estimate_gas(&mut deployer.tx, &provider, 130).await?;
+        foundry_zksync_core::estimate_fee(&mut deployer.tx, &provider, 130).await?;
 
         if !is_legacy {
             let estimate = provider.estimate_eip1559_fees(None).await.wrap_err("Failed to estimate EIP1559 fees. This chain might not support EIP1559, try adding --legacy to your command.")?;

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -692,7 +692,7 @@ impl CreateArgs {
         deployer.tx.set_gas_price(gas_price);
 
         // estimate fee
-        foundry_zksync_core::estimate_fee(&mut deployer.tx, &provider, 130).await?;
+        foundry_zksync_core::estimate_fee(&mut deployer.tx, &provider, 130, None).await?;
 
         if !is_legacy {
             let estimate = provider.estimate_eip1559_fees(None).await.wrap_err("Failed to estimate EIP1559 fees. This chain might not support EIP1559, try adding --legacy to your command.")?;

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -692,7 +692,7 @@ impl CreateArgs {
         deployer.tx.set_gas_price(gas_price);
 
         // estimate fee
-        foundry_zksync_core::estimate_gas(&mut deployer.tx, &provider).await?;
+        foundry_zksync_core::estimate_gas(&mut deployer.tx, &provider, 130).await?;
 
         if !is_legacy {
             let estimate = provider.estimate_eip1559_fees(None).await.wrap_err("Failed to estimate EIP1559 fees. This chain might not support EIP1559, try adding --legacy to your command.")?;

--- a/crates/forge/tests/fixtures/zk/Gas.s.sol
+++ b/crates/forge/tests/fixtures/zk/Gas.s.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Script} from "forge-std/Script.sol";
+import {Greeter} from "src/Greeter.sol";
+
+contract GasScript is Script {
+    function run() public {
+        vm.startBroadcast();
+        Greeter greeter = new Greeter();
+        vm.stopBroadcast();
+    }
+}

--- a/crates/forge/tests/it/zk/gas.rs
+++ b/crates/forge/tests/it/zk/gas.rs
@@ -1,0 +1,69 @@
+use foundry_test_utils::{forgetest_async, util, TestProject};
+
+use foundry_test_utils::{util::OutputExt, ZkSyncNode};
+
+forgetest_async!(script_execution_with_gas_price, |prj, cmd| {
+    setup_gas_prj(&mut prj);
+
+    let node = ZkSyncNode::start().await;
+    let url = node.url();
+
+    cmd.forge_fuse();
+
+    let private_key =
+        ZkSyncNode::rich_wallets().next().map(|(_, pk, _)| pk).expect("No rich wallets available");
+
+    let script_args = vec![
+        "--zk-startup",
+        "./script/Gas.s.sol",
+        "--private-key",
+        &private_key,
+        "--chain",
+        "260",
+        "--rpc-url",
+        url.as_str(),
+        "--slow",
+        "--evm-version",
+        "shanghai",
+        "-vvvvv",
+        "--broadcast",
+        "--with-gas-price",
+        "370000037",
+        "--priority-gas-price",
+        "123123",
+    ];
+
+    cmd.arg("script").args(&script_args);
+
+    let stdout = cmd.assert_success().get_output().stdout_lossy();
+    assert!(stdout.contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL"));
+
+    let run_latest = foundry_common::fs::json_files(prj.root().join("broadcast").as_path())
+        .find(|file| file.ends_with("run-latest.json"))
+        .expect("No broadcast artifacts");
+
+    let json: serde_json::Value =
+        serde_json::from_str(&foundry_common::fs::read_to_string(run_latest).unwrap()).unwrap();
+
+    assert_eq!(json["transactions"].as_array().expect("broadcastable txs").len(), 1);
+
+    let transaction_hash = json["receipts"][0]["transactionHash"].as_str().unwrap();
+    let stdout = cmd
+        .cast_fuse()
+        .arg("tx")
+        .arg(transaction_hash)
+        .arg("--rpc-url")
+        .arg(url.as_str())
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("maxFeePerGas         370000037"));
+    assert!(stdout.contains("maxPriorityFeePerGas 123123"));
+});
+
+fn setup_gas_prj(prj: &mut TestProject) {
+    util::initialize(prj.root());
+    prj.add_script("Gas.s.sol", include_str!("../../fixtures/zk/Gas.s.sol")).unwrap();
+    prj.add_source("Greeter.sol", include_str!("../../../../../testdata/zk/Greeter.sol")).unwrap();
+}

--- a/crates/forge/tests/it/zk/gas.rs
+++ b/crates/forge/tests/it/zk/gas.rs
@@ -70,6 +70,28 @@ forgetest_async!(zk_script_execution_with_gas_multiplier, |prj, cmd| {
     assert!(stdout.contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL"));
 });
 
+forgetest_async!(zk_script_execution_with_gas_per_pubdata, |prj, cmd| {
+    // Setup
+    setup_gas_prj(&mut prj);
+    let node = ZkSyncNode::start().await;
+    let url = node.url();
+    cmd.forge_fuse();
+    let private_key = get_rich_wallet_key();
+
+    // Test with unacceptable gas per pubdata (should fail)
+    let zero_pubdata_args = create_script_args(&private_key, &url, "--zk-gas-per-pubdata", "1");
+    cmd.arg("script").args(&zero_pubdata_args);
+    cmd.assert_failure();
+    cmd.forge_fuse();
+
+    // Test with sufficient gas per pubdata (should succeed)
+    let sufficient_pubdata_args =
+        create_script_args(&private_key, &url, "--zk-gas-per-pubdata", "3000");
+    cmd.arg("script").args(&sufficient_pubdata_args);
+    let stdout = cmd.assert_success().get_output().stdout_lossy();
+    assert!(stdout.contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL"));
+});
+
 fn get_rich_wallet_key() -> String {
     ZkSyncNode::rich_wallets()
         .next()

--- a/crates/forge/tests/it/zk/gas.rs
+++ b/crates/forge/tests/it/zk/gas.rs
@@ -2,7 +2,7 @@ use foundry_test_utils::{forgetest_async, util, TestProject};
 
 use foundry_test_utils::{util::OutputExt, ZkSyncNode};
 
-forgetest_async!(script_execution_with_gas_price, |prj, cmd| {
+forgetest_async!(zk_script_execution_with_gas_price_specified_by_user, |prj, cmd| {
     setup_gas_prj(&mut prj);
 
     let node = ZkSyncNode::start().await;
@@ -23,8 +23,6 @@ forgetest_async!(script_execution_with_gas_price, |prj, cmd| {
         "--rpc-url",
         url.as_str(),
         "--slow",
-        "--evm-version",
-        "shanghai",
         "-vvvvv",
         "--broadcast",
         "--with-gas-price",

--- a/crates/forge/tests/it/zk/mod.rs
+++ b/crates/forge/tests/it/zk/mod.rs
@@ -10,6 +10,7 @@ mod factory;
 mod factory_deps;
 mod fork;
 mod fuzz;
+mod gas;
 mod invariant;
 mod linking;
 mod logs;

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -70,6 +70,7 @@ pub async fn send_transaction(
     is_fixed_gas_limit: bool,
     estimate_via_rpc: bool,
     estimate_multiplier: u64,
+    gas_per_pubdata: Option<u64>,
 ) -> Result<TxHash> {
     let zk_tx_meta =
         if let SendTransactionKind::Raw(tx, _) | SendTransactionKind::Unlocked(tx) = &mut kind {
@@ -141,8 +142,14 @@ pub async fn send_transaction(
                         },
                     );
                 }
-                foundry_zksync_core::estimate_fee(&mut zk_tx, &zk_provider, estimate_multiplier)
-                    .await?;
+
+                foundry_zksync_core::estimate_fee(
+                    &mut zk_tx,
+                    &zk_provider,
+                    estimate_multiplier,
+                    gas_per_pubdata,
+                )
+                .await?;
 
                 let zk_signer = alloy_zksync::wallet::ZksyncWallet::new(signer.default_signer());
                 let signed = zk_tx.build(&zk_signer).await?.encoded_2718();
@@ -440,6 +447,7 @@ impl BundledState {
                             *is_fixed_gas_limit,
                             estimate_via_rpc,
                             self.args.gas_estimate_multiplier,
+                            self.args.gas_per_pubdata,
                         );
                         pending_transactions.push(fut);
                     }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -447,7 +447,7 @@ impl BundledState {
                             *is_fixed_gas_limit,
                             estimate_via_rpc,
                             self.args.gas_estimate_multiplier,
-                            self.args.gas_per_pubdata,
+                            self.args.zk_gas_per_pubdata,
                         );
                         pending_transactions.push(fut);
                     }

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -217,6 +217,10 @@ pub struct ScriptArgs {
 
     #[command(flatten)]
     pub retry: RetryArgs,
+
+    /// Gas per pubdata
+    #[clap(long = "zk-gas-per-pubdata", value_name = "GAS_PER_PUBDATA")]
+    pub zk_gas_per_pubdata: Option<u64>,
 }
 
 impl ScriptArgs {

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -135,15 +135,20 @@ pub async fn estimate_fee<P: ZksyncProvider<T>, T: Transport + Clone>(
     tx: &mut ZkTransactionRequest,
     provider: P,
     estimate_multiplier: u64,
+    gas_per_pubdata: Option<u64>,
 ) -> Result<()> {
     let fee = provider.estimate_fee(tx.clone()).await?;
     tx.set_gas_limit(fee.gas_limit * estimate_multiplier / 100);
     // If user provided a gas price, use it for both maxFeePerGas
     let max_fee = tx.max_fee_per_gas().unwrap_or(fee.max_fee_per_gas);
     let max_priority_fee = tx.max_priority_fee_per_gas().unwrap_or(fee.max_priority_fee_per_gas);
+    let gas_per_pubdata = match gas_per_pubdata {
+        Some(value) => rU256::from(value),
+        None => fee.gas_per_pubdata_limit,
+    };
     tx.set_max_fee_per_gas(max_fee);
     tx.set_max_priority_fee_per_gas(max_priority_fee);
-    tx.set_gas_per_pubdata(fee.gas_per_pubdata_limit);
+    tx.set_gas_per_pubdata(gas_per_pubdata);
 
     Ok(())
 }

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -131,7 +131,7 @@ pub struct EstimatedGas {
 
 /// Estimates the gas parameters for the provided transaction.
 /// This will call `estimateFee` method on the rpc and set the gas parameters on the transaction.
-pub async fn estimate_gas<P: ZksyncProvider<T>, T: Transport + Clone>(
+pub async fn estimate_fee<P: ZksyncProvider<T>, T: Transport + Clone>(
     tx: &mut ZkTransactionRequest,
     provider: P,
     estimate_multiplier: u64,
@@ -139,12 +139,8 @@ pub async fn estimate_gas<P: ZksyncProvider<T>, T: Transport + Clone>(
     let fee = provider.estimate_fee(tx.clone()).await?;
     tx.set_gas_limit(fee.gas_limit * estimate_multiplier / 100);
     // If user provided a gas price, use it for both maxFeePerGas
-    let max_fee = tx
-        .max_fee_per_gas()
-        .map_or(fee.max_fee_per_gas * (estimate_multiplier as u128) / 100, |price| price);
-    let max_priority_fee = tx
-        .max_priority_fee_per_gas()
-        .map_or(fee.max_priority_fee_per_gas * (estimate_multiplier as u128) / 100, |price| price);
+    let max_fee = tx.max_fee_per_gas().unwrap_or(fee.max_fee_per_gas);
+    let max_priority_fee = tx.max_priority_fee_per_gas().unwrap_or(fee.max_priority_fee_per_gas);
     tx.set_max_fee_per_gas(max_fee);
     tx.set_max_priority_fee_per_gas(max_priority_fee);
     tx.set_gas_per_pubdata(fee.gas_per_pubdata_limit);


### PR DESCRIPTION
# What :computer: 
* Use priority fee and max fee per gas when users set it instead of overwriting it with the estimation

# Why :hand:
* We should let the users hardcode their values just as Foundry does. 

# Evidence :camera:
Added a new test retrieving the tx data and asserting over it. Test passes

# Documentation :books:
Please ensure the following before submitting your PR:

- [ x ] Check if these changes affect any documented features or workflows.
- [ x ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.
[Book Update PR](https://github.com/matter-labs/foundry-zksync-book/pull/69)
