### PR TITLE
fix: ignore RUSTSEC-2026-0002 lru soundness issue

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,8 @@ ignore = [
     "RUSTSEC-2025-0134",
     # https://rustsec.org/advisories/RUSTSEC-2025-0137 `reciprocal_mg10` OOB, unused
     "RUSTSEC-2025-0137",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru IterMut violates Stacked Borrows
+    "RUSTSEC-2026-0002",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Added RUSTSEC-2026-0002 to deny.toml ignore list to fix cargo deny failure