### PR TITLE
feat: dynamic ZKsync/LLVM solc revision selection

### DIFF
--- a/crates/verify/src/etherscan/flatten/zksync.rs
+++ b/crates/verify/src/etherscan/flatten/zksync.rs
@@ -99,6 +99,7 @@ impl EtherscanFlattenedSource {
             },
             solc_version: solc_version.clone(),
             cli_settings: CliSettings::default(),
+            zksolc_version,
             zksolc_path,
         };
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -231,7 +231,7 @@ impl VerifyArgs {
                 .create_verify_request(&self, &context)
                 .await?;
             sh_println!("{}", args.source)?;
-            return Ok(())
+            return Ok(());
         }
 
         let verifier_url = self.verifier.verifier_url.clone();

--- a/crates/verify/src/zksync/mod.rs
+++ b/crates/verify/src/zksync/mod.rs
@@ -5,7 +5,9 @@ use alloy_primitives::hex;
 use eyre::{eyre, Result};
 use foundry_cli::opts::EtherscanOpts;
 use foundry_common::{abi::encode_function_args, retry::Retry};
-use foundry_zksync_compilers::compilers::zksolc::input::StandardJsonCompilerInput;
+use foundry_zksync_compilers::compilers::zksolc::{
+    input::StandardJsonCompilerInput, ZKSOLC_FIRST_VERSION_SUPPORTS_CBOR, ZKSYNC_SOLC_REVISIONS,
+};
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, thread::sleep, time::Duration};
@@ -175,8 +177,15 @@ impl ZkVerificationProvider {
 
         let (solc_version, zk_compiler_version) = match context {
             CompilerVerificationContext::ZkSolc(zk_context) => {
-                // Format solc_version as "zkVM-{compiler_version}-1.0.1"
-                let solc_version = format!("zkVM-{}-1.0.1", zk_context.compiler_version.solc);
+                // Format solc_version as "zkVM-{compiler_version}-1.0.2"
+                let solc_revision =
+                    if zk_context.compiler_version.zksolc >= ZKSOLC_FIRST_VERSION_SUPPORTS_CBOR {
+                        &ZKSYNC_SOLC_REVISIONS[1]
+                    } else {
+                        &ZKSYNC_SOLC_REVISIONS[0]
+                    };
+                let solc_version =
+                    format!("zkVM-{}-{solc_revision}", zk_context.compiler_version.solc);
                 let zk_compiler_version = format!("v{}", zk_context.compiler_version.zksolc);
                 (solc_version, zk_compiler_version)
             }

--- a/crates/zksync/compilers/src/compilers/zksolc/input.rs
+++ b/crates/zksync/compilers/src/compilers/zksolc/input.rs
@@ -29,6 +29,8 @@ pub struct ZkSolcVersionedInput {
     pub solc_version: Version,
     /// zksolc cli settings
     pub cli_settings: solc::CliSettings,
+    /// zksolc version
+    pub zksolc_version: Version,
     /// zksolc binary path
     pub zksolc_path: PathBuf,
 }
@@ -52,7 +54,7 @@ impl CompilerInput for ZkSolcVersionedInput {
         let input =
             ZkSolcInput::new(language, sources, settings, &zksolc_version).sanitized(&version);
 
-        Self { solc_version: version, input, cli_settings, zksolc_path }
+        Self { solc_version: version, input, cli_settings, zksolc_version, zksolc_path }
     }
 
     fn language(&self) -> Self::Language {


### PR DESCRIPTION
# What :computer: 

Removes the hardcoded [solc revision 1.0.1](https://github.com/matter-labs/era-solidity/releases) and selects it depending on the zksolc version.

# Why :hand:

ZKsync/LLVM solc revision 1.0.2 with important bug fixes will be released soon. It must be handled properly DevEx-wise and make contract verification predictable.

[CBOR-encoded metadata](https://matter-labs.github.io/era-compiler-solidity/latest/02-command-line-interface.html#--metadata-hash) with compiler versions has been introduced in zksolc v1.5.13. Now all bytecode produced by v1.5.13 and newer will include all compiler versions used for compilation (solc_version, solc_revision, zksolc_version) unless [explicitly disabled](https://matter-labs.github.io/era-compiler-solidity/latest/02-command-line-interface.html#--no-cbor-metadata) with `--no-cbor-metadata`.
Thus, if zksolc version is set to v1.5.12 or older, Foundry will keep using 1.0.1 as before, whereas for v1.5.13 and newer solc revision 1.0.2 will be used.

On the verifier side, CBOR-encoded metadata will be the first object to look for the solc version and revision, leading to more or less automatic experience.

# Note 🗒️ 

Older Foundry versions that will keep using solc revision 1.0.1 with zksolc v1.5.13 and newer regardless of this update, but CBOR-encoded metadata *will have this information*.

# Warning ⚠️ 

The only issue remains when all of the below is true:
1. The plugin version is old
2. zksolc version <= 1.5.12
3. solc revision == 1.0.2

But in this case there is nothing we can do.