### PR TITLE
chore: ci migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: foundry-runner
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |
@@ -71,7 +71,7 @@ jobs:
     runs-on: foundry-runner
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Benchmark setup
         uses: ./.github/actions/benchmark-setup
@@ -101,7 +101,7 @@ jobs:
     runs-on: foundry-runner
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Benchmark setup
         uses: ./.github/actions/benchmark-setup
@@ -131,7 +131,7 @@ jobs:
     runs-on: foundry-runner
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Benchmark setup
         uses: ./.github/actions/benchmark-setup
@@ -161,7 +161,7 @@ jobs:
     runs-on: foundry-runner
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all benchmark results
         uses: actions/download-artifact@v4

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -19,7 +19,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: dtolnay/rust-toolchain@nightly
               with:
                   toolchain: nightly-2025-03-19

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       test-matrix: ${{ steps.gen.outputs.test-matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -52,7 +52,7 @@ jobs:
       # Note(zk): Using our own Alchemy API key to avoid rate limiting issues
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.target }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/determinate-nix-action@v3
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DeterminateSystems/update-flake-lock@main
         with:
           pr-title: "Update flake.lock"
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: DeterminateSystems/determinate-nix-action@v3
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update flake.lock
         run: nix flake update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       prerelease: ${{ steps.release_info.outputs.prerelease }}
       changelog: ${{ steps.build_changelog.outputs.changelog || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag || '' }}
@@ -138,7 +138,7 @@ jobs:
             platform: darwin
             arch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag || '' }}
 
@@ -311,7 +311,7 @@ jobs:
     needs: release
     if: always()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Moves the `nightly` tag to `HEAD`
       - name: Move nightly tag
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ prepare, release, cleanup ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret_scanner.yaml
+++ b/.github/workflows/secret_scanner.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: TruffleHog OSS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: ${{ env.TARGET_RUST_VERSION }}
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2025-03-19 # Required for unstable features in rustfmt
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@v2
         with:
           skip: "*.json"
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-24.04-github-hosted-16core
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: ${{ env.TARGET_RUST_VERSION }}
@@ -109,7 +109,7 @@ jobs:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.sha }}
@@ -153,7 +153,7 @@ jobs:
     name: CI install
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install foundry-zksync
         run: cp ./install-foundry-zksync ./foundryup-zksync/* /tmp/ && cd /tmp && ./install-foundry-zksync
       - name: Verify installation
@@ -163,7 +163,7 @@ jobs:
     name: CI install anvil-zksync
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install foundry-zksync
         run: |
@@ -180,7 +180,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/zk-aave-test.yml
+++ b/.github/workflows/zk-aave-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0