### PR TITLE
ci: use ubuntu22 as linux release platform instead of ubuntu24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,12 +115,12 @@ jobs:
           # `target`: Rust build target triple
           # `platform` and `arch`: Used in tarball names
           # `svm`: target platform to use for the Solc binary: https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
-          - runner: ubuntu-24.04-github-hosted-16core
+          - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             svm_target_platform: linux-amd64
             platform: linux
             arch: amd64
-          - runner: ubuntu-24.04-github-hosted-16core
+          - runner: matterlabs-ci-runner-arm
             target: aarch64-unknown-linux-gnu
             svm_target_platform: linux-aarch64
             platform: linux
@@ -141,6 +141,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || '' }}
+
+      - name: Install Rust toolchain
+        uses: moonrepo/setup-rust@v1
+        env:
+          # To fix rate limiting issues with GitHub API
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          cache: false
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -168,14 +176,16 @@ jobs:
           brew install make
           echo "PATH=/usr/local/opt/make/libexec/gnubin:$PATH" >> $GITHUB_ENV
           
-      - name: Linux ARM setup
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "C_INCLUDE_PATH=/usr/aarch64-linux-gnu/include" >> $GITHUB_ENV
-          echo "CPLUS_INCLUDE_PATH=/usr/aarch64-linux-gnu/include" >> $GITHUB_ENV
+      # Disable custom ARM setup as we use native linux runner
+      # Keep the code here in case we return back to github-hosted ones
+      # - name: Linux ARM setup
+      #   if: matrix.target == 'aarch64-unknown-linux-gnu'
+      #   run: |
+      #     sudo apt-get update -y
+      #     sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libssl-dev
+      #     echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      #     echo "C_INCLUDE_PATH=/usr/aarch64-linux-gnu/include" >> $GITHUB_ENV
+      #     echo "CPLUS_INCLUDE_PATH=/usr/aarch64-linux-gnu/include" >> $GITHUB_ENV
 
       # We diverge from upstream and build with cross as we're building static binaries
       - name: Build binaries


### PR DESCRIPTION
# What :computer: 

* Use ubuntu22 as linux release platform instead of ubuntu24

# Why :hand:

* Dynamic linkage with `glibc` requires us to use the oldest supported Ubuntu version to be compatible with the most of setups.

# Tests

The test release is published here:
https://github.com/matter-labs/foundry-zksync/releases/tag/nightly-b7c50399f941a4affdf43c90d8bfc63a0897b740
https://github.com/matter-labs/foundry-zksync/actions/runs/14197415782