### PR TITLE
fix: use cross for builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,53 +103,35 @@ jobs:
           - runner: macos-latest
             target: x86_64-apple-darwin
             svm_target_platform: macosx-amd64
-            platform: darwin
+            platform: macos-latest
             arch: amd64
           - runner: macos-latest
             target: aarch64-apple-darwin
             svm_target_platform: macosx-aarch64
-            platform: darwin
+            platform: macos-latest
             arch: arm64
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || '' }}
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install required Rust targets
-        run: rustup target add ${{ matrix.target }}
-
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
           cache-on-failure: true
 
-      - name: Apple M1 setup
-        if: matrix.target == 'aarch64-apple-darwin'
-        run: |
-          brew install make
-          echo "PATH=/usr/local/opt/make/libexec/gnubin:$PATH" >> $GITHUB_ENV
-          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+      - name: Install required Rust targets
+        run: rustup target add ${{ matrix.target }}
 
-      - name: Apple Darwin
-        if: matrix.target == 'x86_64-apple-darwin'
-        run: |
-          brew install make
-          echo "PATH=/usr/local/opt/make/libexec/gnubin:$PATH" >> $GITHUB_ENV
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      
+      - name: Install cross v0.2.5 from source
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
-      - name: Linux ARM setup
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "C_INCLUDE_PATH=/usr/aarch64-linux-gnu/include" >> $GITHUB_ENV
-          echo "CPLUS_INCLUDE_PATH=/usr/aarch64-linux-gnu/include" >> $GITHUB_ENV
 
+      # We diverge from upstream and build with cross as we're building static binaries
       - name: Build binaries
         env:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
@@ -165,7 +147,7 @@ jobs:
           #     flags+=(--features asm-keccak)
           # fi
 
-          RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --bin forge --bin cast --target "$target" "${flags[@]}"
+          RUSTFLAGS='-C target-feature=+crt-static' OPENSSL_STATIC=1 cross build --release --bin forge --bin cast --target "$target" "${flags[@]}"
 
           bins=(cast forge)
           for name in "${bins[@]}"; do

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,19 @@
+[target.x86_64-unknown-linux-gnu]
+image = "ubuntu:24.04"
+pre-build = [
+    "export DEBIAN_FRONTEND=noninteractive",
+    "export TZ=Etc/UTC",
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt update -q && apt upgrade -yq",
+    "apt install --assume-yes --no-install-recommends libclang-14-dev clang-14 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-14-dev gnutls-bin",
+    "apt install -y gcc-11 g++-11",
+    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11",
+    "update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11"
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "export DEBIAN_FRONTEND=noninteractive",
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update -q && apt-get install --assume-yes --no-install-recommends libssl-dev:$CROSS_DEB_ARCH pkg-config",
+]

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -210,7 +210,7 @@ impl VerifyBundle {
 
             let contract_bytecode_hash = foundry_zksync_core::hash_bytecode(bytecode);
             if bytecode_hash == contract_bytecode_hash {
-                if artifact.source.extension().map_or(false, |e| e.to_str() == Some("vy")) {
+                if artifact.source.extension().is_some_and(|e| e.to_str() == Some("vy")) {
                     warn!("Skipping verification of Vyper contract: {}", artifact.name);
                 }
 

--- a/crates/zksync/compilers/tests/zksync_tests.rs
+++ b/crates/zksync/compilers/tests/zksync_tests.rs
@@ -496,7 +496,7 @@ contract Util {}
     assert!(compiled.output().errors.iter().any(|error| error
         .formatted_message
         .as_ref()
-        .map_or(false, |msg| msg.contains("File outside of allowed directories"))));
+        .is_some_and(|msg| msg.contains("File outside of allowed directories"))));
 }
 
 #[test]


### PR DESCRIPTION
# What :computer: 
* Use cross for builds.

# Why :hand:
* Building static binaries does not work for `aarch64` on `linux` as there's not native github hosted runner.

# Evidence :camera:
https://github.com/matter-labs/foundry-zksync/actions/runs/12931632743/job/36065983713?pr=860

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
