### PR TITLE
fix: Upstream f45781dd clippy and tests

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -36,7 +36,7 @@ pub struct Params<T: Default> {
 /// Represents ethereum JSON-RPC API
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(tag = "method", content = "params")]
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum EthRequest {
     #[serde(rename = "web3_clientVersion", with = "empty_params")]
     Web3ClientVersion(()),

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -37,7 +37,7 @@ pub struct ReorgOptions {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum TransactionData {
     JSON(TransactionRequest),
     Raw(Bytes),

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -25,7 +25,7 @@ use serde_json::value::RawValue;
 use std::fmt::Write;
 
 /// Different sender kinds used by [`CastTxBuilder`].
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum SenderKind<'a> {
     /// An address without signer. Used for read-only calls and transactions sent through unlocked
     /// accounts.

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -36,7 +36,7 @@ pub struct CounterExampleOutcome {
 
 /// Outcome of a single fuzz
 #[derive(Debug)]
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum FuzzOutcome {
     Case(CaseOutcome),
     CounterExample(CounterExampleOutcome),

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -32,7 +32,7 @@ mod inspector;
 pub use inspector::Fuzzer;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum CounterExample {
     /// Call used as a counter example for fuzz tests.
     Single(BaseCounterExample),

--- a/crates/zksync/compilers/src/compilers/mod.rs
+++ b/crates/zksync/compilers/src/compilers/mod.rs
@@ -83,10 +83,10 @@ fn rebase_path(base: &Path, path: &Path) -> PathBuf {
 
         if Some(path_component) != base_component {
             if base_component.is_some() {
-                new_path.extend(
-                    std::iter::repeat(std::path::Component::ParentDir)
-                        .take(base_components.count() + 1),
-                );
+                new_path.extend(std::iter::repeat_n(
+                    std::path::Component::ParentDir,
+                    base_components.count() + 1,
+                ));
             }
 
             new_path.push(path_component);

--- a/zksync-tests
+++ b/zksync-tests
@@ -9,6 +9,8 @@ cast::cli:
     zk::test_zk_cast_mktx_contract_deploy
     zk::test_zk_cast_using_paymaster
     zk::test_zk_cast_without_paymaster
+forge:
+    cmd::create::zksync::tests::test_zk_deployer_builds_eip712_transactions
 forge::cli:
     cmd::zk_can_init_with_zksync
     zk::build::test_zk_build_sizes
@@ -117,8 +119,6 @@ forge::it:
     zk::sender::test_zk_correctly_updates_sender_nonce
     zk::traces::test_zk_traces_work_during_call
     zk::traces::test_zk_traces_work_during_create
-forge::bin/forge:
-    cmd::create::zksync::tests::test_zk_deployer_builds_eip712_transactions
 forge-verify:
     bytecode::zksync::tests::test_zk_extract_and_compare_bytecodes_both_none
     bytecode::zksync::tests::test_zk_extract_and_compare_bytecodes_none_ipfs


### PR DESCRIPTION
# What :computer: 
* Fix clippy warnings, due to our cargo version being different to the one upstream uses we can't go with the `expect` change to the `large_enum_variant` and need to stick with `allow`. 

# Why :hand:
* Upstream merge

# Evidence :camera:
Test passes and lint passes also

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
