### PR TITLE
fix: use existing deployment nonce during storage migration

### DIFF
--- a/crates/forge/tests/it/zk/fork.rs
+++ b/crates/forge/tests/it/zk/fork.rs
@@ -2,7 +2,11 @@
 
 use crate::{config::*, test_helpers::TEST_DATA_DEFAULT};
 use forge::revm::primitives::SpecId;
-use foundry_test_utils::Filter;
+use foundry_test_utils::{
+    forgetest_async,
+    util::{self, OutputExt},
+    Filter, Fork, ZkSyncNode,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zk_setup_fork_failure() {
@@ -28,3 +32,59 @@ async fn test_zk_consistent_storage_migration_after_fork() {
 
     TestConfig::with_filter(runner, filter).spec_id(SpecId::SHANGHAI).run().await;
 }
+
+forgetest_async!(test_zk_consistent_nonce_migration_after_fork, |prj, cmd| {
+    util::initialize(prj.root());
+
+    // Has deployment nonce (1) and transaction nonce (2) on mainnet block #55159219
+    let test_address = "0x076d6da60aAAC6c97A8a0fE8057f9564203Ee545";
+
+    prj.add_script(
+        "ZkForkNonceTest.s.sol",
+        format!(r#"
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+interface VmExt {{
+    function zkGetTransactionNonce(
+        address account
+    ) external view returns (uint64 nonce);
+    function zkGetDeploymentNonce(
+        address account
+    ) external view returns (uint64 nonce);
+}}
+
+contract ZkForkNonceTest is Script {{
+    VmExt internal constant vmExt = VmExt(VM_ADDRESS);
+
+    address constant TEST_ADDRESS = {test_address};
+    uint128 constant TEST_ADDRESS_TRANSACTION_NONCE = 2;
+    uint128 constant TEST_ADDRESS_DEPLOYMENT_NONCE = 1;
+
+    function run() external {{
+        require(TEST_ADDRESS_TRANSACTION_NONCE == vmExt.zkGetTransactionNonce(TEST_ADDRESS), "failed matching transaction nonce");
+        require(TEST_ADDRESS_DEPLOYMENT_NONCE == vmExt.zkGetDeploymentNonce(TEST_ADDRESS), "failed matching deployment nonce");
+    }}
+}}
+"#).as_str(),
+    )
+    .unwrap();
+
+    let node = ZkSyncNode::start_with_fork(Fork::new_with_block(
+        String::from("https://mainnet.era.zksync.io"),
+        55159219,
+    ))
+    .await;
+
+    cmd.arg("script").args([
+        "ZkForkNonceTest",
+        "--zk-startup",
+        "./script/ForkNonce.s.sol",
+        "--rpc-url",
+        node.url().as_str(),
+        "--sender",
+        test_address,
+    ]);
+
+    cmd.assert_success();
+});

--- a/crates/forge/tests/it/zk/logs.rs
+++ b/crates/forge/tests/it/zk/logs.rs
@@ -51,7 +51,7 @@ async fn test_zk_logs_work_in_create() {
                 Some(vec![
                     "print".into(),
                     "outer print".into(),
-                    "0xF9E9ba9Ed9B96AB918c74B21dD0f1D5f2ac38a30".into(),
+                    "0xB5c1DF089600415B21FB76bf89900Adb575947c8".into(),
                     "print".into(),
                     "0xff".into(),
                     "print".into(),

--- a/crates/forge/tests/it/zk/traces.rs
+++ b/crates/forge/tests/it/zk/traces.rs
@@ -14,10 +14,10 @@ use itertools::Itertools;
 use serde::Deserialize;
 
 const ADDRESS_ZK_TRACE_TEST: Address = address!("7fa9385be102ac3eac297483dd6233d62b3e1496");
-const ADDRESS_ADDER: Address = address!("f9e9ba9ed9b96ab918c74b21dd0f1d5f2ac38a30");
-const ADDRESS_NUMBER: Address = address!("f232f12e115391c535fd519b00efadf042fc8be5");
-const ADDRESS_FIRST_INNER_NUMBER: Address = address!("ed570f3f91621894e001df0fb70bfbd123d3c8ad");
-const ADDRESS_SECOND_INNER_NUMBER: Address = address!("abceaeac3d3a2ac3dcffd7a60ca00a3fac9490ca");
+const ADDRESS_ADDER: Address = address!("b5c1df089600415b21fb76bf89900adb575947c8");
+const ADDRESS_NUMBER: Address = address!("d6a7a38ee698efae2f48f3a62dc7a71c3c0930a1");
+const ADDRESS_FIRST_INNER_NUMBER: Address = address!("89c74b24fb24dda42a8465ee0f9ede2c1308deeb");
+const ADDRESS_SECOND_INNER_NUMBER: Address = address!("9359008843d2c083a14e9c17cde01893938047fa");
 const ADDRESS_CONSOLE: Address = address!("000000000000000000636f6e736f6c652e6c6f67");
 const SELECTOR_TEST_CALL: Bytes = Bytes::from_static(hex!("0d3282c4").as_slice());
 const SELECTOR_TEST_CREATE: Bytes = Bytes::from_static(hex!("61bdc916").as_slice());

--- a/crates/strategy/zksync/src/cheatcode/runner/mod.rs
+++ b/crates/strategy/zksync/src/cheatcode/runner/mod.rs
@@ -954,7 +954,7 @@ impl ZksyncCheatcodeInspectorStrategyRunner {
         for address in data.db.persistent_accounts().into_iter().chain([data.env.tx.caller]) {
             info!(?address, "importing to zk state");
 
-            // Re-use the deployment nonce from storage if present.
+            // Reuse the deployment nonce from storage if present.
             let deployment_nonce = {
                 let nonce_key = get_nonce_key(address);
                 let nonce_addr = NONCE_HOLDER_ADDRESS.to_address();

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -31,7 +31,7 @@ pub use script::{ScriptOutcome, ScriptTester};
 
 // TODO: remove once anvil supports zksync node
 mod zksync;
-pub use zksync::ZkSyncNode;
+pub use zksync::{Fork, ZkSyncNode};
 
 // re-exports for convenience
 pub use foundry_compilers;

--- a/crates/test-utils/src/zksync.rs
+++ b/crates/test-utils/src/zksync.rs
@@ -141,15 +141,13 @@ pub struct ZkSyncNode {
 }
 
 impl ZkSyncNode {
-    /// Start anvil-zksync in memory, binding a random available port
-    ///
-    /// The server is automatically stopped when the instance is dropped.
+    /// Returns the server url.
     #[inline]
     pub fn url(&self) -> String {
         format!("http://127.0.0.1:{}", self.port)
     }
 
-    /// Start anvil-zksync in memory, binding a random available port
+    /// Start anvil-zksync in memory, binding a random available port.
     ///
     /// The server is automatically stopped when the instance is dropped.
     pub async fn start() -> Self {

--- a/crates/test-utils/src/zksync.rs
+++ b/crates/test-utils/src/zksync.rs
@@ -125,12 +125,12 @@ pub struct Fork {
 impl Fork {
     /// Create a fork config with the provided url and the latest block.
     pub fn new(url: String) -> Self {
-        Fork { url, ..Default::default() }
+        Self { url, ..Default::default() }
     }
 
     /// Create a fork config with the provided url and block.
     pub fn new_with_block(url: String, block: u64) -> Self {
-        Fork { url, block: Some(block) }
+        Self { url, block: Some(block) }
     }
 }
 


### PR DESCRIPTION
# What :computer: 
* Use deployment nonce from storage when translating during a EVM <> zkEVM migration, else use zero value.
* Add appropriate debug logs that state inconsistencies may occur due to EVM <> zkEVM mapping.

# Why :hand:
* We would erroneously override deployment nonce with the transaction nonce.

# Evidence :camera:
Tests pass

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
* Additional docs PR https://github.com/matter-labs/foundry-zksync-book/pull/75
