### PR TITLE
chore: Upstream 1a5ff59 merge (#1039)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+[test-groups]
+chisel-serial = { max-threads = 1 }
+
 [profile.default]
 retries = { backoff = "exponential", count = 2, delay = "3s", jitter = true }
 slow-timeout = { period = "1m", terminate-after = 3 }
@@ -9,3 +12,7 @@ slow-timeout = { period = "5m", terminate-after = 4 }
 [[profile.default.overrides]]
 filter = "package(foundry-cheatcodes-spec)"
 retries = 0
+
+[[profile.default.overrides]]
+filter = "package(chisel)"
+test-group = "chisel-serial"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,7 +219,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "winnow 0.7.6",
+ "winnow 0.7.7",
 ]
 
 [[package]]
@@ -555,7 +545,7 @@ checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -917,7 +907,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -934,7 +924,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
  "tiny-keccak 2.0.2",
 ]
@@ -953,7 +943,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
 ]
 
@@ -964,7 +954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.6",
+ "winnow 0.7.7",
 ]
 
 [[package]]
@@ -1736,7 +1726,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1758,7 +1748,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1769,7 +1759,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1822,7 +1812,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1833,9 +1823,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c39646d1a6b51240a1a23bb57ea4eebede7e16fbc237fdc876980233dcecb4f"
+checksum = "b6fcc63c9860579e4cb396239570e979376e70aab79e496621748a09913f8b36"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1863,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1898,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
+checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1914,7 +1904,6 @@ dependencies = [
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -1923,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5325c5e2badf4148e850017cc56cc205888c6e0b52c9e29d3501ec577005230"
+checksum = "655097cd83ab1f15575890943135192560f77097413c6dd1733fdbdc453e81ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1946,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.64.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d4bdb0e5f80f0689e61c77ab678b2b9304af329616af38aef5b6b967b8e736"
+checksum = "8efec445fb78df585327094fcef4cad895b154b58711e504db7a93c41aa27151"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1969,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbbb3ce8da257aedbccdcb1aadafbbb6a5fe9adf445db0e1ea897bdc7e22d08"
+checksum = "5e49cca619c10e7b002dc8e66928ceed66ab7f56c1a3be86c5437bf2d8d89bba"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1992,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a78a8f50a1630db757b60f679c8226a8a70ee2ab5f5e6e51dc67f6c61c7cfd"
+checksum = "7420479eac0a53f776cc8f0d493841ffe58ad9d9783f3947be7265784471b47a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2016,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
+checksum = "3503af839bd8751d0bdc5a46b9cac93a003a353e635b0c12cf2376b5b53e41ea"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -2030,7 +2019,6 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
- "once_cell",
  "percent-encoding",
  "sha2",
  "time",
@@ -2194,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2350,7 +2338,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.100",
+ "syn 2.0.101",
  "which 4.4.2",
 ]
 
@@ -2488,7 +2476,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2724,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -2784,7 +2772,6 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "serial_test",
  "solang-parser",
  "solar-parse",
  "strum 0.27.1",
@@ -2932,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
+checksum = "be8c97f3a6f02b9e24cadc12aaba75201d18754b53ea0a9d99642f806ccdb4c9"
 dependencies = [
  "clap",
 ]
@@ -2958,7 +2945,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3491,7 +3478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3501,7 +3488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3568,7 +3555,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3590,7 +3577,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3684,7 +3671,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3705,7 +3692,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3715,7 +3702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3745,7 +3732,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -3758,15 +3745,15 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
 [[package]]
 name = "deunicode"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc55fe0d1f6c107595572ec8b107c0999bb1a2e0b75e37429a4fb0d6474a0e7d"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "dialoguer"
@@ -3878,17 +3865,6 @@ dependencies = [
  "libc",
  "redox_users 0.4.6",
  "winapi",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -4086,7 +4062,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4097,7 +4073,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4368,7 +4344,7 @@ dependencies = [
  "pear",
  "serde",
  "tempfile",
- "toml 0.8.20",
+ "toml 0.8.21",
  "uncased",
  "version_check",
 ]
@@ -4473,7 +4449,6 @@ dependencies = [
  "foundry-zksync-core",
  "futures 0.3.31",
  "globset",
- "humantime-serde",
  "indicatif",
  "inferno",
  "itertools 0.14.0",
@@ -4502,8 +4477,8 @@ dependencies = [
  "thiserror 2.0.12",
  "tikv-jemallocator",
  "tokio",
- "toml 0.8.20",
- "toml_edit 0.22.24",
+ "toml 0.8.21",
+ "toml_edit 0.22.25",
  "tower-http",
  "tracing",
  "watchexec",
@@ -4533,7 +4508,7 @@ dependencies = [
  "serde_json",
  "solang-parser",
  "thiserror 2.0.12",
- "toml 0.8.20",
+ "toml 0.8.21",
  "tracing",
 ]
 
@@ -4548,7 +4523,7 @@ dependencies = [
  "similar-asserts",
  "solang-parser",
  "thiserror 2.0.12",
- "toml 0.8.20",
+ "toml 0.8.21",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4630,7 +4605,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4741,7 +4716,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "toml 0.8.20",
+ "toml 0.8.21",
  "tracing",
  "walkdir",
 ]
@@ -4847,6 +4822,7 @@ dependencies = [
  "foundry-config",
  "foundry-zksync-compilers",
  "itertools 0.14.0",
+ "jiff",
  "num-format",
  "path-slash",
  "reqwest 0.12.15",
@@ -4938,7 +4914,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "winnow 0.7.6",
+ "winnow 0.7.7",
  "yansi",
 ]
 
@@ -5017,7 +4993,6 @@ dependencies = [
 name = "foundry-config"
 version = "0.0.14"
 dependencies = [
- "Inflector",
  "alloy-chains",
  "alloy-primitives",
  "dirs 6.0.0",
@@ -5029,6 +5004,7 @@ dependencies = [
  "foundry-zksync-compilers",
  "glob",
  "globset",
+ "heck",
  "itertools 0.14.0",
  "mesc",
  "number_prefix",
@@ -5039,13 +5015,12 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "serde_regex",
  "similar-asserts",
  "solar-parse",
  "tempfile",
  "thiserror 2.0.12",
- "toml 0.8.20",
- "toml_edit 0.22.24",
+ "toml 0.8.21",
+ "toml_edit 0.22.25",
  "tracing",
  "walkdir",
  "yansi",
@@ -5257,10 +5232,10 @@ dependencies = [
 name = "foundry-macros"
 version = "0.0.14"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5271,7 +5246,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5325,6 +5300,7 @@ dependencies = [
  "foundry-config",
  "futures 0.3.31",
  "httptest",
+ "idna_adapter",
  "parking_lot",
  "rand 0.8.5",
  "regex",
@@ -5569,7 +5545,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5859,7 +5835,7 @@ dependencies = [
  "gix-hashtable",
  "gix-path",
  "gix-utils",
- "gix-validate",
+ "gix-validate 0.9.4",
  "itoa",
  "smallvec",
  "thiserror 2.0.12",
@@ -5868,12 +5844,13 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.15"
+version = "0.10.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f910668e2f6b2a55ff35a1f04df88a1a049f7b868507f4cbeeaa220eaba7be87"
+checksum = "c091d2e887e02c3462f52252c5ea61150270c0f2657b642e8d0d6df56c16e642"
 dependencies = [
  "bstr",
  "gix-trace",
+ "gix-validate 0.10.0",
  "home",
  "once_cell",
  "thiserror 2.0.12",
@@ -5894,7 +5871,7 @@ dependencies = [
  "gix-path",
  "gix-tempfile",
  "gix-utils",
- "gix-validate",
+ "gix-validate 0.9.4",
  "memmap2",
  "thiserror 2.0.12",
  "winnow 0.6.26",
@@ -5946,6 +5923,16 @@ name = "gix-validate"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b5f1253109da6c79ed7cf6e1e38437080bb6d704c76af14c93e2f255234084"
+dependencies = [
+ "bstr",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -6327,22 +6314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6418,7 +6389,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.9",
 ]
 
 [[package]]
@@ -6479,124 +6450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6615,12 +6468,22 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "279259b0ac81c89d11c290495fdcfa96ea3643b7df311c138b6fe8ca5237f0f8"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
+ "idna_mapping",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna_mapping"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5422cc5bc64289a77dbb45e970b86b5e9a04cb500abc7240505aedc1bf40f38"
+dependencies = [
+ "unicode-joining-type",
 ]
 
 [[package]]
@@ -6693,7 +6556,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6780,7 +6643,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml 0.37.4",
+ "quick-xml 0.37.5",
  "rgb",
  "str_stack",
 ]
@@ -6830,7 +6693,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6945,7 +6808,7 @@ checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7121,7 +6984,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7391,12 +7254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7460,7 +7317,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7494,7 +7351,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7579,25 +7436,24 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "7.5.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
  "miette-derive",
- "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "7.5.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7675,7 +7531,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7935,7 +7791,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7947,7 +7803,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8144,7 +8000,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8236,7 +8092,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8295,7 +8151,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8369,7 +8225,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8418,7 +8274,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8501,7 +8357,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -8553,7 +8409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8594,7 +8450,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.24",
+ "toml_edit 0.22.25",
 ]
 
 [[package]]
@@ -8640,7 +8496,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8660,7 +8516,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "version_check",
  "yansi",
 ]
@@ -8720,7 +8576,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8751,7 +8607,7 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8774,7 +8630,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8839,7 +8695,7 @@ dependencies = [
  "chrono",
  "indexmap 2.9.0",
  "newtype-uuid",
- "quick-xml 0.37.4",
+ "quick-xml 0.37.5",
  "strip-ansi-escapes",
  "thiserror 2.0.12",
  "uuid 1.16.0",
@@ -8856,9 +8712,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.4"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -9313,7 +9169,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.9",
  "windows-registry",
 ]
 
@@ -9589,7 +9445,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 1.0.69",
- "toml 0.8.20",
+ "toml 0.8.21",
  "toolchain_find",
 ]
 
@@ -9688,9 +9544,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "4937d110d34408e9e5ad30ba0b0ca3b6a8a390f8db3636db60144ac4fa792750"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -9847,7 +9703,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10052,7 +9908,7 @@ dependencies = [
  "sentry-core",
  "tokio",
  "ureq",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.9",
 ]
 
 [[package]]
@@ -10102,7 +9958,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10113,7 +9969,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10160,16 +10016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10177,7 +10023,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10251,7 +10097,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10275,31 +10121,6 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct 0.2.0",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures 0.3.31",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -10667,7 +10488,7 @@ checksum = "ca2c9ff6e00eeeff12eac9d589f1f20413d3b71b9c0c292d1eefbd34787e0836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10741,9 +10562,9 @@ dependencies = [
 
 [[package]]
 name = "soldeer-core"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc58b150e6ab9407038329da2b904f795faa2a5eb1b5c2c61b016ca07ecd1b2c"
+checksum = "a67f45108aec81281be2c23000bde114d568ac3899026779f21656bbc3d85671"
 dependencies = [
  "bon",
  "chrono",
@@ -10764,7 +10585,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.12",
  "tokio",
- "toml_edit 0.22.24",
+ "toml_edit 0.22.25",
  "uuid 1.16.0",
  "zip",
  "zip-extract",
@@ -10888,7 +10709,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10901,7 +10722,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11047,9 +10868,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11065,7 +10886,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11081,17 +10902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -11156,7 +10966,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11298,7 +11108,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11309,7 +11119,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11403,16 +11213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11454,7 +11254,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11526,7 +11326,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.9",
 ]
 
 [[package]]
@@ -11554,22 +11354,22 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.24",
+ "toml_edit 0.22.25",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
@@ -11587,16 +11387,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.6",
+ "toml_write",
+ "winnow 0.7.7",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
 
 [[package]]
 name = "tonic"
@@ -11755,7 +11562,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12030,6 +11837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12040,6 +11853,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-joining-type"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f8cb47ccb8bc750808755af3071da4a10dcd147b68fc874b7ae4b12543f6f5"
 
 [[package]]
 name = "unicode-linebreak"
@@ -12115,7 +11934,7 @@ dependencies = [
  "rustls 0.23.26",
  "rustls-pki-types",
  "url",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.9",
 ]
 
 [[package]]
@@ -12141,12 +11960,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-width"
@@ -12282,7 +12095,7 @@ source = "git+https://github.com/matter-labs/vise.git?rev=51669f42f60c50b3a52166
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12371,7 +12184,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -12406,7 +12219,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -12532,9 +12345,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c5a41f2bcb7314344079d0891505458cc2f4b422bdea1d5bfbe6d1a04903b"
+checksum = "08bcbdcad8fb2e316072ba6bbe09419afdb550285668ac2534f4230a6f2da0ee"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -12544,9 +12357,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "180d2741b6115c3d906577e6533ad89472d48d96df00270fccb78233073d77f7"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12559,9 +12372,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12694,7 +12507,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12705,7 +12518,7 @@ checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12716,7 +12529,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12727,7 +12540,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12738,7 +12551,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13102,9 +12915,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -13133,18 +12946,6 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -13206,30 +13007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13240,11 +13017,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -13255,39 +13032,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "synstructure",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13307,29 +13063,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13586,7 +13320,7 @@ dependencies = [
  "serde_json_path_to_error",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "syn 2.0.100",
+ "syn 2.0.101",
  "tera",
  "thiserror 1.0.69",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,6 +346,12 @@ vergen = { version = "8", default-features = false }
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 httptest = "0.16.3"
 path-slash = "0.2"
+jiff = "0.2"
+
+# Use unicode-rs which has a smaller binary size than the default ICU4X as the IDNA backend, used
+# by the `url` crate.
+# See the `idna_adapter` README.md for more details: https://docs.rs/crate/idna_adapter/latest
+idna_adapter = "=1.1.0"
 
 [patch.crates-io]
 vise = { git = "https://github.com/matter-labs/vise.git", rev = "51669f42f60c50b3a521662a4ecd71212a303299" }

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1027,14 +1027,18 @@ async fn test_mine_blks_with_same_timestamp() {
         blk_futs.push(provider.get_block(i.into()).into_future());
     }
 
-    let blks = futures::future::join_all(blk_futs)
+    let timestamps = futures::future::join_all(blk_futs)
         .await
         .into_iter()
         .map(|blk| blk.unwrap().unwrap().header.timestamp)
         .collect::<Vec<_>>();
 
-    // timestamps should be equal
-    assert_eq!(blks, vec![init_timestamp; 4]);
+    // All timestamps should be equal. Allow for 1 second difference.
+    assert!(timestamps.windows(2).all(|w| w[0] == w[1]), "{timestamps:#?}");
+    assert!(
+        timestamps[0] == init_timestamp || timestamps[0] == init_timestamp + 1,
+        "{timestamps:#?} != {init_timestamp}"
+    );
 }
 
 // <https://github.com/foundry-rs/foundry/issues/8962>

--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -100,7 +100,7 @@ fn handle_revert(
         Ok(())
     } else {
         let (actual, expected) = if let Some(contracts) = known_contracts {
-            let decoder = RevertDecoder::new().with_abis(contracts.iter().map(|(_, c)| &c.abi));
+            let decoder = RevertDecoder::new().with_abis(contracts.values().map(|c| &c.abi));
             (
                 &decoder.decode(actual_revert.as_slice(), Some(status)),
                 &decoder.decode(expected_reason, Some(status)),

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -62,7 +62,6 @@ walkdir.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
-serial_test = "3"
 tracing-subscriber.workspace = true
 
 [features]

--- a/crates/chisel/tests/cache.rs
+++ b/crates/chisel/tests/cache.rs
@@ -1,11 +1,9 @@
 use chisel::session::ChiselSession;
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::Config;
-use serial_test::serial;
 use std::path::Path;
 
 #[test]
-#[serial]
 fn test_cache_directory() {
     // Get the cache dir
     // Should be ~/.foundry/cache/chisel
@@ -17,7 +15,6 @@ fn test_cache_directory() {
 }
 
 #[test]
-#[serial]
 fn test_create_cache_directory() {
     // Get the cache dir
     let cache_dir = ChiselSession::cache_dir().unwrap();
@@ -30,7 +27,6 @@ fn test_create_cache_directory() {
 }
 
 #[test]
-#[serial]
 fn test_write_session() {
     // Create the cache directory if it doesn't exist
     let cache_dir = ChiselSession::cache_dir().unwrap();
@@ -58,7 +54,6 @@ fn test_write_session() {
 }
 
 #[test]
-#[serial]
 fn test_write_session_with_name() {
     // Create the cache directory if it doesn't exist
     let cache_dir = ChiselSession::cache_dir().unwrap();
@@ -83,7 +78,6 @@ fn test_write_session_with_name() {
 }
 
 #[test]
-#[serial]
 fn test_clear_cache() {
     // Create a session to validate clearing a non-empty cache directory
     let cache_dir = ChiselSession::cache_dir().unwrap();
@@ -108,7 +102,6 @@ fn test_clear_cache() {
 }
 
 #[test]
-#[serial]
 fn test_list_sessions() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
@@ -135,7 +128,6 @@ fn test_list_sessions() {
 }
 
 #[test]
-#[serial]
 fn test_load_cache() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
@@ -163,7 +155,6 @@ fn test_load_cache() {
 }
 
 #[test]
-#[serial]
 fn test_write_same_session_multiple_times() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
@@ -186,7 +177,6 @@ fn test_write_same_session_multiple_times() {
 }
 
 #[test]
-#[serial]
 fn test_load_latest_cache() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -59,18 +59,19 @@ comfy-table.workspace = true
 dunce.workspace = true
 eyre.workspace = true
 itertools.workspace = true
+jiff.workspace = true
 num-format.workspace = true
+path-slash.workspace = true
 reqwest.workspace = true
 semver.workspace = true
-serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 walkdir.workspace = true
 yansi.workspace = true
-path-slash.workspace = true
 
 anstream.workspace = true
 anstyle.workspace = true

--- a/crates/common/src/serde_helpers.rs
+++ b/crates/common/src/serde_helpers.rs
@@ -125,3 +125,25 @@ where
 
     Ok(num)
 }
+
+pub mod duration {
+    use serde::{Deserialize, Deserializer};
+    use std::time::Duration;
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let d = jiff::SignedDuration::try_from(*duration).map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&format!("{d:#}"))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let d = s.parse::<jiff::SignedDuration>().map_err(serde::de::Error::custom)?;
+        d.try_into().map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -29,7 +29,7 @@ eyre.workspace = true
 figment = { workspace = true, features = ["toml", "env"] }
 glob = "0.3"
 globset = "0.4"
-Inflector = "0.11"
+heck = "0.5"
 itertools.workspace = true
 mesc.workspace = true
 number_prefix = "0.4"
@@ -37,7 +37,6 @@ regex.workspace = true
 reqwest.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
-serde_regex = "1"
 serde.workspace = true
 thiserror.workspace = true
 toml = { workspace = true, features = ["preserve_order"] }

--- a/crates/config/src/etherscan.rs
+++ b/crates/config/src/etherscan.rs
@@ -9,7 +9,7 @@ use figment::{
     value::{Dict, Map},
     Error, Metadata, Profile, Provider,
 };
-use inflector::Inflector;
+use heck::ToKebabCase;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::BTreeMap,

--- a/crates/config/src/providers/ext.rs
+++ b/crates/config/src/providers/ext.rs
@@ -5,7 +5,7 @@ use figment::{
     Error, Figment, Metadata, Profile, Provider,
 };
 use foundry_compilers::ProjectPathsConfig;
-use inflector::Inflector;
+use heck::ToSnakeCase;
 use std::path::{Path, PathBuf};
 
 pub(crate) trait ProviderExt: Provider + Sized {

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -78,7 +78,7 @@ impl FailedInvariantCaseData {
     ) -> Self {
         // Collect abis of fuzzed and invariant contracts to decode custom error.
         let revert_reason = RevertDecoder::new()
-            .with_abis(targeted_contracts.targets.lock().iter().map(|(_, c)| &c.abi))
+            .with_abis(targeted_contracts.targets.lock().values().map(|c| &c.abi))
             .with_abi(invariant_contract.abi)
             .decode(call_result.result.as_ref(), Some(call_result.exit_reason));
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -39,7 +39,6 @@ rayon.workspace = true
 serde.workspace = true
 tracing.workspace = true
 yansi.workspace = true
-humantime-serde = "1.1.1"
 chrono.workspace = true
 
 # bin

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -205,7 +205,7 @@ impl TestOutcome {
 #[derive(Clone, Debug, Serialize)]
 pub struct SuiteResult {
     /// Wall clock time it took to execute all tests in this suite.
-    #[serde(with = "humantime_serde")]
+    #[serde(with = "foundry_common::serde_helpers::duration")]
     pub duration: Duration,
     /// Individual test results: `test fn signature -> TestResult`.
     pub test_results: BTreeMap<String, TestResult>,
@@ -409,6 +409,7 @@ pub struct TestResult {
     /// Labeled addresses
     pub labeled_addresses: AddressHashMap<String>,
 
+    #[serde(with = "foundry_common::serde_helpers::duration")]
     pub duration: Duration,
 
     /// pc breakpoint char map

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1046,13 +1046,13 @@ eof = false
 additional_compiler_profiles = []
 compilation_restrictions = []
 
-[[profile.default.fs_permissions]]
-access = "read"
-path = "out"
-
 [profile.default.rpc_storage_caching]
 chains = "all"
 endpoints = "all"
+
+[[profile.default.fs_permissions]]
+access = "read"
+path = "out"
 
 [profile.default.zksync]
 compile = false

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2670,3 +2670,42 @@ Error: script failed: <empty revert data>
 
 "#]]);
 });
+
+// Tests that script warns if no tx to broadcast.
+// <https://github.com/foundry-rs/foundry/issues/10015>
+forgetest_async!(warns_if_no_transactions_to_broadcast, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_script(
+        "NoTxScript.s.sol",
+        r#"
+        import {Script} from "forge-std/Script.sol";
+
+    contract NoTxScript is Script {
+        function run() public {
+            vm.startBroadcast();
+            // No real tx created
+            vm.stopBroadcast();
+        }
+    }
+    "#,
+    )
+    .unwrap();
+
+    cmd.args([
+        "script",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--rpc-url",
+        &handle.http_endpoint(),
+        "--broadcast",
+        "NoTxScript",
+    ])
+    .assert_success()
+    .stderr_eq(str![
+        r#"
+Warning: No transactions to broadcast.
+
+"#
+    ]);
+});

--- a/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
@@ -15,10 +15,7 @@
                 },
                 "traces": [],
                 "labeled_addresses": {},
-                "duration": {
-                    "secs": "{...}",
-                    "nanos": "{...}"
-                },
+                "duration": "{...}",
                 "breakpoints": {},
                 "gas_snapshots": {}
             }

--- a/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
@@ -204,10 +204,7 @@
           ]
         ],
         "labeled_addresses": {},
-        "duration": {
-          "secs": "{...}",
-          "nanos": "{...}"
-        },
+        "duration": "{...}",
         "breakpoints": {},
         "gas_snapshots": {}
       }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -22,4 +22,4 @@ doc = false
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-proc-macro-error = "1"
+proc-macro-error2 = "2"

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -6,10 +6,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
-extern crate proc_macro_error;
+extern crate proc_macro_error2;
 
 use proc_macro::TokenStream;
-use proc_macro_error::proc_macro_error;
 use syn::{parse_macro_input, DeriveInput, Error};
 
 mod cheatcodes;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -284,6 +284,10 @@ impl ScriptArgs {
                 .as_ref()
                 .is_none_or(|txs| txs.is_empty())
             {
+                if pre_simulation.args.broadcast {
+                    sh_warn!("No transactions to broadcast.")?;
+                }
+
                 return Ok(());
             }
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -48,6 +48,9 @@ anvil_zksync_api_server.workspace = true
 anvil_zksync_config.workspace = true
 anvil_zksync_l1_sidecar.workspace = true
 
+# See /Cargo.toml.
+idna_adapter.workspace = true
+
 [dev-dependencies]
 tokio.workspace = true
 foundry-block-explorers.workspace = true

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -10,6 +10,9 @@
 #[macro_use]
 extern crate tracing;
 
+// See /Cargo.toml.
+use idna_adapter as _;
+
 // Macros useful for testing.
 mod macros;
 

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -10,35 +10,40 @@ use std::sync::{
     LazyLock,
 };
 
+fn shuffled<T>(mut vec: Vec<T>) -> Vec<T> {
+    vec.shuffle(&mut rand::thread_rng());
+    vec
+}
+
 // List of public archive reth nodes to use
 static RETH_ARCHIVE_HOSTS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
-    let mut hosts = vec!["reth-ethereum.ithaca.xyz"];
-    hosts.shuffle(&mut rand::thread_rng());
-    hosts
+    shuffled(vec![
+        //
+        "reth-ethereum.ithaca.xyz",
+    ])
 });
 
 // List of public reth nodes to use (archive and non archive)
 static RETH_HOSTS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
-    let mut hosts = vec!["reth-ethereum.ithaca.xyz", "reth-ethereum-full.ithaca.xyz"];
-    hosts.shuffle(&mut rand::thread_rng());
-    hosts
+    shuffled(vec![
+        //
+        "reth-ethereum.ithaca.xyz",
+        "reth-ethereum-full.ithaca.xyz",
+    ])
 });
 
 // List of general purpose DRPC keys to rotate through
 static DRPC_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
-    let mut keys = vec![
+    shuffled(vec![
+        //
         "Agc9NK9-6UzYh-vQDDM80Tv0A5UnBkUR8I3qssvAG40d",
         "AjUPUPonSEInt2CZ_7A-ai3hMyxxBlsR8I4EssvAG40d",
-    ];
-
-    keys.shuffle(&mut rand::thread_rng());
-
-    keys
+    ])
 });
 
 // List of etherscan keys for mainnet
 static ETHERSCAN_MAINNET_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
-    let mut keys = vec![
+    shuffled(vec![
         "MCAUM7WPE9XP5UQMZPCKIBUJHPM1C24FP6",
         "JW6RWCG2C5QF8TANH4KC7AYIF1CX7RB5D1",
         "ZSMDY6BI2H55MBE3G9CUUQT4XYUDBB6ZSK",
@@ -51,14 +56,16 @@ static ETHERSCAN_MAINNET_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
         "ZUB97R31KSYX7NYVW6224Q6EYY6U56H591",
         // Optimism
         // "JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46",
-    ];
-    keys.shuffle(&mut rand::thread_rng());
-    keys
+    ])
 });
 
 // List of etherscan keys for Optimism.
-static ETHERSCAN_OPTIMISM_KEYS: LazyLock<Vec<&'static str>> =
-    LazyLock::new(|| vec!["JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46"]);
+static ETHERSCAN_OPTIMISM_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    shuffled(vec![
+        //
+        "JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46",
+    ])
+});
 
 /// Returns the next index to use.
 fn next_idx() -> usize {

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -302,7 +302,7 @@ impl VerifyBytecodeArgs {
             .await?;
 
             let match_type = crate::utils::match_bytecodes(
-                &deployed_bytecode.original_bytes(),
+                deployed_bytecode.original_byte_slice(),
                 &onchain_runtime_code,
                 &constructor_args,
                 true,
@@ -513,7 +513,7 @@ impl VerifyBytecodeArgs {
 
             // Compare the onchain runtime bytecode with the runtime code from the fork.
             let match_type = crate::utils::match_bytecodes(
-                &fork_runtime_code.original_bytes(),
+                fork_runtime_code.original_byte_slice(),
                 &onchain_runtime_code,
                 &constructor_args,
                 true,

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -199,29 +199,24 @@ fn is_partial_match(
 }
 
 fn try_extract_and_compare_bytecode(mut local_bytecode: &[u8], mut bytecode: &[u8]) -> bool {
-    local_bytecode = extract_metadata_hash(local_bytecode);
-    bytecode = extract_metadata_hash(bytecode);
+    local_bytecode = ignore_metadata_hash(local_bytecode);
+    bytecode = ignore_metadata_hash(bytecode);
 
     // Now compare the local code and bytecode
     local_bytecode == bytecode
 }
 
-/// @dev This assumes that the metadata is at the end of the bytecode
-fn extract_metadata_hash(bytecode: &[u8]) -> &[u8] {
-    // Get the last two bytes of the bytecode to find the length of CBOR metadata
-    let metadata_len = &bytecode[bytecode.len() - 2..];
-    let metadata_len = u16::from_be_bytes([metadata_len[0], metadata_len[1]]);
-
-    if metadata_len as usize <= bytecode.len() {
-        if ciborium::from_reader::<ciborium::Value, _>(
-            &bytecode[bytecode.len() - 2 - metadata_len as usize..bytecode.len() - 2],
-        )
-        .is_ok()
-        {
-            &bytecode[..bytecode.len() - 2 - metadata_len as usize]
-        } else {
-            bytecode
-        }
+/// This assumes that the metadata is at the end of the bytecode.
+fn ignore_metadata_hash(bytecode: &[u8]) -> &[u8] {
+    // Get the last two bytes of the bytecode to find the length of CBOR metadata.
+    let Some((rest, metadata_len_bytes)) = bytecode.split_last_chunk() else { return bytecode };
+    let metadata_len = u16::from_be_bytes(*metadata_len_bytes) as usize;
+    if metadata_len > rest.len() {
+        return bytecode;
+    }
+    let (rest, metadata) = rest.split_at(rest.len() - metadata_len);
+    if ciborium::from_reader::<ciborium::Value, _>(metadata).is_ok() {
+        rest
     } else {
         bytecode
     }

--- a/deny.toml
+++ b/deny.toml
@@ -10,12 +10,12 @@ ignore = [
     # Used by boojum
     # derivative is unmaintained
     "RUSTSEC-2024-0388",
-    # deprecated paste used by alloy-primitives
+    # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
     # protobuf in trezor_client
     "RUSTSEC-2024-0437",
     # https://rustsec.org/advisories/RUSTSEC-2025-0021 gitoxide uses SHA-1 hash implementations without any collision detection, leaving it vulnerable to hash collision attacks.
-    "RUSTSEC-2025-0021"
+    "RUSTSEC-2025-0021",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -71,6 +71,7 @@ allow = [
     "CDDL-1.0",
     "Zlib",
     "OpenSSL",
+    "CDLA-Permissive-2.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
@@ -84,6 +85,9 @@ exceptions = [
     { allow = ["CC0-1.0"], name = "notify" },
     { allow = ["CC0-1.0"], name = "dunce" },
     { allow = ["CC0-1.0"], name = "aurora-engine-modexp" },
+    # Allow CDLA-Permissive-2.0 for webpki crates
+    { allow = ["CDLA-Permissive-2.0"], name = "webpki-root-certs" },
+    { allow = ["CDLA-Permissive-2.0"], name = "webpki-roots" },
 ]
 #copyleft = "deny"
 


### PR DESCRIPTION
* chore(deps): weekly `cargo update` (#10381)

* chore(deps): weekly `cargo update`

     Locking 46 packages to latest compatible versions
   Unchanged alloy-chains v0.1.69 (available: v0.2.0)
   Unchanged alloy-consensus v0.12.6 (available: v0.15.6)
   Unchanged alloy-contract v0.12.6 (available: v0.15.6)
   Unchanged alloy-dyn-abi v0.8.25 (available: v1.0.0)
   Unchanged alloy-eips v0.12.6 (available: v0.15.6)
   Unchanged alloy-genesis v0.12.6 (available: v0.15.6)
   Unchanged alloy-json-abi v0.8.25 (available: v1.0.0)
   Unchanged alloy-json-rpc v0.12.6 (available: v0.15.6)
   Unchanged alloy-network v0.12.6 (available: v0.15.6)
   Unchanged alloy-primitives v0.8.25 (available: v1.0.0)
   Unchanged alloy-provider v0.12.6 (available: v0.15.6)
   Unchanged alloy-pubsub v0.12.6 (available: v0.15.6)
   Unchanged alloy-rpc-client v0.12.6 (available: v0.15.6)
   Unchanged alloy-rpc-types v0.12.6 (available: v0.15.6)
   Unchanged alloy-serde v0.12.6 (available: v0.15.6)
   Unchanged alloy-signer v0.12.6 (available: v0.15.6)
   Unchanged alloy-signer-aws v0.12.6 (available: v0.15.6)
   Unchanged alloy-signer-gcp v0.12.6 (available: v0.15.6)
   Unchanged alloy-signer-ledger v0.12.6 (available: v0.15.6)
   Unchanged alloy-signer-local v0.12.6 (available: v0.15.6)
   Unchanged alloy-signer-trezor v0.12.6 (available: v0.15.6)
   Unchanged alloy-sol-macro-expander v0.8.25 (available: v1.0.0)
   Unchanged alloy-sol-macro-input v0.8.25 (available: v1.0.0)
   Unchanged alloy-sol-types v0.8.25 (available: v1.0.0)
   Unchanged alloy-transport v0.12.6 (available: v0.15.6)
   Unchanged alloy-transport-http v0.12.6 (available: v0.15.6)
   Unchanged alloy-transport-ipc v0.12.6 (available: v0.15.6)
   Unchanged alloy-transport-ws v0.12.6 (available: v0.15.6)
   Unchanged alloy-trie v0.7.9 (available: v0.8.1)
    Updating ammonia v4.0.0 -> v4.1.0
    Updating async-compression v0.4.22 -> v0.4.23
    Updating aws-config v1.6.1 -> v1.6.2
    Updating aws-credential-types v1.2.2 -> v1.2.3
    Updating aws-lc-sys v0.28.1 -> v0.28.2
    Updating aws-runtime v1.5.6 -> v1.5.7
    Updating aws-sdk-kms v1.65.0 -> v1.66.0
    Updating aws-sdk-sso v1.64.0 -> v1.65.0
    Updating aws-sdk-ssooidc v1.65.0 -> v1.66.0
    Updating aws-sdk-sts v1.65.0 -> v1.66.0
    Updating aws-sigv4 v1.3.0 -> v1.3.1
    Updating aws-smithy-http v0.62.0 -> v0.62.1
    Updating aws-smithy-observability v0.1.2 -> v0.1.3
    Updating aws-smithy-runtime v1.8.1 -> v1.8.3
    Updating aws-smithy-runtime-api v1.7.4 -> v1.8.0
    Updating aws-smithy-types v1.3.0 -> v1.3.1
    Updating aws-types v1.3.6 -> v1.3.7
   Unchanged axum v0.7.9 (available: v0.8.3)
   Unchanged backtrace v0.3.71 (available: v0.3.74)
    Updating bon v3.6.1 -> v3.6.3
    Updating bon-macros v3.6.1 -> v3.6.3
    Updating cc v1.2.19 -> v1.2.20
   Unchanged crossterm v0.28.1 (available: v0.29.0)
      Adding cssparser v0.35.0
      Adding cssparser-macros v0.6.1
      Adding dtoa v1.0.10
      Adding dtoa-short v0.3.5
   Unchanged gcloud-sdk v0.26.4 (available: v0.27.0)
    Updating getrandom v0.2.15 -> v0.2.16
    Updating gix-path v0.10.15 -> v0.10.17
      Adding gix-validate v0.10.0
    Updating html5ever v0.27.0 -> v0.31.0
    Updating jiff v0.2.9 -> v0.2.10
    Updating jiff-static v0.2.9 -> v0.2.10
    Updating libm v0.2.11 -> v0.2.13
    Updating markup5ever v0.12.1 -> v0.16.1
      Adding match_token v0.1.0
   Unchanged op-alloy-consensus v0.11.4 (available: v0.15.1)
   Unchanged op-alloy-rpc-types v0.11.4 (available: v0.15.1)
   Unchanged protobuf v3.3.0 (available: v3.7.2)
   Unchanged protobuf-support v3.3.0 (available: v3.7.2)
    Updating quinn-proto v0.11.10 -> v0.11.11
   Unchanged rand v0.8.5 (available: v0.9.1)
   Unchanged revm v19.7.0 (available: v22.0.1)
   Unchanged revm-inspectors v0.16.0 (available: v0.20.0)
   Unchanged revm-primitives v15.2.0 (available: v18.0.0)
    Updating rpassword v7.3.1 -> v7.4.0
    Updating signal-hook-registry v1.4.4 -> v1.4.5
   Unchanged solang-parser v0.3.3 (available: v0.3.4)
    Updating syn v2.0.100 -> v2.0.101
    Updating tokio-util v0.7.14 -> v0.7.15
    Updating toml v0.8.20 -> v0.8.21
    Updating toml_datetime v0.6.8 -> v0.6.9
    Updating toml_edit v0.22.24 -> v0.22.25
      Adding toml_write v0.1.0
   Unchanged vergen v8.3.2 (available: v9.0.6)
      Adding web_atoms v0.1.0
    Removing windows-sys v0.48.0
    Removing windows-targets v0.48.5
    Removing windows_aarch64_gnullvm v0.48.5
    Removing windows_aarch64_msvc v0.48.5
    Removing windows_i686_gnu v0.48.5
    Removing windows_i686_msvc v0.48.5
    Removing windows_x86_64_gnu v0.48.5
    Removing windows_x86_64_gnullvm v0.48.5
    Removing windows_x86_64_msvc v0.48.5
    Updating winnow v0.7.6 -> v0.7.7
    Updating zerocopy v0.8.24 -> v0.8.25
    Updating zerocopy-derive v0.8.24 -> v0.8.25
note: to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`

* chore: clippy

* test

---------




* chore(deps): replace inflector with heck (#10386)

* chore(deps): switch to proc-macro-error2 (#10387)

* chore(deps): remove serde_regex (#10389)

* chore(deps): use unicode-rs as the idna backend (#10390)

* test(anvil): fix flaky test (#10391)

* test: move serial_tests to nextest test groups (#10392)

* chore: metadata hash extraction cleanup (#10396)

* chore(deps): replace humantime with jiff (#10395)

* chore(deps): replace humantime with jiff

* tests

* feat(forge): script warn if no transactions to broadcast (#10384)

* warn if no transactions to broadcast

* Update revert_handlers.rs

* Update error.rs

* moving to sh_warn from warn

* Adding tc for "no tx to broadcast"

* fmt

* Move and fix test

---------



* Add new licenses

---------

# What :computer: 
* First thing updated with this PR
* Second thing updated with this PR
* Third thing updated with this PR

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
