### PR TITLE
fix: cast call with --trace, missing test assertion

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -32,6 +32,7 @@ use foundry_evm::{
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceMode},
 };
+use foundry_zksync_core::MAX_L2_GAS_LIMIT;
 use regex::Regex;
 use revm::context::TransactionType;
 use std::{str::FromStr, sync::LazyLock};
@@ -309,7 +310,7 @@ impl CallArgs {
 
             // modify settings that usually set in eth_call
             env.evm_env.cfg_env.disable_block_gas_limit = true;
-            env.evm_env.block_env.gas_limit = u64::MAX;
+            env.evm_env.block_env.gas_limit = if is_zk { MAX_L2_GAS_LIMIT } else { u64::MAX };
 
             // Apply the block overrides.
             if let Some(block_overrides) = block_overrides {

--- a/crates/cast/tests/cli/zk.rs
+++ b/crates/cast/tests/cli/zk.rs
@@ -650,7 +650,8 @@ casttest!(test_zk_cast_call_with_trace, async |_prj, cmd| {
         .args(["rpc", "hardhat_setCode", COUNTER_ADDRESS, COUNTER_BYTECODE, "--rpc-url", &url])
         .assert_success();
 
-    cmd.cast_fuse()
+    let output = cmd
+        .cast_fuse()
         .args([
             "call",
             "--trace",
@@ -664,15 +665,19 @@ casttest!(test_zk_cast_call_with_trace, async |_prj, cmd| {
         ])
         .assert_success()
         .get_output()
-        .stdout_lossy()
-        .contains(
+        .stdout_lossy();
+
+    assert!(
+        output.contains(
             format!(
                 "Traces:
-  [43369] {COUNTER_ADDRESS}::number()
-    └─ ← [Return] 0x0000000000000000000000000000000000000000000000000000000000000001"
+  [2141] {COUNTER_ADDRESS}::number()
+    └─ ← [Return] 0x0000000000000000000000000000000000000000000000000000000000000000"
             )
             .as_str(),
-        );
+        ),
+        "trace mismatch, got output:\n{output}"
+    );
 });
 
 casttest!(test_zk_cast_run_with_create, async |prj, cmd| {

--- a/crates/zksync/core/src/lib.rs
+++ b/crates/zksync/core/src/lib.rs
@@ -36,6 +36,7 @@ use zksync_types::{Nonce, ProtocolVersionId, bytecode::BytecodeHash};
 pub use utils::{fix_l2_gas_limit, fix_l2_gas_price};
 pub use vm::{balance, deploy_nonce, encode_create_params, tx_nonce};
 
+pub use utils::MAX_L2_GAS_LIMIT;
 pub use vm::{SELECTOR_CONTRACT_DEPLOYER_CREATE, SELECTOR_CONTRACT_DEPLOYER_CREATE2};
 pub use zksync_multivm::interface::{Call, CallType};
 pub use zksync_types::{

--- a/crates/zksync/core/src/utils.rs
+++ b/crates/zksync/core/src/utils.rs
@@ -32,11 +32,11 @@ use alloy_primitives::hex;
 use eyre::Result;
 use url::Url;
 use zksync_basic_types::U256;
-use zksync_multivm::zk_evm_latest::zkevm_opcode_defs::MAX_TX_ERGS_LIMIT;
 use zksync_types::H256;
 
-/// Max l2 gas limit to use in transactions.
-pub const MAX_L2_GAS_LIMIT: u64 = MAX_TX_ERGS_LIMIT as u64;
+/// Max l2 gas limit to use in transactions. Determined empirically to be good enough
+/// for all use cases.
+pub const MAX_L2_GAS_LIMIT: u64 = ((u32::MAX >> 1) as u64) * 2;
 
 /// Gets the RPC URL for Ethereum.
 ///

--- a/crates/zksync/core/src/utils.rs
+++ b/crates/zksync/core/src/utils.rs
@@ -32,11 +32,11 @@ use alloy_primitives::hex;
 use eyre::Result;
 use url::Url;
 use zksync_basic_types::U256;
+use zksync_multivm::zk_evm_latest::zkevm_opcode_defs::MAX_TX_ERGS_LIMIT;
 use zksync_types::H256;
 
-/// Max l2 gas limit to use in transactions. Determined empirically to be good enough
-/// for all use cases.
-pub const MAX_L2_GAS_LIMIT: u64 = ((u32::MAX >> 1) as u64) * 2;
+/// Max l2 gas limit to use in transactions.
+pub const MAX_L2_GAS_LIMIT: u64 = MAX_TX_ERGS_LIMIT as u64;
 
 /// Gets the RPC URL for Ethereum.
 ///

--- a/crates/zksync/core/src/vm/inspect.rs
+++ b/crates/zksync/core/src/vm/inspect.rs
@@ -37,7 +37,6 @@ use zksync_multivm::{
     },
     tracers::CallTracer,
     vm_latest::{HistoryDisabled, ToTracerPointer, Vm},
-    zk_evm_latest::zkevm_opcode_defs::MAX_TX_ERGS_LIMIT,
 };
 use zksync_types::{
     ACCOUNT_CODE_STORAGE_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, PackedEthSignature, StorageKey,


### PR DESCRIPTION
# What :computer: 
* fixes cast call issue with `--trace`.
* fixes missing assertion in `test_zk_cast_call_with_trace` test.

# Why :hand:
* EVM default gas limit would cause tx to fail the balance check in the bootloader.

# Evidence :camera:
Test passes.

# Documentation :books:
Please ensure the following before submitting your PR:

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
* docs https://github.com/matter-labs/foundry-zksync-book/pull/93
