### PR TITLE
fix: do not skip first line of error

### DIFF
--- a/zksync-tests
+++ b/zksync-tests
@@ -87,6 +87,7 @@ foundry-config:
 foundry-evm-core:
     backend::tests::test_zk_code_by_hash_failure_is_propagated
 foundry-zksync-compilers:
+    artifacts::error::tests::test_error_msg_strips_serverity
     compilers::artifact_output::zk::bytecode::tests::serialized_bytecode_is_not_prefixed
     compilers::artifact_output::zk::tests::contract_to_artifact_empty_contract_produces_empty_artifact
     compilers::artifact_output::zk::tests::contract_to_artifact_simple_valid_fields


### PR DESCRIPTION
# What :computer: 
* Avoid skipping first line of error

# Why :hand:
* https://github.com/matter-labs/foundry-zksync/pull/898 introduced the functionality to skip compiler errors if they follow a certain pattern, this no longer fits the actual formatted output that zksolc outputs currently. So the functionality must be removed to avoid removing important context from the zksolc compilation process.
* We still trim the severity from the formatted message as it's consistent and duplicated.

# Evidence :camera:
Test passes

# Documentation :books:
-

- [x] Check if these changes affect any documented features or workflows.
- [x] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
* Mitigates error text omission in #1212 
