### PR TITLE
fix: avoid retrying verification for already verified contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
           log: info
           logFilePath: anvil_zksync.log
           target: x86_64-unknown-linux-gnu
-          releaseTag: v0.3.2
+          releaseTag: v0.6.1
 
       - name: Setup Git config
         run: |

--- a/.github/workflows/zk-aave-test.yml
+++ b/.github/workflows/zk-aave-test.yml
@@ -36,7 +36,7 @@ jobs:
           log: info
           logFilePath: anvil_zksync.log
           target: x86_64-unknown-linux-gnu
-          releaseTag: v0.3.2
+          releaseTag: v0.6.1
 
       - name: Setup Git config
         run: |


### PR DESCRIPTION
# What :computer: 
* avoid retrying verification for already verified contracts

# Why :hand:
* rather than retrying 5 times for already verified exit with message

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended
```bash
/Users/dustinbrickwood/Documents/dev/zk/devx/foundry-zksync/target/release/forge verify-contract --chain-id 300 0xDc72Fb0Eb865d75877fF23b12aa51C2689aAbf2c src/Counter.sol:Counter --verifier zksync --verifier-url https://explorer.sepolia.era.zksync.dev/contract_verification --zksync
Start verifying contract `0xDc72Fb0Eb865d75877fF23b12aa51C2689aAbf2c` deployed on zksync-testnet

Submitting verification for [src/Counter.sol:Counter] at address 0xDc72Fb0Eb865d75877fF23b12aa51C2689aAbf2c.
Contract [src/Counter.sol:Counter] "0xDc72Fb0Eb865d75877fF23b12aa51C2689aAbf2c" is already verified. Skipping verification.
```

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
