### PR TITLE
fix: foundry toml invalid setting does not discard other settings

### DIFF
--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -20,8 +20,8 @@ use foundry_zksync_compilers::{
     },
 };
 use semver::Version;
-use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, path::PathBuf};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{collections::HashSet, path::PathBuf, str::FromStr};
 
 use crate::{Config, SkipBuildFilters, SolcReq};
 
@@ -73,10 +73,10 @@ pub struct ZkSyncConfig {
     /// zkSolc optimizer details
     pub optimizer_details: Option<OptimizerDetails>,
 
-    // zksolc suppressed warnings.
+    #[serde(deserialize_with = "deserialize_warning_set")]
     pub suppressed_warnings: HashSet<WarningType>,
 
-    // zksolc suppressed errors.
+    #[serde(deserialize_with = "deserialize_error_set")]
     pub suppressed_errors: HashSet<ErrorType>,
 }
 
@@ -121,6 +121,8 @@ impl ZkSyncConfig {
         via_ir: bool,
         offline: bool,
     ) -> Result<ZkSolcSettings, SolcError> {
+        info!("Parsing settings for zksync");
+        info!("self: {:?}", self);
         let optimizer = Optimizer {
             enabled: Some(self.optimizer),
             mode: Some(self.optimizer_mode),
@@ -332,6 +334,40 @@ pub fn config_ensure_zksolc(
     }
 
     Ok(None)
+}
+
+fn deserialize_warning_set<'de, D>(deserializer: D) -> Result<HashSet<WarningType>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let strings: Vec<String> = Vec::deserialize(deserializer)?;
+    Ok(strings
+        .into_iter()
+        .filter_map(|s| match WarningType::from_str(&s) {
+            Ok(warning) => Some(warning),
+            Err(e) => {
+                error!("Failed to parse warning type: '{}' with error: {}", s, e);
+                None
+            }
+        })
+        .collect())
+}
+
+fn deserialize_error_set<'de, D>(deserializer: D) -> Result<HashSet<ErrorType>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let strings: Vec<String> = Vec::deserialize(deserializer)?;
+    Ok(strings
+        .into_iter()
+        .filter_map(|s| match ErrorType::from_str(&s) {
+            Ok(error) => Some(error),
+            Err(e) => {
+                error!("Failed to parse error type: '{}' with error: {}", s, e);
+                None
+            }
+        })
+        .collect())
 }
 
 #[cfg(test)]

--- a/crates/config/src/zksync.rs
+++ b/crates/config/src/zksync.rs
@@ -73,9 +73,11 @@ pub struct ZkSyncConfig {
     /// zkSolc optimizer details
     pub optimizer_details: Option<OptimizerDetails>,
 
+    // zksolc suppressed warnings.
     #[serde(deserialize_with = "deserialize_warning_set")]
     pub suppressed_warnings: HashSet<WarningType>,
 
+    // zksolc suppressed errors.
     #[serde(deserialize_with = "deserialize_error_set")]
     pub suppressed_errors: HashSet<ErrorType>,
 }
@@ -121,8 +123,6 @@ impl ZkSyncConfig {
         via_ir: bool,
         offline: bool,
     ) -> Result<ZkSolcSettings, SolcError> {
-        info!("Parsing settings for zksync");
-        info!("self: {:?}", self);
         let optimizer = Optimizer {
             enabled: Some(self.optimizer),
             mode: Some(self.optimizer_mode),

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -31,5 +31,6 @@ mod version;
 mod ext_integration;
 mod zk_build;
 mod zk_cmd;
+mod zk_config;
 mod zk_ext_integration;
 mod zk_script;

--- a/crates/forge/tests/cli/zk_config.rs
+++ b/crates/forge/tests/cli/zk_config.rs
@@ -1,0 +1,51 @@
+//! Contains various tests for checking configuration
+
+use std::fs;
+
+use foundry_test_utils::util::OutputExt;
+
+// test to check that the config is not skipped when using the wrong settings in the foundry.toml
+// and emits the correct warnings
+forgetest!(foundry_toml_config_error_does_not_skip_correct_settings, |prj, cmd| {
+    let faulty_toml = r"
+    [profile.default]
+    src = 'src'
+    out = 'out'
+    libs = ['lib']
+    solc_version = '0.8.20'
+
+    [profile.default.zksync]
+    suppressed_errors = ['invalid-error', 'sendtransfer']
+    suppressed_warnings = ['invalid-warning']
+    zksolc='1.5.10'";
+
+    prj.add_source("Greeter.sol", include_str!("../../../../testdata/zk/Greeter.sol")).unwrap();
+
+    fs::write(prj.root().join("foundry.toml"), faulty_toml).unwrap();
+
+    let output = cmd
+        .forge_fuse()
+        .arg("build")
+        .arg("--zksync")
+        .arg("--build-info")
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(output.contains("Invalid suppressed error type: invalid-error"));
+    assert!(output.contains("Invalid suppressed warning type: invalid-warning"));
+
+    // read build info to assert that the version of zksolc was not skipped
+    let build_info = fs::read_to_string(
+        prj.root().join("zkout").join("build-info").join(
+            fs::read_dir(prj.root().join("zkout").join("build-info"))
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .file_name(),
+        ),
+    )
+    .unwrap();
+    assert!(build_info.contains("1.5.10"));
+});

--- a/crates/forge/tests/cli/zk_config.rs
+++ b/crates/forge/tests/cli/zk_config.rs
@@ -1,4 +1,4 @@
-//! Contains various tests for checking configuration
+//! Contains tests for checking configuration for zksync
 
 use std::fs;
 
@@ -6,7 +6,7 @@ use foundry_test_utils::util::OutputExt;
 
 // test to check that the config is not skipped when using the wrong settings in the foundry.toml
 // and emits the correct warnings
-forgetest!(foundry_toml_config_error_does_not_skip_correct_settings, |prj, cmd| {
+forgetest!(test_zk_foundry_toml_config_error_does_not_skip_correct_settings, |prj, cmd| {
     let faulty_toml = r"
     [profile.default]
     src = 'src'


### PR DESCRIPTION
# What :computer:  
* Added custom deserialization to detect incorrect warnings and errors, inform the user, and ensure the rest of the configuration is not discarded.  

# Why :hand:  
* Previously, when users provided an incorrect warning or error, they were not informed, and the rest of the zkSync configuration was discarded.  

# Evidence :camera:
Test pass

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.