### PR TITLE
fix: Pin version of solc for tests depending on specific zksolc versions

### DIFF
--- a/crates/zksync/compilers/test-data/dapp-sample/lib/ds-test/demo/demo.sol
+++ b/crates/zksync/compilers/test-data/dapp-sample/lib/ds-test/demo/demo.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.4.23;
+pragma solidity 0.8.10;
 
 import "../src/test.sol";
 

--- a/crates/zksync/compilers/test-data/dapp-sample/lib/ds-test/src/test.sol
+++ b/crates/zksync/compilers/test-data/dapp-sample/lib/ds-test/src/test.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.4.23;
+pragma solidity 0.8.10;
 
 contract DSTest {
     event log                    (string);

--- a/crates/zksync/compilers/test-data/dapp-sample/src/Dapp.sol
+++ b/crates/zksync/compilers/test-data/dapp-sample/src/Dapp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.6;
+pragma solidity 0.8.10;
 
 contract Dapp {
 }

--- a/crates/zksync/compilers/test-data/dapp-sample/src/Dapp.t.sol
+++ b/crates/zksync/compilers/test-data/dapp-sample/src/Dapp.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.6;
+pragma solidity 0.8.10;
 
 import "ds-test/test.sol";
 

--- a/crates/zksync/compilers/tests/zksync_tests.rs
+++ b/crates/zksync/compilers/tests/zksync_tests.rs
@@ -95,7 +95,7 @@ fn zksync_can_set_hash_type_with_supported_versions() {
                 "Contract",
                 r#"
             // SPDX-License-Identifier: MIT OR Apache-2.0
-            pragma solidity ^0.8.10;
+            pragma solidity 0.8.10;
             contract Contract {
                 function call() public {}
             }
@@ -141,7 +141,7 @@ fn test_zksync_can_compile_contract_with_suppressed_errors(zksolc_version: Versi
             "Erroneous",
             r#"
         // SPDX-License-Identifier: MIT OR Apache-2.0
-        pragma solidity ^0.8.10;
+        pragma solidity 0.8.10;
         contract Erroneous {
             function distribute(address payable recipient) public {
                 recipient.send(1);
@@ -190,7 +190,7 @@ fn test_zksync_can_compile_contract_with_suppressed_warnings(zksolc_version: Ver
             "Warning",
             r#"
         // SPDX-License-Identifier: MIT OR Apache-2.0
-        pragma solidity ^0.8.10;
+        pragma solidity 0.8.10;
         contract Warning {
             function test() public view {
                 require(tx.origin != address(0), "what");
@@ -252,7 +252,7 @@ fn test_zksync_can_compile_contract_with_assembly_create_suppressed_warnings(
             "Warning",
             r#"
         // SPDX-License-Identifier: MIT OR Apache-2.0
-        pragma solidity ^0.8.10;
+        pragma solidity 0.8.10;
         contract Warning {
             function deployWithCreate(bytes memory bytecode) public returns (address addr) {
                 assembly {
@@ -476,7 +476,7 @@ fn zksync_can_emit_build_info() {
         .add_source(
             "A",
             r#"
-pragma solidity ^0.8.10;
+pragma solidity 0.8.10;
 import "./B.sol";
 contract A { }
 "#,
@@ -487,7 +487,7 @@ contract A { }
         .add_source(
             "B",
             r"
-pragma solidity ^0.8.10;
+pragma solidity 0.8.10;
 contract B { }
 ",
         )
@@ -738,7 +738,7 @@ fn zksync_detects_change_on_cache_if_zksolc_version_changes() {
         .add_source(
             "A",
             r#"
-pragma solidity ^0.8.10;
+pragma solidity 0.8.10;
 import "./B.sol";
 contract A { }
 "#,
@@ -749,7 +749,7 @@ contract A { }
         .add_source(
             "B",
             r"
-pragma solidity ^0.8.10;
+pragma solidity 0.8.10;
 contract B { }
 ",
         )


### PR DESCRIPTION
# What :computer: 
* Tests now default to use the latest version of Solc 0.8.29, which works with the latest zksolc 1.5.12. For some tests, we forced older versions of zksolc to check backward compatibility but the compiler failed when paired with solc 0.8.29. 

# Why :hand:
* Fix tests

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
