### PR TITLE
fix: Added test for issue 1036 regarding crypto provider initialization

### DIFF
--- a/crates/forge/tests/it/zk/repros.rs
+++ b/crates/forge/tests/it/zk/repros.rs
@@ -43,3 +43,6 @@ test_repro!(565; |cfg| {
 
 // https://github.com/matter-labs/foundry-zksync/issues/687
 test_repro!(687);
+
+// https://github.com/matter-labs/foundry-zksync/issues/1036
+test_repro!(1036);

--- a/testdata/zk/repros/Issue1036.t.sol
+++ b/testdata/zk/repros/Issue1036.t.sol
@@ -7,7 +7,7 @@ import "cheats/Vm.sol";
 contract Issue1036 is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
-    function test_failingForkViaWebsocket() public {
+    function test_forkSuceedsViaWebsocket() public {
         // The issue presented itself when using websocket endpoints and
         // not initializing properly the crypto provider.
         vm.createSelectFork("wss://mainnet.era.zksync.io/ws");

--- a/testdata/zk/repros/Issue1036.t.sol
+++ b/testdata/zk/repros/Issue1036.t.sol
@@ -6,10 +6,10 @@ import "cheats/Vm.sol";
 
 contract Issue1036 is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
-    
+
     function test_failingForkViaWebsocket() public {
         // The issue presented itself when using websocket endpoints and
         // not initializing properly the crypto provider.
-        vm.createSelectFork('wss://mainnet.era.zksync.io/ws');
+        vm.createSelectFork("wss://mainnet.era.zksync.io/ws");
     }
 }

--- a/testdata/zk/repros/Issue1036.t.sol
+++ b/testdata/zk/repros/Issue1036.t.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Issue1036 is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    
+    function test_failingForkViaWebsocket() public {
+        // The issue presented itself when using websocket endpoints and
+        // not initializing properly the crypto provider.
+        vm.createSelectFork('wss://mainnet.era.zksync.io/ws');
+    }
+}

--- a/zksync-tests
+++ b/zksync-tests
@@ -113,6 +113,7 @@ forge::it:
     zk::paymaster::test_zk_contract_paymaster
     zk::paymaster::test_zk_deploy_with_paymaster
     zk::proxy::script_zk_can_deploy_proxy
+    zk::repros::issue_1036
     zk::repros::issue_497
     zk::repros::issue_565
     zk::repros::issue_687


### PR DESCRIPTION
# What :computer: 
* Latest upstream merge solved the crypto provider initialization that when missing it led to a panic when forking via websocket endpoint.  
* #1036 

# Why :hand:
* Added test to avoid a regression
 
# Evidence :camera:
New test passing 

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
