### PR TITLE
fix: unable to install `foundry-zksync` from commit or tag in certain scenarios

### DIFF
--- a/foundryup-zksync/foundryup-zksync
+++ b/foundryup-zksync/foundryup-zksync
@@ -473,6 +473,7 @@ EOF
 
     # Force checkout, discarding any local changes
     cd "$REPO_PATH"
+    ensure git restore Cargo.lock
     ensure git fetch origin "${FOUNDRYUP_BRANCH}:remotes/origin/${FOUNDRYUP_BRANCH}"
     ensure git checkout "origin/${FOUNDRYUP_BRANCH}"
 


### PR DESCRIPTION
This PR fixes a bug that prevents installing another version of `foundry-zksync` from commit or tag when one had already been installed.

## Steps to reproduce

Check the version:

```shell
foundryup-zksync --version
```

```
foundryup-zksync: 1.5.0
```

Install some version of foundry-zksync:

```shell
foundryup-zksync -i 0.1.5
```

Install another version of foundry-zksync:

```shell
foundryup-zksync --commit ae913af65
```

```
.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

 ╔═╗ ╔═╗ ╦ ╦ ╔╗╔ ╔╦╗ ╦═╗ ╦ ╦         Portable and modular toolkit
 ╠╣  ║ ║ ║ ║ ║║║  ║║ ╠╦╝ ╚╦╝    for ZKsync Application Development
 ╚   ╚═╝ ╚═╝ ╝╚╝ ═╩╝ ╩╚═  ╩                 written in Rust.

.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

Fork of    : https://github.com/foundry-rs/
Repo       : https://github.com/matter-labs/foundry-zksync/
Book       : https://foundry-book.zksync.io/

.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

foundryup-zksync: checking if foundryup is up to date...
foundryup-zksync: foundryup is up to date.
error: Your local changes to the following files would be overwritten by checkout:
	Cargo.lock
Please commit your changes or stash them before you switch branches.
Aborting
foundryup-zksync: command failed: git checkout origin/main
```

The error should not happen. This PR fixes it.