### PR TITLE
fix: release artifact names and tags

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,7 +36,7 @@ jobs:
 
   # Trigger workflow to generate artifacts
   release:
-    # if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,7 +36,7 @@ jobs:
 
   # Trigger workflow to generate artifacts
   release:
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    # if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,9 +10,6 @@ permissions:
 
 # Run the workflow on push to the main branch and manually
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -40,8 +37,6 @@ jobs:
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:
-      tag: foundry-zksync-v0.0.4
-      version: "0.0.4"
-      # tag: ${{ needs.release-please.outputs.tag_name }}
-      # version: ${{ (needs.release-please.outputs.tag_name && format('{0}.{1}.{2}', needs.release-please.outputs.major, needs.release-please.outputs.minor, needs.release-please.outputs.patch)) || ''}}
+      tag: ${{ needs.release-please.outputs.tag_name }}
+      version: ${{ (needs.release-please.outputs.tag_name && format('{0}.{1}.{2}', needs.release-please.outputs.major, needs.release-please.outputs.minor, needs.release-please.outputs.patch)) || ''}}
     secrets: inherit

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -33,7 +33,7 @@ jobs:
 
   # Trigger workflow to generate artifacts
   release:
-    # if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -40,6 +40,8 @@ jobs:
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:
-      tag: ${{ needs.release-please.outputs.tag_name }}
-      version: ${{ (needs.release-please.outputs.tag_name && format('{0}.{1}.{2}', needs.release-please.outputs.major, needs.release-please.outputs.minor, needs.release-please.outputs.patch)) || ''}}
+      tag: foundry-zksync-v0.0.4
+      version: "0.0.4"
+      # tag: ${{ needs.release-please.outputs.tag_name }}
+      # version: ${{ (needs.release-please.outputs.tag_name && format('{0}.{1}.{2}', needs.release-please.outputs.major, needs.release-please.outputs.minor, needs.release-please.outputs.patch)) || ''}}
     secrets: inherit

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -41,5 +41,5 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
-      version: "${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}"
+      version: ${{ (needs.release-please.outputs.tag_name && format('{0}.{1}.{2}', needs.release-please.outputs.major, needs.release-please.outputs.minor, needs.release-please.outputs.patch)) || ''}}
     secrets: inherit

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -40,8 +40,6 @@ jobs:
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:
-      # tag: ${{ needs.release-please.outputs.tag_name }}
-      # version: "${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}"
-      tag: foundry-zksync-v0.0.4
-      version: "0.0.4"
+      tag: ${{ needs.release-please.outputs.tag_name }}
+      version: "${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}"
     secrets: inherit

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,10 +36,12 @@ jobs:
 
   # Trigger workflow to generate artifacts
   release:
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    # if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:
-      tag: ${{ needs.release-please.outputs.tag_name }}
-      version: "${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}"
+      # tag: ${{ needs.release-please.outputs.tag_name }}
+      # version: "${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}"
+      tag: foundry-zksync-v0.0.4
+      version: "0.0.4"
     secrets: inherit

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,6 +10,9 @@ permissions:
 
 # Run the workflow on push to the main branch and manually
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -38,4 +41,5 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+      version: "${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,26 +72,26 @@ jobs:
       # This tag is used for this specific nightly version's release
       # which allows users to roll back. It is also used to build
       # the changelog.
-      # - name: Create build-specific tag (nightly)
-      #   if: ${{ env.IS_NIGHTLY == 'true' }}
-      #   uses: actions/github-script@v7
-      #   env:
-      #     TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
-      #   with:
-      #     script: |
-      #       const createTag = require('./.github/scripts/create-tag.js')
-      #       await createTag({ github, context }, process.env.TAG_NAME)
+      - name: Create build-specific tag (nightly)
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
+        with:
+          script: |
+            const createTag = require('./.github/scripts/create-tag.js')
+            await createTag({ github, context }, process.env.TAG_NAME)
 
-      # - name: Build changelog (nightly)
-      #   if: ${{ env.IS_NIGHTLY == 'true' }}
-      #   id: build_changelog
-      #   uses: mikepenz/release-changelog-builder-action@v4
-      #   with:
-      #     configuration: "./.github/changelog.json"
-      #     fromTag: 'nightly'
-      #     toTag: ${{ steps.release_info.outputs.tag_name }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build changelog (nightly)
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: "./.github/changelog.json"
+          fromTag: 'nightly'
+          toTag: ${{ steps.release_info.outputs.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: ${{ matrix.target }} (${{ matrix.runner }})
@@ -137,20 +137,20 @@ jobs:
         with:
           ref: ${{ inputs.tag || '' }}
 
-      # - uses: Swatinem/rust-cache@v2
-      #   with:
-      #     key: ${{ matrix.target }}
-      #     cache-on-failure: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+          cache-on-failure: true
 
-      # - name: Install required Rust targets
-      #   run: rustup target add ${{ matrix.target }}
+      - name: Install required Rust targets
+        run: rustup target add ${{ matrix.target }}
 
-      # - uses: dtolnay/rust-toolchain@stable
-      #   with:
-      #     targets: ${{ matrix.target }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       
-      # - name: Install cross v0.2.5 from source
-      #   run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
+      - name: Install cross v0.2.5 from source
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       # We diverge from upstream and build with cross as we're building static binaries
       - name: Build binaries
@@ -158,9 +158,9 @@ jobs:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
         shell: bash
         run: |
-          # set -eo pipefail
-          # target="${{ matrix.target }}"
-          # flags=()
+          set -eo pipefail
+          target="${{ matrix.target }}"
+          flags=()
 
           # Disable asm-keccak, see https://github.com/alloy-rs/core/issues/711
           # # Remove jemalloc, only keep `asm-keccak` if applicable
@@ -168,16 +168,16 @@ jobs:
           #     flags+=(--features asm-keccak)
           # fi
 
-          # RUSTFLAGS='-C target-feature=+crt-static' OPENSSL_STATIC=1 cross build --release --bin forge --bin cast --target "$target" "${flags[@]}"
+          RUSTFLAGS='-C target-feature=+crt-static' OPENSSL_STATIC=1 cross build --release --bin forge --bin cast --target "$target" "${flags[@]}"
 
-          # bins=(cast forge)
-          # for name in "${bins[@]}"; do
-          #     bin=./target/$target/release/$name
-          #     file "$bin" || true
-          #     ldd "$bin" || true
-          #     $bin --version || true
-          #     echo "${name}_bin_path=${bin}" >> $GITHUB_ENV
-          # done
+          bins=(cast forge)
+          for name in "${bins[@]}"; do
+              bin=./target/$target/release/$name
+              file "$bin" || true
+              ldd "$bin" || true
+              $bin --version || true
+              echo "${name}_bin_path=${bin}" >> $GITHUB_ENV
+          done
 
       - name: Archive binaries
         id: artifacts
@@ -189,76 +189,74 @@ jobs:
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
-              # tar -czvf "foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-              # echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-              echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+              tar -czvf "foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+              echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
           elif [ "$PLATFORM_NAME" == "darwin" ]; then
               # We need to use gtar here otherwise the archive is corrupt.
               # See: https://github.com/actions/virtual-environments/issues/2619
-              # gtar -czvf "foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-              # echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-              echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+              gtar -czvf "foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+              echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
           fi
 
-      # - name: Build man page
-      #   id: man
-      #   if: matrix.target == 'x86_64-unknown-linux-gnu'
-      #   env:
-      #     PLATFORM_NAME: ${{ matrix.platform }}
-      #     TARGET: ${{ matrix.target }}
-      #     VERSION_NAME: ${{ needs.prepare.outputs.version_name }}
-      #   shell: bash
-      #   run: |
-      #     sudo apt-get -y install help2man
-      #     help2man -N ./target/${TARGET}/release/forge > forge.1
-      #     help2man -N ./target/${TARGET}/release/cast > cast.1
-      #     gzip forge.1
-      #     gzip cast.1
-      #     tar -czvf "foundry_man_${VERSION_NAME}.tar.gz" forge.1.gz cast.1.gz
-      #     echo "foundry_man=foundry_man_${VERSION_NAME}.tar.gz" >> $GITHUB_OUTPUT
+      - name: Build man page
+        id: man
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        env:
+          PLATFORM_NAME: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
+          VERSION_NAME: ${{ needs.prepare.outputs.version_name }}
+        shell: bash
+        run: |
+          sudo apt-get -y install help2man
+          help2man -N ./target/${TARGET}/release/forge > forge.1
+          help2man -N ./target/${TARGET}/release/cast > cast.1
+          gzip forge.1
+          gzip cast.1
+          tar -czvf "foundry_man_${VERSION_NAME}.tar.gz" forge.1.gz cast.1.gz
+          echo "foundry_man=foundry_man_${VERSION_NAME}.tar.gz" >> $GITHUB_OUTPUT
 
       # Creates the release for this specific version
-      # - name: Create release
-      #   if: ${{ inputs.tag == '' }}
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     name: ${{ needs.prepare.outputs.release_name }}
-      #     tag_name: ${{ needs.prepare.outputs.tag_name }}
-      #     prerelease: ${{ needs.prepare.outputs.prerelease }}
-      #     body: ${{ needs.prepare.outputs.changelog }}
-      #     files: |
-      #       ${{ steps.artifacts.outputs.file_name }}
-      #       ${{ steps.man.outputs.foundry_man }}
+      - name: Create release
+        if: ${{ inputs.tag == '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ needs.prepare.outputs.release_name }}
+          tag_name: ${{ needs.prepare.outputs.tag_name }}
+          prerelease: ${{ needs.prepare.outputs.prerelease }}
+          body: ${{ needs.prepare.outputs.changelog }}
+          files: |
+            ${{ steps.artifacts.outputs.file_name }}
+            ${{ steps.man.outputs.foundry_man }}
 
-      # - name: Update release-please release artifacts
-      #   if: ${{ inputs.tag != '' }}
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     tag_name: ${{ inputs.tag }}
-      #     files: |
-      #       ${{ steps.artifacts.outputs.file_name }}
-      #       ${{ steps.man.outputs.foundry_man }}
+      - name: Update release-please release artifacts
+        if: ${{ inputs.tag != '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            ${{ steps.artifacts.outputs.file_name }}
+            ${{ steps.man.outputs.foundry_man }}
 
-      # - name: Binaries attestation
-      #   uses: actions/attest-build-provenance@v2
-      #   with:
-      #     subject-path: |
-      #       ${{ env.cast_bin_path }}
-      #       ${{ env.forge_bin_path }}
+      - name: Binaries attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            ${{ env.cast_bin_path }}
+            ${{ env.forge_bin_path }}
 
-      # # If this is a nightly release, it also updates the release
-      # # tagged `nightly` for compatibility with `foundryup`
-      # - name: Update nightly release
-      #   if: ${{ env.IS_NIGHTLY == 'true' }}
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     name: "Nightly foundry-zksync"
-      #     tag_name: "nightly"
-      #     prerelease: true
-      #     body: ${{ needs.prepare.outputs.changelog }}
-      #     files: |
-      #       ${{ steps.artifacts.outputs.file_name }}
-      #       ${{ steps.man.outputs.foundry_man }}
+      # If this is a nightly release, it also updates the release
+      # tagged `nightly` for compatibility with `foundryup`
+      - name: Update nightly release
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Nightly foundry-zksync"
+          tag_name: "nightly"
+          prerelease: true
+          body: ${{ needs.prepare.outputs.changelog }}
+          files: |
+            ${{ steps.artifacts.outputs.file_name }}
+            ${{ steps.man.outputs.foundry_man }}
 
   retry-on-failure:
     if: failure() && fromJSON(github.run_attempt) < 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,10 @@ jobs:
           
       - name: Print release info
         run: |
-            echo tag_name: ${{ steps.release_info.outputs.tag_name }}
-            echo version_name: ${{ steps.release_info.outputs.version_name }}
-            echo release_name: ${{ steps.release_info.outputs.release_name }}
-            echo prerelease: ${{ steps.release_info.outputs.prerelease }}
+            echo tag_name: "${{ steps.release_info.outputs.tag_name }}"
+            echo version_name: "${{ steps.release_info.outputs.version_name }}"
+            echo release_name: "${{ steps.release_info.outputs.release_name }}"
+            echo prerelease: "${{ steps.release_info.outputs.prerelease }}"
 
       # Creates a `nightly-SHA` tag for this specific nightly
       # This tag is used for this specific nightly version's release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,11 @@ jobs:
 
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
             echo "version_name=v${VERSION}" >> $GITHUB_OUTPUT
-            echo "release_name=foundry-zksync ${VERSION}" >> $GITHUB_OUTPUT
+            echo "release_name=foundry-zksync v${VERSION}" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
           
-      - name: Print outputs
+      - name: Print release info
         run: |
             echo tag_name: ${{ steps.release_info.outputs.tag_name }}
             echo version_name: ${{ steps.release_info.outputs.version_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,11 @@ jobs:
       - name: Compute release name and tag
         id: release_info
         run: |
-          echo "nightly? $IS_NIGHTLY"
-          if [[ $IS_NIGHTLY ]]; then
-            echo nightly
+          if [[ $IS_NIGHTLY == "true" ]]; then
             echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
           else
-            echo "${{inputs.version}}"
             echo "tag_name=${{ inputs.version }}" >> $GITHUB_OUTPUT
             echo "release_name=${{ inputs.tag }}" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,22 +42,22 @@ jobs:
       - name: Compute release name and tag
         id: release_info
         run: |
-          echo "nightly? $IS_NIGHTLY"
+          echo "nightly: $IS_NIGHTLY"
           if [ $IS_NIGHTLY == "true" ]; then
-            TAG=${{ inputs.tag || format('nightly-{0}', github.sha) }}
-            VERSION=${{ inputs.version || 'nightly' }}
+            TAG="${{ inputs.tag || format('nightly-{0}', github.sha) }}"
+            VERSION="${{ inputs.version || 'nightly' }}"
 
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
             echo "version_name=${VERSION}" >> $GITHUB_OUTPUT
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT  
           else
-            TAG=${{ inputs.tag || format('stable-{0}', github.sha) }}
-            VERSION=${{ inputs.version || 'stable' }}
+            TAG="${{ inputs.tag || format('stable-{0}', github.sha) }}"
+            VERSION="${{ inputs.version || 'stable' }}"
 
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
             echo "version_name=v${VERSION}" >> $GITHUB_OUTPUT
-            echo "release_name=foundry-zksync ${VERSION} >> $GITHUB_OUTPUT
+            echo "release_name=foundry-zksync ${VERSION}" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,11 @@ jobs:
             echo "release_name=foundry-zksync ${VERSION}" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
+          
+          echo tag_name: ${tag_name}
+          echo version_name: ${version_name}
+          echo release_name: ${release_name}
+          echo prerelease: ${prerelease}
 
       # Creates a `nightly-SHA` tag for this specific nightly
       # This tag is used for this specific nightly version's release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,12 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: "Tag to use for the release."
+        description: "Tag to use for the release (<component>-v<version>)."
+        type: string
+        required: true
+        default: ""
+      version:
+        description: "Version for the release."
         type: string
         required: true
         default: ""
@@ -41,8 +46,9 @@ jobs:
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
           else
-            echo "tag_name=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
-            echo "release_name=foundry-zksync@${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+            echo "${{inputs.version}}"
+            echo "tag_name=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "release_name=${{ inputs.tag }}" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
@@ -115,20 +121,20 @@ jobs:
         with:
           ref: ${{ inputs.tag || '' }}
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
-          cache-on-failure: true
+      # - uses: Swatinem/rust-cache@v2
+      #   with:
+      #     key: ${{ matrix.target }}
+      #     cache-on-failure: true
 
-      - name: Install required Rust targets
-        run: rustup target add ${{ matrix.target }}
+      # - name: Install required Rust targets
+      #   run: rustup target add ${{ matrix.target }}
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      # - uses: dtolnay/rust-toolchain@stable
+      #   with:
+      #     targets: ${{ matrix.target }}
       
-      - name: Install cross v0.2.5 from source
-        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
+      # - name: Install cross v0.2.5 from source
+      #   run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       # We diverge from upstream and build with cross as we're building static binaries
       - name: Build binaries
@@ -136,9 +142,9 @@ jobs:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
         shell: bash
         run: |
-          set -eo pipefail
-          target="${{ matrix.target }}"
-          flags=()
+          # set -eo pipefail
+          # target="${{ matrix.target }}"
+          # flags=()
 
           # Disable asm-keccak, see https://github.com/alloy-rs/core/issues/711
           # # Remove jemalloc, only keep `asm-keccak` if applicable
@@ -146,16 +152,16 @@ jobs:
           #     flags+=(--features asm-keccak)
           # fi
 
-          RUSTFLAGS='-C target-feature=+crt-static' OPENSSL_STATIC=1 cross build --release --bin forge --bin cast --target "$target" "${flags[@]}"
+          # RUSTFLAGS='-C target-feature=+crt-static' OPENSSL_STATIC=1 cross build --release --bin forge --bin cast --target "$target" "${flags[@]}"
 
-          bins=(cast forge)
-          for name in "${bins[@]}"; do
-              bin=./target/$target/release/$name
-              file "$bin" || true
-              ldd "$bin" || true
-              $bin --version || true
-              echo "${name}_bin_path=${bin}" >> $GITHUB_ENV
-          done
+          # bins=(cast forge)
+          # for name in "${bins[@]}"; do
+          #     bin=./target/$target/release/$name
+          #     file "$bin" || true
+          #     ldd "$bin" || true
+          #     $bin --version || true
+          #     echo "${name}_bin_path=${bin}" >> $GITHUB_ENV
+          # done
 
       - name: Archive binaries
         id: artifacts
@@ -167,74 +173,76 @@ jobs:
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
-              tar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-              echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+              # tar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+              # echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+              echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           elif [ "$PLATFORM_NAME" == "darwin" ]; then
               # We need to use gtar here otherwise the archive is corrupt.
               # See: https://github.com/actions/virtual-environments/issues/2619
-              gtar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-              echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+              # gtar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+              # echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+              echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           fi
 
-      - name: Build man page
-        id: man
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        env:
-          PLATFORM_NAME: ${{ matrix.platform }}
-          TARGET: ${{ matrix.target }}
-          VERSION_NAME: ${{ (env.IS_NIGHTLY == 'true' && 'nightly') || needs.prepare.outputs.tag_name }}
-        shell: bash
-        run: |
-          sudo apt-get -y install help2man
-          help2man -N ./target/${TARGET}/release/forge > forge.1
-          help2man -N ./target/${TARGET}/release/cast > cast.1
-          gzip forge.1
-          gzip cast.1
-          tar -czvf "foundry_man_${VERSION_NAME}.tar.gz" forge.1.gz cast.1.gz
-          echo "foundry_man=foundry_man_${VERSION_NAME}.tar.gz" >> $GITHUB_OUTPUT
+      # - name: Build man page
+      #   id: man
+      #   if: matrix.target == 'x86_64-unknown-linux-gnu'
+      #   env:
+      #     PLATFORM_NAME: ${{ matrix.platform }}
+      #     TARGET: ${{ matrix.target }}
+      #     VERSION_NAME: ${{ (env.IS_NIGHTLY == 'true' && 'nightly') || needs.prepare.outputs.tag_name }}
+      #   shell: bash
+      #   run: |
+      #     sudo apt-get -y install help2man
+      #     help2man -N ./target/${TARGET}/release/forge > forge.1
+      #     help2man -N ./target/${TARGET}/release/cast > cast.1
+      #     gzip forge.1
+      #     gzip cast.1
+      #     tar -czvf "foundry_man_${VERSION_NAME}.tar.gz" forge.1.gz cast.1.gz
+      #     echo "foundry_man=foundry_man_${VERSION_NAME}.tar.gz" >> $GITHUB_OUTPUT
 
       # Creates the release for this specific version
-      - name: Create release
-        if: ${{ inputs.tag == '' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          name: ${{ needs.prepare.outputs.release_name }}
-          tag_name: ${{ needs.prepare.outputs.tag_name }}
-          prerelease: ${{ needs.prepare.outputs.prerelease }}
-          body: ${{ needs.prepare.outputs.changelog }}
-          files: |
-            ${{ steps.artifacts.outputs.file_name }}
-            ${{ steps.man.outputs.foundry_man }}
+      # - name: Create release
+      #   if: ${{ inputs.tag == '' }}
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     name: ${{ needs.prepare.outputs.release_name }}
+      #     tag_name: ${{ needs.prepare.outputs.tag_name }}
+      #     prerelease: ${{ needs.prepare.outputs.prerelease }}
+      #     body: ${{ needs.prepare.outputs.changelog }}
+      #     files: |
+      #       ${{ steps.artifacts.outputs.file_name }}
+      #       ${{ steps.man.outputs.foundry_man }}
 
-      - name: Update release-please release artifacts
-        if: ${{ inputs.tag != '' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.tag }}
-          files: |
-            ${{ steps.artifacts.outputs.file_name }}
-            ${{ steps.man.outputs.foundry_man }}
+      # - name: Update release-please release artifacts
+      #   if: ${{ inputs.tag != '' }}
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     tag_name: ${{ inputs.tag }}
+      #     files: |
+      #       ${{ steps.artifacts.outputs.file_name }}
+      #       ${{ steps.man.outputs.foundry_man }}
 
-      - name: Binaries attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: |
-            ${{ env.cast_bin_path }}
-            ${{ env.forge_bin_path }}
+      # - name: Binaries attestation
+      #   uses: actions/attest-build-provenance@v2
+      #   with:
+      #     subject-path: |
+      #       ${{ env.cast_bin_path }}
+      #       ${{ env.forge_bin_path }}
 
-      # If this is a nightly release, it also updates the release
-      # tagged `nightly` for compatibility with `foundryup`
-      - name: Update nightly release
-        if: ${{ env.IS_NIGHTLY == 'true' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "Nightly foundry-zksync"
-          tag_name: "nightly"
-          prerelease: true
-          body: ${{ needs.prepare.outputs.changelog }}
-          files: |
-            ${{ steps.artifacts.outputs.file_name }}
-            ${{ steps.man.outputs.foundry_man }}
+      # # If this is a nightly release, it also updates the release
+      # # tagged `nightly` for compatibility with `foundryup`
+      # - name: Update nightly release
+      #   if: ${{ env.IS_NIGHTLY == 'true' }}
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     name: "Nightly foundry-zksync"
+      #     tag_name: "nightly"
+      #     prerelease: true
+      #     body: ${{ needs.prepare.outputs.changelog }}
+      #     files: |
+      #       ${{ steps.artifacts.outputs.file_name }}
+      #       ${{ steps.man.outputs.foundry_man }}
 
   retry-on-failure:
     if: failure() && fromJSON(github.run_attempt) < 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,15 +189,15 @@ jobs:
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
-              # tar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-              # echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-              echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+              # tar -czvf "foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+              # echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+              echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           elif [ "$PLATFORM_NAME" == "darwin" ]; then
               # We need to use gtar here otherwise the archive is corrupt.
               # See: https://github.com/actions/virtual-environments/issues/2619
-              # gtar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-              # echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-              echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+              # gtar -czvf "foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+              # echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+              echo "file_name=foundry_zksync_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           fi
 
       # - name: Build man page

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
           PLATFORM_NAME: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
           ARCH: ${{ matrix.arch }}
-          VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
+          VERSION_NAME: ${{ (env.IS_NIGHTLY == true && 'nightly') || needs.prepare.outputs.tag_name }}
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       tag_name: ${{ steps.release_info.outputs.tag_name }}
+      version_name: ${{ steps.release_info.outputs.version_name }}
       release_name: ${{ steps.release_info.outputs.release_name }}
       prerelease: ${{ steps.release_info.outputs.prerelease }}
       changelog: ${{ steps.build_changelog.outputs.changelog || '' }}
@@ -37,20 +38,26 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag || '' }}
-
+        
       - name: Compute release name and tag
         id: release_info
         run: |
           echo "nightly? $IS_NIGHTLY"
-          if [[ $IS_NIGHTLY == "true" ]]; then
-            echo nightly
-            echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+          if [ $IS_NIGHTLY == "true" ]; then
+            TAG=${{ inputs.tag || format('nightly-{0}', github.sha) }}
+            VERSION=${{ inputs.version || 'nightly' }}
+
+            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
+            echo "version_name=${VERSION}" >> $GITHUB_OUTPUT
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
-            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> $GITHUB_OUTPUT  
           else
-            echo "${{inputs.version}}"
-            echo "tag_name=${{ inputs.version }}" >> $GITHUB_OUTPUT
-            echo "release_name=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            TAG=${{ inputs.tag || format('stable-{0}', github.sha) }}
+            VERSION=${{ inputs.version || 'stable' }}
+
+            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
+            echo "version_name=v${VERSION}" >> $GITHUB_OUTPUT
+            echo "release_name=foundry-zksync ${VERSION} >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
@@ -58,7 +65,7 @@ jobs:
       # This tag is used for this specific nightly version's release
       # which allows users to roll back. It is also used to build
       # the changelog.
-      - name: Create build-specific nightly tag
+      - name: Create build-specific tag (nightly)
         if: ${{ env.IS_NIGHTLY == 'true' }}
         uses: actions/github-script@v7
         env:
@@ -68,7 +75,7 @@ jobs:
             const createTag = require('./.github/scripts/create-tag.js')
             await createTag({ github, context }, process.env.TAG_NAME)
 
-      - name: Build changelog
+      - name: Build changelog (nightly)
         if: ${{ env.IS_NIGHTLY == 'true' }}
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4
@@ -171,7 +178,7 @@ jobs:
           PLATFORM_NAME: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
           ARCH: ${{ matrix.arch }}
-          VERSION_NAME: ${{ (env.IS_NIGHTLY == true && 'nightly') || needs.prepare.outputs.tag_name }}
+          VERSION_NAME: ${{ needs.prepare.outputs.version_name }}
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
@@ -192,7 +199,7 @@ jobs:
       #   env:
       #     PLATFORM_NAME: ${{ matrix.platform }}
       #     TARGET: ${{ matrix.target }}
-      #     VERSION_NAME: ${{ (env.IS_NIGHTLY == 'true' && 'nightly') || needs.prepare.outputs.tag_name }}
+      #     VERSION_NAME: ${{ needs.prepare.outputs.version_name }}
       #   shell: bash
       #   run: |
       #     sudo apt-get -y install help2man

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Compute release name and tag
         id: release_info
         run: |
+          echo "nightly? $IS_NIGHTLY"
           if [[ $IS_NIGHTLY ]]; then
+            echo nightly
             echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,14 @@ jobs:
       - name: Compute release name and tag
         id: release_info
         run: |
+          echo "nightly? $IS_NIGHTLY"
           if [[ $IS_NIGHTLY == "true" ]]; then
+            echo nightly
             echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
           else
+            echo "${{inputs.version}}"
             echo "tag_name=${{ inputs.version }}" >> $GITHUB_OUTPUT
             echo "release_name=${{ inputs.tag }}" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           if [ $IS_NIGHTLY == "true" ]; then
             TAG="${{ inputs.tag || format('nightly-{0}', github.sha) }}"
             VERSION="${{ inputs.version || 'nightly' }}"
-
+            
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
             echo "version_name=${VERSION}" >> $GITHUB_OUTPUT
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
@@ -61,35 +61,37 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
           
-          echo tag_name: ${tag_name}
-          echo version_name: ${version_name}
-          echo release_name: ${release_name}
-          echo prerelease: ${prerelease}
+      - name: Print outputs
+        run: |
+            echo tag_name: ${{ steps.release_info.outputs.tag_name }}
+            echo version_name: ${{ steps.release_info.outputs.version_name }}
+            echo release_name: ${{ steps.release_info.outputs.release_name }}
+            echo prerelease: ${{ steps.release_info.outputs.prerelease }}
 
       # Creates a `nightly-SHA` tag for this specific nightly
       # This tag is used for this specific nightly version's release
       # which allows users to roll back. It is also used to build
       # the changelog.
-      - name: Create build-specific tag (nightly)
-        if: ${{ env.IS_NIGHTLY == 'true' }}
-        uses: actions/github-script@v7
-        env:
-          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
-        with:
-          script: |
-            const createTag = require('./.github/scripts/create-tag.js')
-            await createTag({ github, context }, process.env.TAG_NAME)
+      # - name: Create build-specific tag (nightly)
+      #   if: ${{ env.IS_NIGHTLY == 'true' }}
+      #   uses: actions/github-script@v7
+      #   env:
+      #     TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
+      #   with:
+      #     script: |
+      #       const createTag = require('./.github/scripts/create-tag.js')
+      #       await createTag({ github, context }, process.env.TAG_NAME)
 
-      - name: Build changelog (nightly)
-        if: ${{ env.IS_NIGHTLY == 'true' }}
-        id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v4
-        with:
-          configuration: "./.github/changelog.json"
-          fromTag: 'nightly'
-          toTag: ${{ steps.release_info.outputs.tag_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Build changelog (nightly)
+      #   if: ${{ env.IS_NIGHTLY == 'true' }}
+      #   id: build_changelog
+      #   uses: mikepenz/release-changelog-builder-action@v4
+      #   with:
+      #     configuration: "./.github/changelog.json"
+      #     fromTag: 'nightly'
+      #     toTag: ${{ steps.release_info.outputs.tag_name }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: ${{ matrix.target }} (${{ matrix.runner }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag || '' }}
-        
+
       - name: Compute release name and tag
         id: release_info
         run: |
@@ -50,7 +50,7 @@ jobs:
             echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
             echo "version_name=${VERSION}" >> $GITHUB_OUTPUT
             echo "release_name=foundry-zksync Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
-            echo "prerelease=true" >> $GITHUB_OUTPUT  
+            echo "prerelease=true" >> $GITHUB_OUTPUT
           else
             TAG="${{ inputs.tag || format('stable-{0}', github.sha) }}"
             VERSION="${{ inputs.version || 'stable' }}"
@@ -63,10 +63,10 @@ jobs:
           
       - name: Print release info
         run: |
-            echo tag_name: "${{ steps.release_info.outputs.tag_name }}"
-            echo version_name: "${{ steps.release_info.outputs.version_name }}"
-            echo release_name: "${{ steps.release_info.outputs.release_name }}"
-            echo prerelease: "${{ steps.release_info.outputs.prerelease }}"
+          echo tag_name: "${{ steps.release_info.outputs.tag_name }}"
+          echo version_name: "${{ steps.release_info.outputs.version_name }}"
+          echo release_name: "${{ steps.release_info.outputs.release_name }}"
+          echo prerelease: "${{ steps.release_info.outputs.prerelease }}"
 
       # Creates a `nightly-SHA` tag for this specific nightly
       # This tag is used for this specific nightly version's release


### PR DESCRIPTION
# What :computer: 
* Properly name artifacts when releasing.
* Fix bug in `IS_NIGHTLY` detection.

# Why :hand:
* We had inconsistency with nightly artifacts names with the stable ones.

# Evidence :camera:
Action runs
https://github.com/matter-labs/foundry-zksync/actions/runs/12950423332/job/36123203197
https://github.com/matter-labs/foundry-zksync/actions/runs/12950402414/job/36123129539

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
We're currently using `include-component-in-tag = true` in release-please so our stable tags come out as `foundry-zksync-v0.0.4` meanwhile nightly tags are `nightly-{{sha}}`, this is all good but if we don't need the component we should look into removing that part. @dutterbutter 
