### PR TITLE
fix: use official foundry-compilers 0.19.12, remove fork patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5382,8 +5382,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.19.10"
-source = "git+https://github.com/nbaztec/compilers.git?branch=v0.19.10-fix-remapping#013c7e120cf575e404d703093aa033ceb1548bc3"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dde08d155d44039c2c05bc474e03e4e01323006d9660a9ef68c644bcde9aaee"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5415,8 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts"
-version = "0.19.10"
-source = "git+https://github.com/nbaztec/compilers.git?branch=v0.19.10-fix-remapping#013c7e120cf575e404d703093aa033ceb1548bc3"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e0ffe73c1857652a1600eb5a917babee8adad33b0699754dba28da9f07d07d"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5424,8 +5426,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-solc"
-version = "0.19.10"
-source = "git+https://github.com/nbaztec/compilers.git?branch=v0.19.10-fix-remapping#013c7e120cf575e404d703093aa033ceb1548bc3"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e874e6e777eba39614e17c403ecd34ddbc685d600bd487bc8b3ae3c6cc1d14d8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5446,8 +5449,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
-version = "0.19.10"
-source = "git+https://github.com/nbaztec/compilers.git?branch=v0.19.10-fix-remapping#013c7e120cf575e404d703093aa033ceb1548bc3"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642198c91aaa950191ef39c9e779dadb9993afd78355f2e76e25161da8958423"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5460,8 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-core"
-version = "0.19.10"
-source = "git+https://github.com/nbaztec/compilers.git?branch=v0.19.10-fix-remapping#013c7e120cf575e404d703093aa033ceb1548bc3"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69f38b9d2d75df367a0cdc604c58227cb5e7ae935fe0c3a065acc65990354bb"
 dependencies = [
  "alloy-primitives",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,7 +285,7 @@ foundry-primitives = { path = "crates/primitives" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }
-foundry-compilers = { version = "0.19.10", default-features = false, features = [
+foundry-compilers = { version = "0.19.12", default-features = false, features = [
     "rustls",
     "svm-solc",
 ] }
@@ -536,7 +536,6 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 ## foundry
 # foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers.git", rev = "f5b46b2" }
 # foundry-compilers = { git = "https://github.com/foundry-rs/compilers.git", branch = "main" }
-foundry-compilers = { git = "https://github.com/nbaztec/compilers.git", branch = "v0.19.10-fix-remapping" }
 
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "b4299fc" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -157,8 +157,6 @@ allow-git = [
     "https://github.com/tempoxyz/tempo",
     # Transitive dependency of Tempo
     "https://github.com/paradigmxyz/reth",
-    # Temporary fix for foundry-compilers
-    "https://github.com/nbaztec/compilers",
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
The remapping sorting fix (https://github.com/foundry-rs/compilers/pull/343) has been merged and released in foundry-compilers 0.19.12.

This removes the temporary fork patch (nbaztec/compilers) that was used as a workaround.

# What :computer: 
* First thing updated with this PR
* Second thing updated with this PR
* Third thing updated with this PR

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
