### PR TITLE
fix: addresses issue with state diff recording idx

### DIFF
--- a/testdata/zk/StateDiff.t.sol
+++ b/testdata/zk/StateDiff.t.sol
@@ -831,13 +831,12 @@ contract ZkStateDiffTest is DSTest {
 
     function testNoDuplicateAccountAccess() external {
         DeepDelegator deep = new DeepDelegator();
-    
+
         vm.startStateDiffRecording();
         deep.deepAccess(store1, store2);
-    
-        Vm.AccountAccess[] memory diff =
-            filterCallOrCreate(vm.stopAndReturnStateDiff());
-    
+
+        Vm.AccountAccess[] memory diff = filterCallOrCreate(vm.stopAndReturnStateDiff());
+
         assertEq(diff.length, 7, "unexpected extra account-access entry");
     }
 

--- a/testdata/zk/StateDiff.t.sol
+++ b/testdata/zk/StateDiff.t.sol
@@ -30,6 +30,12 @@ contract StorageAccessorDelegator {
     }
 }
 
+contract DeepDelegator {
+    function deepAccess(StorageAccessor a, StorageAccessor b) external {
+        new StorageAccessorDelegator().accessDelegation(a, b);
+    }
+}
+
 contract Payment {
     constructor() payable {}
 
@@ -821,6 +827,18 @@ contract ZkStateDiffTest is DSTest {
         });
 
         assertEq(expected, diff);
+    }
+
+    function testNoDuplicateAccountAccess() external {
+        DeepDelegator deep = new DeepDelegator();
+    
+        vm.startStateDiffRecording();
+        deep.deepAccess(store1, store2);
+    
+        Vm.AccountAccess[] memory diff =
+            filterCallOrCreate(vm.stopAndReturnStateDiff());
+    
+        assertEq(diff.length, 7, "unexpected extra account-access entry");
     }
 
     function concat(Vm.StorageAccess memory a) internal pure returns (Vm.StorageAccess[] memory out) {


### PR DESCRIPTION
# What :computer: 
* Updates `zksync_remove_duplicate_account_access` to use the most recent stack entry and check bounds before removal, logging a warning if the index is out of range

# Why :hand:
* Closes #1064 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
