### PR TITLE
fix: allow alloy-chains git source in cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -142,6 +142,7 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/foundry-rs/foundry",
     "https://github.com/alloy-rs/alloy",
+    "https://github.com/alloy-rs/chains",
     "https://github.com/foundry-rs/compilers",
     "https://github.com/foundry-rs/foundry-fork-db",
     "https://github.com/matter-labs/zksync-telemetry",


### PR DESCRIPTION
## Summary
- Add `https://github.com/alloy-rs/chains` to the `allow-git` list in `deny.toml` to fix `cargo deny check sources` failure caused by the pinned alloy-chains git dependency

## Test plan
- [ ] CI passes `cargo deny check sources`