### PR TITLE
fix: add proper filter sets for ci test runs

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -116,7 +116,8 @@ def main():
                     os_str = f" ({target.target})"
 
                 name = case.name
-                flags = f"-E '{case.filter}'"
+                # NOTE(zk): filter out zk tests from upstream ci runs
+                flags = f"-E '{case.filter} & not (test(~zk) or test(~test_zk_aave_di) or package(~zksync))'"
                 if case.n_partitions > 1:
                     s = f"{partition}/{case.n_partitions}"
                     name += f" ({s})"

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -94,4 +94,4 @@ jobs:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
           HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
           WS_ARCHIVE_URLS: ${{ secrets.WS_ARCHIVE_URLS }}
-        run: cargo nextest run ${{ matrix.flags }} --filter-expr 'not (test(~zk) or test(~test_zk_aave_di))'
+        run: cargo nextest run ${{ matrix.flags }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
           RUST_BACKTRACE: full
           TEST_MAINNET_URL: http://localhost:8011
         run: |
-          ZK_DEBUG_HISTORICAL_BLOCK_HASHES=5 cargo nextest run --package '*' --lib --test '*' --filter-expr 'test(~zk) and not test(~test_zk_aave_di)'
+          ZK_DEBUG_HISTORICAL_BLOCK_HASHES=5 cargo nextest run --package '*' --lib --test '*' -E '(test(~zk) or package(~zksync)) and not test(~test_zk_aave_di)'
 
   deny:
     uses: ithacaxyz/ci/.github/workflows/deny.yml@main


### PR DESCRIPTION
# What :computer: 

* Append zksync filter expressions to the upstream ones.
* Add tests in zksync packages to the subset of zk tests.

# Why :hand:

* Current filters don't do what we expect, seems that having different filter expressions are joined using `or` and not `and`. This broke the upstream test workflow partition including tests from different partitions into one another and including zk tests into the upstream partitions. 
* Some tests in zksync package were missing the `zk` prefix making them included on the upstream tests and excluded from the `zksync` tests.

# Evidence :camera:
* No zk tests run in upstream workflows.
* Tests on zksync packages are included in zk test workflow.
* Upstream workflows each run the same tests as their counterpart in upstream.

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
