### PR TITLE
fix: trigger binaries gen even if some aux release-please step failed

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -33,7 +33,7 @@ jobs:
 
   # Trigger workflow to generate artifacts
   release:
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ always() && needs.release-please.outputs.releases_created == 'true' }}
     needs: release-please
     uses: ./.github/workflows/release.yml
     with:


### PR DESCRIPTION
# What :computer: 
* [x] Trigger binaries gen even if some aux release-please step failed

# Why :hand:

In some corner cases and network issues, `release-please` might work correctly, but Slack notification might fail or some other auxiliary step that prevents the binaries generation job to be executed.

Use `always()` condition together with the proper output setup to handle this.
