### PR TITLE
build: update checkout action to v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:                  
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Docker meta
               id: meta


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/checkout@v4. Pure maintenance, behavior unchanged.