### PR TITLE
fix: address issue with replaying tx via cast run 

### DIFF
--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -124,9 +124,10 @@ pub fn configure_zksync_tx_env(
     env.tx.transact_to = TxKind::Call(
         outer_tx.recipient_account().expect("recipient_account not found in execute").to_address(),
     );
-
-    env.tx.gas_limit = outer_tx.gas_limit().as_u64();
-
+    env.tx.gas_limit = match &outer_tx.common_data {
+        ExecuteTransactionCommon::L2(l2) => l2.fee.gas_limit.as_u64(),
+        _ => outer_tx.gas_limit().as_u64(),
+    };
     env.tx.nonce = Some(outer_tx.nonce().expect("nonce not found in common_data").0.into());
 
     env.tx.value = outer_tx.execute.value.to_ru256();

--- a/crates/verify/src/zk_provider.rs
+++ b/crates/verify/src/zk_provider.rs
@@ -135,6 +135,7 @@ impl ZkVerificationContext {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum CompilerVerificationContext {
     Solc(VerificationContext),
     ZkSolc(ZkVerificationContext),

--- a/crates/zksync/core/src/utils.rs
+++ b/crates/zksync/core/src/utils.rs
@@ -111,12 +111,8 @@ pub fn get_private_key(private_key: &Option<String>) -> Result<H256> {
 /// happen:
 ///   * The scripts can fail if the balance is not enough for gas * MAGIC_VALUE
 ///   * The tests/deploy can fail if MAGIC_VALUE is too low
-pub fn fix_l2_gas_price(gas_price: U256, base_fee: U256) -> U256 {
-    if base_fee.is_zero() && gas_price < U256::from(260_000_000) {
-        U256::from(260_000_000)
-    } else {
-        gas_price
-    }
+pub fn fix_l2_gas_price(gas_price: U256) -> U256 {
+    U256::max(gas_price, U256::from(260_000_000))
 }
 
 /// Limits the gas_limit proportional to a user's available balance given the gas_price.
@@ -126,12 +122,13 @@ pub fn fix_l2_gas_limit(
     gas_price: U256,
     value: U256,
     balance: U256,
-    base_fee: U256,
 ) -> U256 {
-    if base_fee.is_zero() && !gas_price.is_zero() && balance > value {
-        let max_by_balance = balance.saturating_sub(value) / gas_price;
-        U256::min(U256::min(proposed_gas_limit, max_by_balance), U256::from(MAX_L2_GAS_LIMIT))
-    } else {
+    let gas_limit = if gas_price.is_zero() || balance <= value {
         proposed_gas_limit
-    }
+    } else {
+        let max_gas_limit = balance.saturating_sub(value).div_mod(gas_price).0;
+        U256::min(proposed_gas_limit, max_gas_limit)
+    };
+
+    U256::min(gas_limit, U256::from(MAX_L2_GAS_LIMIT))
 }

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -220,7 +220,7 @@ where
     let storage_ptr =
         StorageView::new(&mut era_db, modified_storage_keys, tx.common_data.initiator_address)
             .into_rc_ptr();
-    
+
     let InnerZkVmResult {
         tx_result,
         bytecodes,
@@ -430,10 +430,10 @@ where
     DB: Database,
     <DB as Database>::Error: Debug,
 {
-    let value   = ecx.env.tx.value.to_u256();
+    let value = ecx.env.tx.value.to_u256();
     let basefee = ecx.env.block.basefee.to_u256();
-    let gas0    = ecx.env.tx.gas_price.to_u256();
-    let limit0  = ecx.env.tx.gas_limit.into();
+    let gas0 = ecx.env.tx.gas_price.to_u256();
+    let limit0 = ecx.env.tx.gas_limit.into();
 
     let use_paymaster = !paymaster_params.paymaster.is_zero();
     let payer = if use_paymaster {
@@ -445,7 +445,7 @@ where
 
     // apply heuristics only for dev-nets (baseFee == 0)
     let max_fee_per_gas = fix_l2_gas_price(gas0, basefee);
-    let gas_limit       = fix_l2_gas_limit(limit0, max_fee_per_gas, value, balance, basefee);
+    let gas_limit = fix_l2_gas_limit(limit0, max_fee_per_gas, value, balance, basefee);
 
     (gas_limit, max_fee_per_gas)
 }
@@ -511,11 +511,11 @@ fn inspect_inner<S: ReadStorage + StorageAccessRecorder>(
     let batch_env = create_l1_batch_env(storage.clone(), &ccx.zk_env);
 
     let system_env = create_system_env(BASELINE_CONTRACTS.clone(), chain_id);
-    
+
     let mut vm: Vm<_, HistoryDisabled> = Vm::new(batch_env, system_env, storage.clone());
-    
+
     let tx: Transaction = l2_tx.clone().into();
-    
+
     let call_tracer_result = Arc::default();
     let cheatcode_tracer_result = Arc::default();
     let mut expected_calls = HashMap::<_, _>::new();
@@ -540,7 +540,7 @@ fn inspect_inner<S: ReadStorage + StorageAccessRecorder>(
         )
         .into_tracer_pointer(),
     ];
-    
+
     let compressed_bytecodes = vm.push_transaction(tx).compressed_bytecodes.into_owned();
     let mut tx_result = vm.inspect(&mut tracers.into(), InspectExecutionMode::OneTx);
     let mut call_traces = Arc::try_unwrap(call_tracer_result).unwrap().take().unwrap_or_default();

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -1,4 +1,3 @@
-use crate::convert::ConvertU256;
 use alloy_primitives::{hex, FixedBytes, Log};
 use anvil_zksync_config::types::{BoojumConfig, SystemContractsOptions as Options};
 use anvil_zksync_core::{formatter::Formatter, system_contracts::SystemContracts};
@@ -450,8 +449,6 @@ where
 
     let max_fee_per_gas = fix_l2_gas_price(gas_price);
     let gas_limit = fix_l2_gas_limit(gas_limit, max_fee_per_gas, value, balance);
-
-    ecx.env.block.basefee = max_fee_per_gas.to_ru256();
 
     (gas_limit, max_fee_per_gas)
 }


### PR DESCRIPTION
# What :computer: 
* Turns on evm_interpreter 
* Fixes gas issues

**Note:** Some improvements can still be made, for instance we return `Error function_selector = 0xe8d529f9, data = 0xe8d529f9` as a String and its never decoded via Openchain. We should improve this to do so, then its human readable as `OrderFailed()` instead of `0xe8d529f9`.

# Why :hand:
* By specifying true for base system contracts for evm interpreter we can successfully replay both EraVM and EVM transactions during replay
* The gas calculation has not been updated for quite some time resulting in incorrect gas limits 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

**BEFORE:**

```
cast run --zksync --rpc-url https://api.mainnet.abs.xyz 0x7b902729627b4a027b30498feea48299fac067443f9a32907df2200537b3b320 -vvvvv --decode-internal
Executing previous transactions from the block.
2025-06-11T19:45:37.004465Z ERROR foundry_zksync_core::vm::tracers::error: vm error: Not enough gas
2025-06-11T19:45:37.005124Z ERROR foundry_zksync_core::vm::tracers::error: vm error: Not enough gas
2025-06-11T19:45:37.005184Z ERROR foundry_zksync_core::vm::tracers::error: vm error: Not enough gas
2025-06-11T19:45:37.005204Z ERROR foundry_zksync_core::vm::tracers::error: vm error: Not enough gas
2025-06-11T19:45:37.005749Z ERROR foundry_zksync_core::vm::inspect: tx execution halted: Account validation error: Not enough gas for transaction validation
Traces:
  [0] 0x0000000000000000000000000000000000000000::fallback()
    └─ ← [Continue] <empty revert data>


Error: Transaction failed.
Gas used: 38017
```

**NOW:**

```
cast run --zksync --rpc-url https://api.mainnet.abs.xyz 0x7b902729627b4a027b30498feea48299fac067443f9a32907df2200537b3b320 -vvvvv --decode-internal
Executing previous transactions from the block.
Traces:
  [36279] 0x634E831cE6D460c2CD5067Af98D6452Eb280E374::7e42ae50{value: 17073000000000000}(59d1364475c1130d58882a5f85744008a462b0b53e3a83f86ecd9eee865d8597)
    ├─ [204] 0xf70da97812CB96acDF810712Aa562db8dfA3dbEF::fallback{value: 17073000000000000}()
    │   └─ ← [Return]
    └─ ← [Return]


Transaction successfully executed.
Gas used: 150717
```

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
