### PR TITLE
refactor(ci): restore upstream workflow files with repository guards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "softprops/action-gh-release"

--- a/.github/workflows/bump-forge-std.yml
+++ b/.github/workflows/bump-forge-std.yml
@@ -1,0 +1,33 @@
+# Daily CI job to update forge-std version used for tests if new release has been published
+
+name: bump-forge-std
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run daily at midnight UTC
+  workflow_dispatch: # Needed so we can run it manually
+
+jobs:
+  update-tag:
+    if: github.repository == 'foundry-rs/foundry'
+    name: update forge-std tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Fetch and update forge-std tag
+        run: curl 'https://api.github.com/repos/foundry-rs/forge-std/tags' | jq '.[0].commit.sha' -jr > testdata/forge-std-rev
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v7
+        with:
+          commit-message: "chore: bump forge-std version used for tests"
+          title: "chore(tests): bump forge-std version"
+          body: |
+            New release of forge-std has been published, bump forge-std version used in tests. Likely some fixtures need to be updated.
+          branch: chore/bump-forge-std

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,20 @@
+# Runs `cargo update` periodically.
+
+name: dependencies
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 0 * * SUN" # Run weekly on Sundays at midnight UTC
+  workflow_dispatch: # Needed so we can run it manually
+
+jobs:
+  update:
+    if: github.repository == 'foundry-rs/foundry'
+    uses: tempoxyz/ci/.github/workflows/cargo-update-pr.yml@268b3ce142717ff86c58fbbcc3abc3f109f0fb8d # main
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,111 @@
+name: docker
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        default: nightly
+        description: The tag we're building for
+        type: string
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+concurrency:
+  group: docker-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+  # Keep in sync with `release.yml`.
+  RUST_PROFILE: dist
+  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer
+
+jobs:
+  build:
+    if: github.repository == 'foundry-rs/foundry'
+    name: build and push
+    runs-on: depot-ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Login into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Creates an additional 'latest' or 'nightly' tag
+      # If the job is triggered via cron schedule, tag nightly and nightly-{SHA}
+      # If the job is triggered via workflow dispatch and on a master branch, tag branch and latest
+      # Otherwise, just tag as the branch name
+      - name: Finalize Docker Metadata
+        id: docker_tagging
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          REGISTRY="${{ env.REGISTRY }}"
+          IMAGE="${{ env.IMAGE_NAME }}"
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            printf "cron trigger, assigning nightly tag\n"
+            printf "docker_tags=%s/%s:nightly,%s/%s:nightly-%s\n" "$REGISTRY" "$IMAGE" "$REGISTRY" "$IMAGE" "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF##*/}" == "main" ]] || [[ "${GITHUB_REF##*/}" == "master" ]]; then
+            printf "manual trigger from master/main branch, assigning latest tag\n"
+            printf "docker_tags=%s/%s:%s,%s/%s:latest\n" "$REGISTRY" "$IMAGE" "${GITHUB_REF##*/}" "$REGISTRY" "$IMAGE" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR="v${BASH_REMATCH[1]}"
+            MINOR="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            printf "version tag release, assigning %s, %s, and %s tags\n" "$TAG" "$MINOR" "$MAJOR"
+            printf "docker_tags=%s/%s:%s,%s/%s:%s,%s/%s:%s\n" "$REGISTRY" "$IMAGE" "$TAG" "$REGISTRY" "$IMAGE" "$MINOR" "$REGISTRY" "$IMAGE" "$MAJOR" >> "$GITHUB_OUTPUT"
+          else
+            printf "Neither scheduled nor manual release from main branch. Just tagging as branch name\n"
+            printf "docker_tags=%s/%s:%s\n" "$REGISTRY" "$IMAGE" "${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Log docker metadata to explicitly know what is being pushed
+      - name: Inspect Docker Metadata
+        run: |
+          printf "TAGS -> %s\n" "${{ steps.docker_tagging.outputs.docker_tags }}"
+          printf "LABELS -> %s\n" "${{ steps.meta.outputs.labels }}"
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+
+      - name: Build and push Foundry image
+        uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1
+        with:
+          build-args: |
+            RUST_PROFILE=${{ env.RUST_PROFILE }}
+            RUST_FEATURES=${{ env.RUST_FEATURES }}
+            TAG_NAME=${{ inputs.tag_name }}
+            VERGEN_GIT_SHA=${{ github.sha }}
+          project: 8gkbxxjrpw
+          context: .
+          tags: ${{ steps.docker_tagging.outputs.docker_tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,55 @@
+name: nix
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 0 * * SUN" # Run weekly on Sundays at midnight UTC
+  workflow_dispatch: # Needed so we can run it manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Opens a PR with an updated flake.lock file
+  update:
+    if: github.repository == 'foundry-rs/foundry'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: DeterminateSystems/determinate-nix-action@73327eb48f028efaaf5013656ba216ca3cdeca7b # v3
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/update-flake-lock@5909792a83875ddb5dd4b18734534a98a74a709c # main
+        with:
+          pr-title: "Update flake.lock"
+          pr-labels: |
+            L-ignore
+            A-dependencies
+
+  build:
+    if: github.repository == 'foundry-rs/foundry'
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+    steps:
+      - uses: DeterminateSystems/determinate-nix-action@73327eb48f028efaaf5013656ba216ca3cdeca7b # v3
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Update flake.lock
+        run: nix flake update
+
+      - name: Activate nix env
+        run: nix develop -c echo Ok
+
+      - name: Check that we can compile all crates
+        run: nix develop -c cargo check --all-targets

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,296 @@
+name: npm
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        type: string
+        required: false
+        description: The run id of the release to publish
+  workflow_run:
+    types: [completed]
+    workflows: [release]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  NPM_CONFIG_PROVENANCE: true
+  NPM_REGISTRY_URL: "https://registry.npmjs.org"
+
+jobs:
+  publish-arch:
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+    name: ${{ matrix.tool }}-${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      fail-fast: false
+      matrix:
+        include:
+          - tool: forge
+            os: linux
+            arch: amd64
+          - tool: forge
+            os: linux
+            arch: arm64
+          - tool: forge
+            os: darwin
+            arch: amd64
+          - tool: forge
+            os: darwin
+            arch: arm64
+          - tool: forge
+            os: win32
+            arch: amd64
+          - tool: cast
+            os: linux
+            arch: amd64
+          - tool: cast
+            os: linux
+            arch: arm64
+          - tool: cast
+            os: darwin
+            arch: amd64
+          - tool: cast
+            os: darwin
+            arch: arm64
+          - tool: cast
+            os: win32
+            arch: amd64
+          - tool: anvil
+            os: linux
+            arch: amd64
+          - tool: anvil
+            os: linux
+            arch: arm64
+          - tool: anvil
+            os: darwin
+            arch: amd64
+          - tool: anvil
+            os: darwin
+            arch: arm64
+          - tool: anvil
+            os: win32
+            arch: amd64
+          - tool: chisel
+            os: linux
+            arch: amd64
+          - tool: chisel
+            os: linux
+            arch: arm64
+          - tool: chisel
+            os: darwin
+            arch: amd64
+          - tool: chisel
+            os: darwin
+            arch: arm64
+          - tool: chisel
+            os: win32
+            arch: amd64
+    # Run automatically after a successful 'release' workflow, or manually if a run_id is provided.
+    # Only runs in the upstream foundry-rs/foundry repository.
+    if: >-
+      ${{
+        github.repository == 'foundry-rs/foundry' &&
+        (
+          (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+          (github.event_name == 'workflow_dispatch' && inputs.run_id != '')
+        )
+      }}
+    outputs:
+      RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set Isolated Artifact Directory
+        id: paths
+        run: |
+          set -euo pipefail
+          printf 'artifact_dir=%s\n' "$RUNNER_TEMP/foundry_artifacts" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Isolated Artifact Directory
+        env:
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
+        run: |
+          mkdir -p "$ARTIFACT_DIR"
+          ls -la "$ARTIFACT_DIR" || true
+
+      - name: Download Release Assets
+        uses: actions/download-artifact@v7
+        with:
+          merge-multiple: true
+          # Download all foundry artifacts from the triggering release run
+          pattern: "foundry_*"
+          # Extract artifacts into an isolated temp directory, not the workspace
+          path: ${{ steps.paths.outputs.artifact_dir }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node (for npm publish auth)
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Derive RELEASE_VERSION
+        id: release-version
+        working-directory: ./npm
+        env:
+          PROVENANCE: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
+        run: |
+          set -euo pipefail
+
+          echo "Artifacts in $ARTIFACT_DIR:"
+          ls -la "$ARTIFACT_DIR" || true
+
+          # Derive RELEASE_VERSION from any foundry artifact we downloaded
+          # Expected names: foundry_<VERSION>_<platform>_<arch>.{tar.gz,zip}
+          first_file=$(ls "$ARTIFACT_DIR"/foundry_* 2>/dev/null | head -n1 || true)
+          if [[ -z "${first_file}" ]]; then
+            echo "No foundry artifacts found to publish" >&2
+            exit 1
+          fi
+          version_part=$(basename "$first_file")
+          version_part=${version_part#foundry_}
+          export RELEASE_VERSION=${version_part%%_*}
+          echo "Detected RELEASE_VERSION=$RELEASE_VERSION"
+
+          printf 'RELEASE_VERSION=%s\n' "$RELEASE_VERSION" >>"$GITHUB_OUTPUT"
+
+      - name: Stage Binary Into Package
+        working-directory: ./npm
+        env:
+          RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
+        run: |
+          set -euo pipefail
+
+          bun ./scripts/stage-from-artifact.mjs \
+            --tool '${{ matrix.tool }}' \
+            --platform '${{ matrix.os }}' \
+            --arch '${{ matrix.arch }}' \
+            --release-version "$RELEASE_VERSION" \
+            --artifact-dir "$ARTIFACT_DIR"
+
+      - name: Sanity Check Binary
+        working-directory: ./npm
+        run: |
+          set -euo pipefail
+          TOOL='${{ matrix.tool }}'
+          PLATFORM='${{ matrix.os }}'
+          ARCH='${{ matrix.arch }}'
+
+          PKG_DIR="./@foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
+          BIN="$PKG_DIR/bin/${TOOL}"
+          if [[ "$PLATFORM" == "win32" ]]; then
+            BIN="$PKG_DIR/bin/${TOOL}.exe"
+          fi
+          echo "Verifying binary at: $BIN"
+          ls -la "$BIN"
+          if [[ ! -f "$BIN" ]]; then
+            echo "ERROR: Binary not found at $BIN" >&2
+            exit 1
+          fi
+
+          if [[ "${{ matrix.os }}" != "win32" ]]; then
+            if [[ ! -x "$BIN" ]]; then
+              echo "ERROR: Binary not marked executable" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Publish ${{ matrix.os }}-${{ matrix.arch }} Binary
+        working-directory: ./npm
+        env:
+          PROVENANCE: true
+          VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TOOL='${{ matrix.tool }}'
+          PLATFORM='${{ matrix.os }}'
+          ARCH='${{ matrix.arch }}'
+
+          PACKAGE_DIR="./@foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
+          ls -la "$PACKAGE_DIR"
+
+          bun ./scripts/publish.mjs "$PACKAGE_DIR"
+
+          echo "Published @foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
+
+  publish-meta:
+    if: github.repository == 'foundry-rs/foundry'
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+    needs: publish-arch
+    name: Publish Meta Package
+    runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node (for npm publish auth)
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Dependencies
+        working-directory: ./npm
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        working-directory: ./npm
+        run: bun tsc --project tsconfig.json --noEmit
+
+      - name: Publish Meta Packages
+        working-directory: ./npm
+        run: |
+          set -euo pipefail
+          bun ./scripts/publish-meta.mjs --release-version "$RELEASE_VERSION"
+        env:
+          PROVENANCE: true
+          VERSION_NAME: ${{ env.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+          NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}


### PR DESCRIPTION
# What :computer: 
* Restore 5 deleted upstream workflow files (`nix.yml`, `docker-publish.yml`, `npm.yml`, `dependencies.yml`, `bump-forge-std.yml`) and `dependabot.yml`
* Add `if: github.repository == 'foundry-rs/foundry'` guards to every job so they never execute in this fork

# Why :hand:
* Every upstream merge produces modify/delete conflicts for these files because we deleted them but upstream keeps modifying them
* By keeping the files in sync with upstream and guarding them with a repository check, git can perform proper 3-way merges going forward
* This eliminates ~4-5 workflow-related conflicts per upstream merge

# Evidence :camera:
The guard condition ensures no workflows will run in the fork:
```yaml
jobs:
  build:
    if: github.repository == 'foundry-rs/foundry'
```

# Documentation :books:
- [x] No documented features or workflows are affected by this change