### PR TITLE
fix: improve error handling and add dry-run support for zkSync deployment

### DIFF
--- a/crates/cast/tests/cli/zk.rs
+++ b/crates/cast/tests/cli/zk.rs
@@ -688,7 +688,16 @@ casttest!(test_zk_cast_run_with_create, async |prj, cmd| {
 
     let output = cmd
         .forge_fuse()
-        .args(["create", "Counter", "--rpc-url", &url, "--private-key", private_key, "--zksync"])
+        .args([
+            "create",
+            "Counter",
+            "--rpc-url",
+            &url,
+            "--private-key",
+            private_key,
+            "--zksync",
+            "--broadcast",
+        ])
         .assert_success()
         .get_output()
         .stdout_lossy();
@@ -745,7 +754,16 @@ casttest!(test_zk_cast_run_with_call, async |prj, cmd| {
 
     let output = cmd
         .forge_fuse()
-        .args(["create", "Counter", "--rpc-url", &url, "--private-key", private_key, "--zksync"])
+        .args([
+            "create",
+            "Counter",
+            "--rpc-url",
+            &url,
+            "--private-key",
+            private_key,
+            "--zksync",
+            "--broadcast",
+        ])
         .assert_success()
         .get_output()
         .stdout_lossy();

--- a/crates/forge/src/cmd/create/zksync.rs
+++ b/crates/forge/src/cmd/create/zksync.rs
@@ -304,6 +304,30 @@ impl CreateArgs {
             self.verify_preflight_check(constructor_args.clone(), chain, &id).await?;
         }
 
+        // Whether to broadcast the transaction or not
+        let dry_run = !self.broadcast;
+
+        if dry_run {
+            if !shell::is_json() {
+                sh_warn!("Dry run enabled, not broadcasting transaction\n")?;
+
+                sh_println!("Contract: {}", &self.contract.name)?;
+                sh_println!("Transaction: {}", serde_json::to_string_pretty(&deployer.tx)?)?;
+                sh_println!("ABI: {}\n", serde_json::to_string_pretty(&abi)?)?;
+
+                sh_warn!("To broadcast this transaction, add --broadcast to the previous command. See forge create --help for more.")?;
+            } else {
+                let output = json!({
+                    "contract": &self.contract.name,
+                    "transaction": &deployer.tx,
+                    "abi": &abi
+                });
+                sh_println!("{}", serde_json::to_string_pretty(&output)?)?;
+            }
+
+            return Ok(());
+        }
+
         // Deploy the actual contract
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;
         let tx_hash = receipt.transaction_hash();

--- a/crates/forge/src/cmd/create/zksync.rs
+++ b/crates/forge/src/cmd/create/zksync.rs
@@ -315,7 +315,9 @@ impl CreateArgs {
                 sh_println!("Transaction: {}", serde_json::to_string_pretty(&deployer.tx)?)?;
                 sh_println!("ABI: {}\n", serde_json::to_string_pretty(&abi)?)?;
 
-                sh_warn!("To broadcast this transaction, add --broadcast to the previous command. See forge create --help for more.")?;
+                sh_warn!(
+                    "To broadcast this transaction, add --broadcast to the previous command. See forge create --help for more."
+                )?;
             } else {
                 let output = json!({
                     "contract": &self.contract.name,

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -643,6 +643,7 @@ pub fn deploy_zk_contract(
         url,
         "--private-key",
         private_key,
+        "--broadcast",
     ]);
 
     if let Some(args) = extra_args {

--- a/crates/forge/tests/it/zk/create.rs
+++ b/crates/forge/tests/it/zk/create.rs
@@ -108,6 +108,7 @@ forgetest_async!(
             url.as_str(),
             "--private-key",
             private_key,
+            "--broadcast",
             "--timeout",
             "1",
             "--zk-gas-per-pubdata",
@@ -117,3 +118,56 @@ forgetest_async!(
         cmd.assert_failure();
     }
 );
+
+forgetest_async!(forge_zk_create_dry_run_without_broadcast, |prj, cmd| {
+    util::initialize(prj.root());
+    prj.add_source("ERC20.sol", include_str!("../../../../../testdata/zk/ERC20.sol")).unwrap();
+
+    let node = ZkSyncNode::start().await;
+    let url = node.url();
+
+    let private_key =
+        ZkSyncNode::rich_wallets().next().map(|(_, pk, _)| pk).expect("No rich wallets available");
+
+    // Test dry-run behavior WITHOUT --broadcast flag
+    cmd.forge_fuse().args([
+        "create",
+        "--zk-startup",
+        "./src/ERC20.sol:MyToken",
+        "--rpc-url",
+        url.as_str(),
+        "--private-key",
+        private_key,
+    ]);
+
+    let output = cmd.assert_success().get_output().stdout_lossy();
+
+    // Should show transaction details (this proves dry-run is working)
+    assert!(output.contains("Contract: MyToken"), "Expected contract name in output");
+    assert!(output.contains("Transaction:"), "Expected transaction details in output");
+    assert!(output.contains("ABI:"), "Expected ABI output in output");
+
+    // Should NOT show deployment success messages (this is the key test)
+    assert!(!output.contains("Deployed to:"), "Should not show deployment address in dry-run");
+    assert!(!output.contains("Transaction hash:"), "Should not show transaction hash in dry-run");
+});
+
+forgetest_async!(forge_zk_create_with_broadcast_flag, |prj, cmd| {
+    util::initialize(prj.root());
+    prj.add_source("ERC20.sol", include_str!("../../../../../testdata/zk/ERC20.sol")).unwrap();
+
+    let node = ZkSyncNode::start().await;
+    let url = node.url();
+
+    let private_key =
+        ZkSyncNode::rich_wallets().next().map(|(_, pk, _)| pk).expect("No rich wallets available");
+
+    // Test actual deployment WITH --broadcast flag (helper function already includes --broadcast)
+    let deployed_address =
+        deploy_zk_contract(&mut cmd, url.as_str(), private_key, "./src/ERC20.sol:MyToken", None)
+            .expect("Failed to deploy ERC20 contract");
+
+    // Should successfully deploy and return an address
+    assert!(!deployed_address.is_empty(), "Deployed address should not be empty");
+    assert!(deployed_address.starts_with("0x"), "Address should be a valid hex address");
+});

--- a/crates/forge/tests/it/zk/paymaster.rs
+++ b/crates/forge/tests/it/zk/paymaster.rs
@@ -75,6 +75,7 @@ forgetest_async!(test_zk_deploy_with_paymaster, |prj, cmd| {
             "--value",
             "1000000000000000000",
             "--zksync",
+            "--broadcast",
         ])
         .assert_success()
         .get_output()
@@ -102,7 +103,8 @@ forgetest_async!(test_zk_deploy_with_paymaster, |prj, cmd| {
             "--zk-paymaster-input",
             "0x8c5a344500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
             "--via-ir",
-            "--zksync"
+            "--zksync",
+            "--broadcast",
         ])
         .assert_success()
         .get_output()
@@ -125,7 +127,8 @@ forgetest_async!(test_zk_deploy_with_paymaster, |prj, cmd| {
             "--zk-paymaster-input",
             "0x0000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
             "--via-ir",
-            "--zksync"
+            "--zksync",
+            "--broadcast",
         ])
         .assert_failure();
 });

--- a/zksync-tests
+++ b/zksync-tests
@@ -80,6 +80,8 @@ forge::it:
     zk::create::forge_zk_can_deploy_contracts_with_gas_per_pubdata_and_succeed
     zk::create::forge_zk_can_deploy_contracts_with_invalid_gas_per_pubdata_and_fail
     zk::create::forge_zk_can_deploy_erc20
+    zk::create::forge_zk_create_dry_run_without_broadcast
+    zk::create::forge_zk_create_with_broadcast_flag
     zk::deploy::multiple_deployments_of_the_same_contract
     zk::factory::script_zk_can_deploy_in_constructor
     zk::factory::script_zk_can_deploy_in_method


### PR DESCRIPTION
# What :computer: 
* Enhanced `deploy_zk` function to support dry-run mode, allowing users to preview transaction details without broadcasting.
* Added tests to validate dry-run behavior and ensure correct output formatting.
* Included `--broadcast` flag in relevant test cases to align with new deployment behavior.

# Why :hand:
* Dry run is enable by default on upstream Foundry

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
