### PR TITLE
fix: set log level for nonce revert to trace

### DIFF
--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -344,7 +344,7 @@ where
     if let Some(initiator_nonce) = modified_storage.get_mut(&initiator_nonce_key) {
         let FullNonce { tx_nonce, deploy_nonce } = parse_full_nonce(initiator_nonce.to_ru256());
         let new_tx_nonce = tx_nonce.saturating_sub(1);
-        error!(address=?initiator_address, from=?tx_nonce, to=?new_tx_nonce, deploy_nonce, "reverting initiator tx nonce for CALL");
+        trace!(address=?initiator_address, from=?tx_nonce, to=?new_tx_nonce, deploy_nonce, "reverting initiator tx nonce for CALL");
         *initiator_nonce = new_full_nonce(new_tx_nonce, deploy_nonce).to_h256();
     }
 


### PR DESCRIPTION
# What :computer: 
* Currently the log level is erroneously set to `error!` which was a typo.

# Why :hand:
* This happens each zkEVM call and is not an error.

# Evidence :camera:
Tests pass

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
