### PR TITLE
chore: bump default to v1.5.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,8 +3923,8 @@ dependencies = [
 
 [[package]]
 name = "era-solc"
-version = "1.5.10"
-source = "git+https://github.com/matter-labs/era-compiler-solidity.git?tag=1.5.10#0c9df3b260c95e0881799bb3b2c85bd16a6dbf4d"
+version = "1.5.11"
+source = "git+https://github.com/matter-labs/era-compiler-solidity.git?tag=1.5.11#b2b78f7a5814acdc2efebff2615111185dcc986c"
 dependencies = [
  "anyhow",
  "boolinator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ zksync_vm_interface = { git = "https://github.com/matter-labs/zksync-era.git", r
 zksync_multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "core-v25.4.0" }
 zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "core-v25.4.0" }
 zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "core-v25.4.0" }
-era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity.git", tag = "1.5.10", package = "era-solc" }
+era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity.git", tag = "1.5.11", package = "era-solc" }
 
 # macros
 proc-macro2 = "1.0"

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -176,7 +176,7 @@ pub fn config_zksolc_compiler(config: &Config) -> Result<ZkSolcCompiler, SolcErr
     {
         zksolc
     } else if !config.offline {
-        let default_version = semver::Version::new(1, 5, 10);
+        let default_version = semver::Version::new(1, 5, 11);
         let mut zksolc = ZkSolc::find_installed_version(&default_version)?;
         if zksolc.is_none() {
             ZkSolc::blocking_install(&default_version)?;

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -201,7 +201,7 @@ impl ForgeTestProfile {
         zk_config.zksync.startup = true;
         zk_config.zksync.fallback_oz = true;
         zk_config.zksync.optimizer_mode = '3';
-        zk_config.zksync.zksolc = Some(foundry_config::SolcReq::Version(Version::new(1, 5, 10)));
+        zk_config.zksync.zksolc = Some(foundry_config::SolcReq::Version(Version::new(1, 5, 11)));
         zk_config.fuzz.no_zksync_reserved_addresses = true;
         zk_config.invariant.depth = 15;
 

--- a/crates/zksync/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/zksync/compilers/src/compilers/zksolc/mod.rs
@@ -40,7 +40,7 @@ pub const ZKSOLC: &str = "zksolc";
 /// ZKsync solc release used for all ZKsync solc versions
 pub const ZKSYNC_SOLC_RELEASE: Version = Version::new(1, 0, 1);
 /// Default zksolc version
-pub const ZKSOLC_VERSION: Version = Version::new(1, 5, 10);
+pub const ZKSOLC_VERSION: Version = Version::new(1, 5, 11);
 
 #[cfg(test)]
 macro_rules! take_solc_installer_lock {


### PR DESCRIPTION
# What :computer: 
* Bumps default zksolc version to [1.5.11](https://github.com/matter-labs/era-compiler-solidity/releases/tag/1.5.11)

# Why :hand:
* Latest zksolc version
* Requested by @hedgar2017 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
