### PR TITLE
refactor: remove trace_zksync from CheatcodesExecutor trait

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -115,17 +115,6 @@ pub trait CheatcodesExecutor {
     fn tracing_inspector(&mut self) -> Option<&mut Option<Box<TraceCollector>>> {
         None
     }
-
-    fn trace_zksync(
-        &mut self,
-        ccx_state: &mut Cheatcodes,
-        ecx: Ecx,
-        call_traces: Box<dyn std::any::Any>, /* TODO(merge): Should me moved elsewhere,
-                                              * represents `Vec<Call>` */
-    ) {
-        let mut inspector = self.get_inspector(ccx_state);
-        inspector.trace_zksync(ecx, call_traces, false);
-    }
 }
 
 /// Constructs [FoundryEvm] and runs a given closure with it.

--- a/crates/strategy/zksync/src/cheatcode/runner/mod.rs
+++ b/crates/strategy/zksync/src/cheatcode/runner/mod.rs
@@ -670,9 +670,11 @@ impl CheatcodeInspectorStrategyExt for ZksyncCheatcodeInspectorStrategyRunner {
                 );
 
                 // append traces
-                executor
-                    .get_inspector(state)
-                    .trace_zksync(ecx, Box::new(result.call_traces), false);
+                executor.get_inspector(state).trace_zksync(
+                    ecx,
+                    Box::new(result.call_traces),
+                    false,
+                );
 
                 // for each log in cloned logs call handle_expect_emit
                 if !state.expected_emits.is_empty() {
@@ -864,9 +866,11 @@ impl CheatcodeInspectorStrategyExt for ZksyncCheatcodeInspectorStrategyRunner {
                     }
 
                     // append traces
-                    executor
-                        .get_inspector(state)
-                        .trace_zksync(ecx, Box::new(result.call_traces), false);
+                    executor.get_inspector(state).trace_zksync(
+                        ecx,
+                        Box::new(result.call_traces),
+                        false,
+                    );
 
                     // for each log in cloned logs call handle_expect_emit
                     if !state.expected_emits.is_empty() {

--- a/crates/strategy/zksync/src/cheatcode/runner/mod.rs
+++ b/crates/strategy/zksync/src/cheatcode/runner/mod.rs
@@ -670,7 +670,9 @@ impl CheatcodeInspectorStrategyExt for ZksyncCheatcodeInspectorStrategyRunner {
                 );
 
                 // append traces
-                executor.trace_zksync(state, ecx, Box::new(result.call_traces));
+                executor
+                    .get_inspector(state)
+                    .trace_zksync(ecx, Box::new(result.call_traces), false);
 
                 // for each log in cloned logs call handle_expect_emit
                 if !state.expected_emits.is_empty() {
@@ -862,7 +864,9 @@ impl CheatcodeInspectorStrategyExt for ZksyncCheatcodeInspectorStrategyRunner {
                     }
 
                     // append traces
-                    executor.trace_zksync(state, ecx, Box::new(result.call_traces));
+                    executor
+                        .get_inspector(state)
+                        .trace_zksync(ecx, Box::new(result.call_traces), false);
 
                     // for each log in cloned logs call handle_expect_emit
                     if !state.expected_emits.is_empty() {


### PR DESCRIPTION
# What :computer: 
* Remove the `trace_zksync` method from the upstream `CheatcodesExecutor` trait
* Inline the tracing call at the two usage sites in the zksync strategy runner using `executor.get_inspector(state).trace_zksync()` directly

# Why :hand:
* The `CheatcodesExecutor` trait is an upstream trait that we add zksync-specific methods to
* When upstream adds new methods to this trait (e.g. `set_in_inner_context`), the trait definition collides during merges
* By removing `trace_zksync` from the trait and inlining the equivalent call, we keep the upstream trait body closer to its original form

# Evidence :camera:
```
$ cargo check -p foundry-cheatcodes -p foundry-strategy-zksync
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 48s
```

The `trace_zksync` method on `InspectorExt` (the actual implementation) remains unchanged.

# Documentation :books:
- [x] No documented features or workflows are affected by this refactor