### PR TITLE
chore: remove redundant profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,12 +192,11 @@ jobs:
         env:
           TAG_NAME: ${{ (env.IS_NIGHTLY == 'true' && 'nightly') || needs.prepare.outputs.tag_name }}
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
-          PROFILE: release
           TARGET: ${{ matrix.target }}
         shell: bash
         run: |
           set -eo pipefail
-          flags=(--target $TARGET --profile $PROFILE --bins
+          flags=(--target $TARGET --bins
             --no-default-features --features aws-kms,gcp-kms,cli,asm-keccak)
 
           # Disable asm-keccak, see https://github.com/alloy-rs/core/issues/711


### PR DESCRIPTION
`--release` is already present, so `--profile` is disallowed.