### PR TITLE
chore: update cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,16 +7,9 @@ yanked = "warn"
 ignore = [
     # proc-macro-error is unmaintained
     "RUSTSEC-2024-0370",
-    # instant is unmaintained
-    "RUSTSEC-2024-0384",
-    # rustls advisory, only servers affected
-    "RUSTSEC-2024-0399",
     # Used by boojum
     # derivative is unmaintained
     "RUSTSEC-2024-0388",
-    # Used by era-test-node
-    # net2 is unmaintained
-    "RUSTSEC-2020-0016",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,10 @@ ignore = [
     # Used by boojum
     # derivative is unmaintained
     "RUSTSEC-2024-0388",
+    # deprecated paste used by alloy-primitives
+    "RUSTSEC-2024-0436",
+    # protobuf in trezor_client
+    "RUSTSEC-2024-0437"
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -104,8 +108,7 @@ allow-git = [
     "https://github.com/bluealloy/revm",
     "https://github.com/RustCrypto/hashes",
     "https://github.com/popzxc/alloy-zksync",
-    "https://github.com/nbaztec/proptest",
 ]
 
 [sources.allow-org]
-github = ["matter-labs", "Moonsong-Labs"]
+github = ["matter-labs"]


### PR DESCRIPTION
# What :computer: 
* Remove some deprecated ignores, allows and denies.
* Add `RUSTSEC-2024-0436` which involves an unmaintained dependency on alloy-primitives.
* Add ` RUSTSEC-2024-0437` which involves a potential stack overflow attack vulnerability in `rust-protobuf` which is used by `trezor_client`. Probably not relevant to use but if it is we need trezor_client to be updated by upstream. 

# Why :hand:
Cleanup + making deny happy

# Evidence :camera:
cargo deny passes

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
