### PR TITLE
refactor: unify ZkTransactionOpts across cast, forge create, and forge script

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -1,11 +1,12 @@
 use super::run::fetch_contracts_bytecode_from_trace;
 use crate::{
-    Cast, ZkCast, ZkTransactionOpts,
+    Cast, ZkCast,
     debug::handle_traces,
     traces::TraceKind,
     tx::{CastTxBuilder, SenderKind},
     zksync,
 };
+use foundry_cli::opts::ZkTransactionOpts;
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex, map::HashMap};
 use alloy_provider::Provider;

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -6,7 +6,6 @@ use crate::{
     tx::{CastTxBuilder, SenderKind},
     zksync,
 };
-use foundry_cli::opts::ZkTransactionOpts;
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex, map::HashMap};
 use alloy_provider::Provider;
@@ -18,7 +17,7 @@ use alloy_serde::OtherFields;
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
-    opts::{ChainValueParser, RpcOpts, TransactionOpts},
+    opts::{ChainValueParser, RpcOpts, TransactionOpts, ZkTransactionOpts},
     utils::{self, LoadConfig, TraceResult, get_provider, parse_ether_value},
 };
 use foundry_common::{

--- a/crates/cast/src/cmd/call/zksync.rs
+++ b/crates/cast/src/cmd/call/zksync.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::SolCall;
 use alloy_zksync::network::transaction_request::TransactionRequest as ZkTransactionRequest;
-use cast::ZkTransactionOpts;
+use foundry_cli::opts::ZkTransactionOpts;
 use eyre::Result;
 
 /// Converts the given tx request to be a full ZkSync transaction request with fee estimation
@@ -13,7 +13,7 @@ pub async fn convert_tx(
     zk_tx: ZkTransactionOpts,
     zk_code: Option<String>,
 ) -> Result<ZkTransactionRequest> {
-    let mut tx = zk_tx.build_base_tx(evm_tx, zk_code)?;
+    let mut tx = cast::zksync::build_zk_tx(&zk_tx, evm_tx, zk_code)?;
 
     // NOTE(zk): here we are doing a `call` so the fee doesn't matter
     // but we need a valid value for `gas_per_pubdata`

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -1,5 +1,4 @@
 use crate::tx::{CastTxBuilder, SenderKind};
-use foundry_cli::opts::ZkTransactionOpts;
 use alloy_ens::NameOrAddress;
 use alloy_primitives::U256;
 use alloy_provider::Provider;
@@ -7,7 +6,7 @@ use alloy_rpc_types::BlockId;
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
-    opts::{RpcOpts, TransactionOpts},
+    opts::{RpcOpts, TransactionOpts, ZkTransactionOpts},
     utils::{self, LoadConfig, parse_ether_value},
 };
 use foundry_wallets::WalletOpts;

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -1,7 +1,5 @@
-use crate::{
-    ZkTransactionOpts,
-    tx::{CastTxBuilder, SenderKind},
-};
+use crate::tx::{CastTxBuilder, SenderKind};
+use foundry_cli::opts::ZkTransactionOpts;
 use alloy_ens::NameOrAddress;
 use alloy_primitives::U256;
 use alloy_provider::Provider;

--- a/crates/cast/src/cmd/estimate/zksync.rs
+++ b/crates/cast/src/cmd/estimate/zksync.rs
@@ -1,7 +1,7 @@
 use alloy_provider::Provider;
 use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
-use cast::ZkTransactionOpts;
+use foundry_cli::opts::ZkTransactionOpts;
 use eyre::Result;
 use foundry_cli::utils;
 use foundry_config::Config;
@@ -13,6 +13,6 @@ pub async fn estimate_gas(
     config: &Config,
 ) -> Result<u64> {
     let zk_provider = utils::get_provider_zksync(config)?;
-    let tx = zk_tx.build_base_tx(evm_tx, zk_code)?;
+    let tx = cast::zksync::build_zk_tx(&zk_tx, evm_tx, zk_code)?;
     Ok(zk_provider.estimate_gas(tx).await?)
 }

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -2,7 +2,6 @@ use crate::{
     tx::{self, CastTxBuilder, SenderKind},
     zksync::NoopWallet,
 };
-use foundry_cli::opts::ZkTransactionOpts;
 use alloy_eips::Encodable2718;
 use alloy_ens::NameOrAddress;
 use alloy_network::{EthereumWallet, TransactionBuilder};
@@ -13,7 +12,7 @@ use alloy_zksync::wallet::ZksyncWallet;
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
-    opts::{EthereumOpts, TransactionOpts},
+    opts::{EthereumOpts, TransactionOpts, ZkTransactionOpts},
     utils::{LoadConfig, get_provider},
 };
 use std::{path::PathBuf, str::FromStr};

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -1,7 +1,8 @@
 use crate::{
     tx::{self, CastTxBuilder, SenderKind},
-    zksync::{NoopWallet, ZkTransactionOpts},
+    zksync::NoopWallet,
 };
+use foundry_cli::opts::ZkTransactionOpts;
 use alloy_eips::Encodable2718;
 use alloy_ens::NameOrAddress;
 use alloy_network::{EthereumWallet, TransactionBuilder};

--- a/crates/cast/src/cmd/mktx/zksync.rs
+++ b/crates/cast/src/cmd/mktx/zksync.rs
@@ -1,4 +1,3 @@
-use foundry_cli::opts::ZkTransactionOpts;
 use alloy_network::TransactionBuilder;
 use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
@@ -7,7 +6,7 @@ use alloy_zksync::{
     provider::ZksyncProvider,
 };
 use eyre::Result;
-use foundry_cli::utils;
+use foundry_cli::{opts::ZkTransactionOpts, utils};
 use foundry_config::Config;
 
 /// Builds a complete ZkSync transaction request with fee estimation

--- a/crates/cast/src/cmd/mktx/zksync.rs
+++ b/crates/cast/src/cmd/mktx/zksync.rs
@@ -1,4 +1,4 @@
-use crate::zksync::ZkTransactionOpts;
+use foundry_cli::opts::ZkTransactionOpts;
 use alloy_network::TransactionBuilder;
 use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
@@ -18,7 +18,7 @@ pub async fn build_tx(
     config: &Config,
 ) -> Result<ZkTransactionRequest> {
     let zk_provider = utils::get_provider_zksync(config)?;
-    let mut tx = zk_tx.build_base_tx(evm_tx, Some(zk_code))?;
+    let mut tx = crate::zksync::build_zk_tx(&zk_tx, evm_tx, Some(zk_code))?;
 
     let fee = ZksyncProvider::estimate_fee(&zk_provider, tx.clone()).await?;
     tx.set_max_fee_per_gas(fee.max_fee_per_gas);

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -1,9 +1,7 @@
 use std::{path::PathBuf, str::FromStr, time::Duration};
 
-use crate::{
-    tx::{self, CastTxBuilder, CastTxSender, SendTxOpts},
-    zksync::ZkTransactionOpts,
-};
+use crate::tx::{self, CastTxBuilder, CastTxSender, SendTxOpts};
+use foundry_cli::opts::ZkTransactionOpts;
 use alloy_eips::Encodable2718;
 use alloy_ens::NameOrAddress;
 use alloy_network::{AnyNetwork, EthereumWallet, TransactionBuilder};

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, str::FromStr, time::Duration};
 
 use crate::tx::{self, CastTxBuilder, CastTxSender, SendTxOpts};
-use foundry_cli::opts::ZkTransactionOpts;
 use alloy_eips::Encodable2718;
 use alloy_ens::NameOrAddress;
 use alloy_network::{AnyNetwork, EthereumWallet, TransactionBuilder};
@@ -13,7 +12,7 @@ use alloy_signer::Signer;
 use clap::Parser;
 use eyre::{Result, eyre};
 use foundry_cli::{
-    opts::TransactionOpts,
+    opts::{TransactionOpts, ZkTransactionOpts},
     utils::{self, LoadConfig, get_provider},
 };
 use foundry_wallets::WalletSigner;

--- a/crates/cast/src/cmd/send/zksync.rs
+++ b/crates/cast/src/cmd/send/zksync.rs
@@ -12,8 +12,9 @@ use foundry_cli::opts::EthereumOpts;
 
 use crate::{
     tx::{self, CastTxBuilder, InputState, SenderKind},
-    zksync::{NoopWallet, ZkTransactionOpts},
+    zksync::NoopWallet,
 };
+use foundry_cli::opts::ZkTransactionOpts;
 
 pub async fn send_zk_transaction(
     zk_provider: RootProvider<Zksync>,
@@ -57,7 +58,7 @@ async fn send_transaction_internal<Z>(
 where
     Z: ZksyncProvider,
 {
-    let mut tx = zk_tx_opts.build_base_tx(tx, zk_code)?;
+    let mut tx = crate::zksync::build_zk_tx(&zk_tx_opts, tx, zk_code)?;
 
     // Estimate fees
     foundry_zksync_core::estimate_fee(&mut tx, &zk_provider, 130, None).await?;

--- a/crates/cast/src/cmd/send/zksync.rs
+++ b/crates/cast/src/cmd/send/zksync.rs
@@ -61,7 +61,8 @@ where
     let mut tx = crate::zksync::build_zk_tx(&zk_tx_opts, tx, zk_code)?;
 
     // Estimate fees
-    foundry_zksync_core::estimate_fee(&mut tx, &zk_provider, 130, None).await?;
+    foundry_zksync_core::estimate_fee(&mut tx, &zk_provider, 130, zk_tx_opts.gas_per_pubdata)
+        .await?;
 
     let pending_tx: PendingTransactionBuilder<Zksync> = zk_provider.send_transaction(tx).await?;
     let tx_hash = pending_tx.inner().tx_hash();

--- a/crates/cast/src/cmd/send/zksync.rs
+++ b/crates/cast/src/cmd/send/zksync.rs
@@ -61,8 +61,7 @@ where
     let mut tx = crate::zksync::build_zk_tx(&zk_tx_opts, tx, zk_code)?;
 
     // Estimate fees
-    foundry_zksync_core::estimate_fee(&mut tx, &zk_provider, 130, zk_tx_opts.gas_per_pubdata)
-        .await?;
+    foundry_zksync_core::estimate_fee(&mut tx, &zk_provider, 130, None).await?;
 
     let pending_tx: PendingTransactionBuilder<Zksync> = zk_provider.send_transaction(tx).await?;
     let tx_hash = pending_tx.inner().tx_hash();

--- a/crates/cast/src/zksync.rs
+++ b/crates/cast/src/zksync.rs
@@ -4,7 +4,7 @@ use alloy_consensus::SignableTransaction;
 use alloy_dyn_abi::FunctionExt;
 use alloy_json_abi::Function;
 use alloy_network::{AnyNetwork, NetworkWallet, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, Signature, TxKind, U256, hex};
+use alloy_primitives::{Address, Signature, TxKind, U256, hex};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, TransactionRequest};
 use alloy_serde::WithOtherFields;
@@ -15,9 +15,8 @@ use alloy_zksync::network::{
     tx_envelope::TxEnvelope,
     unsigned_tx::{TypedTransaction, eip712::PaymasterParams},
 };
-use clap::Parser;
 use eyre::{Context, Result};
-use foundry_cli::utils;
+use foundry_cli::{opts::ZkTransactionOpts, utils};
 use foundry_common::{
     fmt::{format_token, format_token_raw},
     shell,
@@ -26,84 +25,47 @@ use foundry_config::Config;
 
 use crate::Cast;
 
-#[derive(Clone, Debug, Parser)]
-#[command(next_help_heading = "Transaction options")]
-pub struct ZkTransactionOpts {
-    /// Paymaster address for the ZKSync transaction
-    #[arg(long = "zk-paymaster-address", requires = "paymaster_input")]
-    pub paymaster_address: Option<Address>,
+/// Builds a base ZkSync transaction request from the common parameters
+pub fn build_zk_tx(
+    opts: &ZkTransactionOpts,
+    evm_tx: WithOtherFields<TransactionRequest>,
+    zk_code: Option<String>,
+) -> Result<ZkTransactionRequest> {
+    let is_create = evm_tx.to == Some(TxKind::Create);
+    let mut tx: ZkTransactionRequest = evm_tx.inner.into();
 
-    /// Paymaster input for the ZKSync transaction
-    #[arg(long = "zk-paymaster-input", requires = "paymaster_address", value_parser = parse_hex_bytes)]
-    pub paymaster_input: Option<Bytes>,
-
-    /// Custom signature for the ZKSync transaction
-    #[arg(long = "zk-custom-signature",  value_parser = parse_hex_bytes)]
-    pub custom_signature: Option<Bytes>,
-
-    /// Factory dependencies for the ZKSync transaction
-    #[arg(long = "zk-factory-deps", value_parser = parse_hex_bytes, value_delimiter = ',')]
-    pub factory_deps: Vec<Bytes>,
-
-    /// Gas per pubdata for the ZKSync transaction
-    #[arg(long = "zk-gas-per-pubdata")]
-    pub gas_per_pubdata: Option<U256>,
-}
-
-fn parse_hex_bytes(s: &str) -> Result<Bytes, String> {
-    hex::decode(s).map(Bytes::from).map_err(|e| format!("Invalid hex string: {e}"))
-}
-
-impl ZkTransactionOpts {
-    pub fn has_zksync_args(&self) -> bool {
-        self.paymaster_address.is_some()
-            || self.custom_signature.is_some()
-            || !self.factory_deps.is_empty()
-            || self.gas_per_pubdata.is_some()
+    if let Some(gas_per_pubdata) = opts.gas_per_pubdata {
+        tx.set_gas_per_pubdata(U256::from(gas_per_pubdata));
     }
 
-    /// Builds a base ZkSync transaction request from the common parameters
-    pub fn build_base_tx(
-        &self,
-        evm_tx: WithOtherFields<TransactionRequest>,
-        zk_code: Option<String>,
-    ) -> Result<ZkTransactionRequest> {
-        let is_create = evm_tx.to == Some(TxKind::Create);
-        let mut tx: ZkTransactionRequest = evm_tx.inner.into();
-
-        if let Some(gas_per_pubdata) = self.gas_per_pubdata {
-            tx.set_gas_per_pubdata(gas_per_pubdata);
-        }
-
-        if let (Some(paymaster), Some(paymaster_input)) =
-            (self.paymaster_address, self.paymaster_input.clone())
-        {
-            tx.set_paymaster_params(PaymasterParams { paymaster, paymaster_input });
-        }
-
-        if let Some(custom_signature) = self.custom_signature.clone() {
-            tx.set_custom_signature(custom_signature);
-        }
-
-        if is_create {
-            let input_data = tx.input().cloned().unwrap_or_default().to_vec();
-            let zk_code = zk_code
-                .ok_or_else(|| eyre::eyre!("ZkSync code is required for contract creation"))?;
-            let zk_code_bytes = hex::decode(zk_code)?;
-            let constructor_args = &input_data[zk_code_bytes.len()..];
-
-            tx = tx.with_create_params(
-                zk_code_bytes,
-                constructor_args.to_vec(),
-                self.factory_deps.iter().map(|b| b.to_vec()).collect(),
-            )?;
-        } else {
-            tx.set_factory_deps(self.factory_deps.clone());
-        }
-
-        tx.prep_for_submission();
-        Ok(tx)
+    if let (Some(paymaster), Some(paymaster_input)) =
+        (opts.paymaster_address, opts.paymaster_input.clone())
+    {
+        tx.set_paymaster_params(PaymasterParams { paymaster, paymaster_input });
     }
+
+    if let Some(custom_signature) = opts.custom_signature.clone() {
+        tx.set_custom_signature(custom_signature);
+    }
+
+    if is_create {
+        let input_data = tx.input().cloned().unwrap_or_default().to_vec();
+        let zk_code = zk_code
+            .ok_or_else(|| eyre::eyre!("ZkSync code is required for contract creation"))?;
+        let zk_code_bytes = hex::decode(zk_code)?;
+        let constructor_args = &input_data[zk_code_bytes.len()..];
+
+        tx = tx.with_create_params(
+            zk_code_bytes,
+            constructor_args.to_vec(),
+            opts.factory_deps.iter().map(|b| b.to_vec()).collect(),
+        )?;
+    } else {
+        tx.set_factory_deps(opts.factory_deps.clone());
+    }
+
+    tx.prep_for_submission();
+    Ok(tx)
 }
 
 pub struct ZkCast<P, Z> {
@@ -253,7 +215,7 @@ pub async fn convert_tx(
     zk_tx: ZkTransactionOpts,
     zk_code: Option<String>,
 ) -> Result<ZkTransactionRequest> {
-    let mut tx = zk_tx.build_base_tx(evm_tx, zk_code)?;
+    let mut tx = build_zk_tx(&zk_tx, evm_tx, zk_code)?;
 
     // NOTE(zk): here we are doing a `call` so the fee doesn't matter
     // but we need a valid value for `gas_per_pubdata`
@@ -282,6 +244,6 @@ pub async fn estimate_gas(
     config: &Config,
 ) -> Result<u64> {
     let zk_provider = utils::get_provider_zksync(config)?;
-    let tx = zk_tx.build_base_tx(evm_tx, zk_code)?;
+    let tx = build_zk_tx(&zk_tx, evm_tx, zk_code)?;
     Ok(zk_provider.estimate_gas(tx).await?)
 }

--- a/crates/cast/src/zksync.rs
+++ b/crates/cast/src/zksync.rs
@@ -50,8 +50,8 @@ pub fn build_zk_tx(
 
     if is_create {
         let input_data = tx.input().cloned().unwrap_or_default().to_vec();
-        let zk_code = zk_code
-            .ok_or_else(|| eyre::eyre!("ZkSync code is required for contract creation"))?;
+        let zk_code =
+            zk_code.ok_or_else(|| eyre::eyre!("ZkSync code is required for contract creation"))?;
         let zk_code_bytes = hex::decode(zk_code)?;
         let constructor_args = &input_data[zk_code_bytes.len()..];
 

--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashSet, path::PathBuf};
 
-use alloy_primitives::{Address, Bytes, hex};
 use clap::Parser;
 use foundry_config::zksync::ZkSyncConfig;
 use foundry_zksync_compilers::compilers::zksolc::{ErrorType, WarningType};
@@ -110,23 +109,6 @@ pub struct ZkSyncArgs {
     #[clap(long = "zk-optimizer")]
     pub optimizer: bool,
 
-    /// Paymaster address
-    #[clap(
-        long = "zk-paymaster-address",
-        value_name = "PAYMASTER_ADDRESS",
-        visible_alias = "paymaster-address"
-    )]
-    pub paymaster_address: Option<Address>,
-
-    /// Paymaster input
-    #[clap(
-        long = "zk-paymaster-input",
-        value_name = "PAYMASTER_INPUT",
-        visible_alias = "paymaster-input",
-        value_parser = parse_hex_bytes
-    )]
-    pub paymaster_input: Option<Bytes>,
-
     /// Set the warnings to suppress for zksolc.
     #[clap(
         long = "zk-suppressed-warnings",
@@ -193,6 +175,3 @@ impl ZkSyncArgs {
     }
 }
 
-fn parse_hex_bytes(s: &str) -> Result<Bytes, String> {
-    hex::decode(s).map(Bytes::from).map_err(|e| format!("Invalid hex string: {e}"))
-}

--- a/crates/cli/src/opts/build/zksync.rs
+++ b/crates/cli/src/opts/build/zksync.rs
@@ -174,4 +174,3 @@ impl ZkSyncArgs {
         zksync
     }
 }
-

--- a/crates/cli/src/opts/mod.rs
+++ b/crates/cli/src/opts/mod.rs
@@ -6,6 +6,7 @@ mod global;
 mod rpc;
 mod tempo;
 mod transaction;
+mod zk_transaction;
 
 pub use build::*;
 pub use chain::*;
@@ -15,3 +16,4 @@ pub use global::*;
 pub use rpc::*;
 pub use tempo::*;
 pub use transaction::*;
+pub use zk_transaction::*;

--- a/crates/cli/src/opts/zk_transaction.rs
+++ b/crates/cli/src/opts/zk_transaction.rs
@@ -9,7 +9,11 @@ fn parse_hex_bytes(s: &str) -> Result<Bytes, String> {
 #[command(next_help_heading = "ZKSync transaction options")]
 pub struct ZkTransactionOpts {
     /// Paymaster address for the ZKSync transaction
-    #[arg(long = "zk-paymaster-address", visible_alias = "paymaster-address", requires = "paymaster_input")]
+    #[arg(
+        long = "zk-paymaster-address",
+        visible_alias = "paymaster-address",
+        requires = "paymaster_input"
+    )]
     pub paymaster_address: Option<Address>,
 
     /// Paymaster input for the ZKSync transaction

--- a/crates/cli/src/opts/zk_transaction.rs
+++ b/crates/cli/src/opts/zk_transaction.rs
@@ -1,0 +1,39 @@
+use alloy_primitives::{Address, Bytes, hex};
+use clap::Parser;
+
+fn parse_hex_bytes(s: &str) -> Result<Bytes, String> {
+    hex::decode(s).map(Bytes::from).map_err(|e| format!("Invalid hex string: {e}"))
+}
+
+#[derive(Clone, Debug, Default, Parser)]
+#[command(next_help_heading = "ZKSync transaction options")]
+pub struct ZkTransactionOpts {
+    /// Paymaster address for the ZKSync transaction
+    #[arg(long = "zk-paymaster-address", alias = "paymaster-address", requires = "paymaster_input")]
+    pub paymaster_address: Option<Address>,
+
+    /// Paymaster input for the ZKSync transaction
+    #[arg(long = "zk-paymaster-input", alias = "paymaster-input", requires = "paymaster_address", value_parser = parse_hex_bytes)]
+    pub paymaster_input: Option<Bytes>,
+
+    /// Custom signature for the ZKSync transaction
+    #[arg(long = "zk-custom-signature", value_parser = parse_hex_bytes)]
+    pub custom_signature: Option<Bytes>,
+
+    /// Factory dependencies for the ZKSync transaction
+    #[arg(long = "zk-factory-deps", value_parser = parse_hex_bytes, value_delimiter = ',')]
+    pub factory_deps: Vec<Bytes>,
+
+    /// Gas per pubdata for the ZKSync transaction
+    #[arg(long = "zk-gas-per-pubdata")]
+    pub gas_per_pubdata: Option<u64>,
+}
+
+impl ZkTransactionOpts {
+    pub fn has_zksync_args(&self) -> bool {
+        self.paymaster_address.is_some()
+            || self.custom_signature.is_some()
+            || !self.factory_deps.is_empty()
+            || self.gas_per_pubdata.is_some()
+    }
+}

--- a/crates/cli/src/opts/zk_transaction.rs
+++ b/crates/cli/src/opts/zk_transaction.rs
@@ -9,11 +9,11 @@ fn parse_hex_bytes(s: &str) -> Result<Bytes, String> {
 #[command(next_help_heading = "ZKSync transaction options")]
 pub struct ZkTransactionOpts {
     /// Paymaster address for the ZKSync transaction
-    #[arg(long = "zk-paymaster-address", alias = "paymaster-address", requires = "paymaster_input")]
+    #[arg(long = "zk-paymaster-address", visible_alias = "paymaster-address", requires = "paymaster_input")]
     pub paymaster_address: Option<Address>,
 
     /// Paymaster input for the ZKSync transaction
-    #[arg(long = "zk-paymaster-input", alias = "paymaster-input", requires = "paymaster_address", value_parser = parse_hex_bytes)]
+    #[arg(long = "zk-paymaster-input", visible_alias = "paymaster-input", requires = "paymaster_address", value_parser = parse_hex_bytes)]
     pub paymaster_input: Option<Bytes>,
 
     /// Custom signature for the ZKSync transaction

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -102,6 +102,9 @@ pub struct CreateArgs {
     #[command(flatten)]
     retry: RetryArgs,
 
+    /// Only `gas_per_pubdata`, `paymaster_address`, and `paymaster_input` are used
+    /// during deployment. `custom_signature` and `factory_deps` are unused in the
+    /// create path (factory deps are derived from compilation output).
     #[command(flatten)]
     pub zk_tx: ZkTransactionOpts,
 }

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -13,7 +13,7 @@ use clap::{Parser, ValueHint};
 use eyre::{Context, Result};
 use forge_verify::{RetryArgs, VerifierArgs, VerifyArgs};
 use foundry_cli::{
-    opts::{BuildOpts, EthereumOpts, EtherscanOpts, TransactionOpts},
+    opts::{BuildOpts, EthereumOpts, EtherscanOpts, TransactionOpts, ZkTransactionOpts},
     utils::{self, LoadConfig, find_contract_artifacts, read_constructor_args_file},
 };
 use foundry_common::{
@@ -103,7 +103,7 @@ pub struct CreateArgs {
     retry: RetryArgs,
 
     #[command(flatten)]
-    pub zksync: zksync::ZkCreateArgs,
+    pub zk_tx: ZkTransactionOpts,
 }
 
 impl CreateArgs {

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -102,7 +102,8 @@ pub struct CreateArgs {
     #[command(flatten)]
     retry: RetryArgs,
 
-    /// Only `gas_per_pubdata`, `paymaster_address`, and `paymaster_input` are used during deployment.
+    /// Only `gas_per_pubdata`, `paymaster_address`, and `paymaster_input` are used during
+    /// deployment.
     #[command(flatten)]
     pub zk_tx: ZkTransactionOpts,
 }

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -102,9 +102,7 @@ pub struct CreateArgs {
     #[command(flatten)]
     retry: RetryArgs,
 
-    /// Only `gas_per_pubdata`, `paymaster_address`, and `paymaster_input` are used
-    /// during deployment. `custom_signature` and `factory_deps` are unused in the
-    /// create path (factory deps are derived from compilation output).
+    /// Only `gas_per_pubdata`, `paymaster_address`, and `paymaster_input` are used during deployment.
     #[command(flatten)]
     pub zk_tx: ZkTransactionOpts,
 }

--- a/crates/forge/src/cmd/create/zksync.rs
+++ b/crates/forge/src/cmd/create/zksync.rs
@@ -19,7 +19,6 @@ use alloy_zksync::{
     },
     wallet::ZksyncWallet,
 };
-use clap::Parser;
 use eyre::{Context, Result};
 use forge_verify::VerifyArgs;
 use foundry_cli::{
@@ -33,13 +32,6 @@ use foundry_zksync_compilers::compilers::artifact_output::zk::ZkContractArtifact
 use foundry_zksync_core::convert::ConvertH160;
 use serde_json::json;
 
-#[derive(Clone, Debug, Parser)]
-pub struct ZkCreateArgs {
-    /// Gas per pubdata
-    #[clap(long = "zk-gas-per-pubdata", value_name = "GAS_PER_PUBDATA")]
-    pub gas_per_pubdata: Option<u64>,
-}
-
 #[derive(Debug, Default)]
 /// Data used to deploy a contract on zksync
 pub struct ZkSyncData {
@@ -51,12 +43,10 @@ pub struct ZkSyncData {
 
 impl CreateArgs {
     pub(super) async fn run_zksync(mut self, project: Project) -> Result<()> {
-        let paymaster_params = if let Some(paymaster_address) =
-            self.build.compiler.zk.paymaster_address
-        {
+        let paymaster_params = if let Some(paymaster_address) = self.zk_tx.paymaster_address {
             Some(PaymasterParams {
                 paymaster: paymaster_address,
-                paymaster_input: self.build.compiler.zk.paymaster_input.clone().unwrap_or_default(),
+                paymaster_input: self.zk_tx.paymaster_input.clone().unwrap_or_default(),
             })
         } else {
             None
@@ -282,7 +272,7 @@ impl CreateArgs {
             &mut deployer.tx,
             &provider,
             130,
-            self.zksync.gas_per_pubdata,
+            self.zk_tx.gas_per_pubdata,
         )
         .await?;
 

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -179,15 +179,12 @@ impl<'a> SendTransactionKind<'a> {
                     }
 
                     // Cheatcode paymaster takes priority; CLI args are fallback
-                    let paymaster_params = if let Some(paymaster_data) =
-                        &zk_tx_meta.paymaster_data
+                    let paymaster_params = if let Some(paymaster_data) = &zk_tx_meta.paymaster_data
                     {
-                        Some(
-                            alloy_zksync::network::unsigned_tx::eip712::PaymasterParams {
-                                paymaster: paymaster_data.paymaster.to_address(),
-                                paymaster_input: paymaster_data.paymaster_input.clone().into(),
-                            },
-                        )
+                        Some(alloy_zksync::network::unsigned_tx::eip712::PaymasterParams {
+                            paymaster: paymaster_data.paymaster.to_address(),
+                            paymaster_input: paymaster_data.paymaster_input.clone().into(),
+                        })
                     } else if let (Some(addr), Some(input)) =
                         (zk_tx_opts.paymaster_address, zk_tx_opts.paymaster_input.clone())
                     {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -178,26 +178,13 @@ impl<'a> SendTransactionKind<'a> {
                         );
                     }
 
-                    // Cheatcode paymaster takes priority; CLI args are fallback
-                    let paymaster_params = if let Some(paymaster_data) = &zk_tx_meta.paymaster_data
-                    {
-                        Some(alloy_zksync::network::unsigned_tx::eip712::PaymasterParams {
-                            paymaster: paymaster_data.paymaster.to_address(),
-                            paymaster_input: paymaster_data.paymaster_input.clone().into(),
-                        })
-                    } else if let (Some(addr), Some(input)) =
-                        (zk_tx_opts.paymaster_address, zk_tx_opts.paymaster_input.clone())
-                    {
-                        Some(alloy_zksync::network::unsigned_tx::eip712::PaymasterParams {
-                            paymaster: addr,
-                            paymaster_input: input,
-                        })
-                    } else {
-                        None
-                    };
-
-                    if let Some(params) = paymaster_params {
-                        zk_tx.set_paymaster_params(params);
+                    if let Some(paymaster_data) = &zk_tx_meta.paymaster_data {
+                        zk_tx.set_paymaster_params(
+                            alloy_zksync::network::unsigned_tx::eip712::PaymasterParams {
+                                paymaster: paymaster_data.paymaster.to_address(),
+                                paymaster_input: paymaster_data.paymaster_input.clone().into(),
+                            },
+                        );
                     }
 
                     foundry_zksync_core::estimate_fee(

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -26,7 +26,7 @@ use eyre::{ContextCompat, Result};
 use forge_script_sequence::{AdditionalContract, NestedValue};
 use forge_verify::{RetryArgs, VerifierArgs};
 use foundry_cli::{
-    opts::{BuildOpts, EvmArgs, GlobalArgs},
+    opts::{BuildOpts, EvmArgs, GlobalArgs, ZkTransactionOpts},
     utils::{self, LoadConfig},
 };
 use foundry_common::{
@@ -225,9 +225,8 @@ pub struct ScriptArgs {
     #[command(flatten)]
     pub retry: RetryArgs,
 
-    /// Gas per pubdata
-    #[clap(long = "zk-gas-per-pubdata", value_name = "GAS_PER_PUBDATA")]
-    pub zk_gas_per_pubdata: Option<u64>,
+    #[command(flatten)]
+    pub zk_tx: ZkTransactionOpts,
 }
 
 impl ScriptArgs {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -225,6 +225,9 @@ pub struct ScriptArgs {
     #[command(flatten)]
     pub retry: RetryArgs,
 
+    /// Only `gas_per_pubdata`, `paymaster_address`, and `paymaster_input` are used
+    /// during broadcast. `custom_signature` and `factory_deps` are unused in the
+    /// script path (factory deps come from cheatcode transaction metadata).
     #[command(flatten)]
     pub zk_tx: ZkTransactionOpts,
 }

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -225,10 +225,7 @@ pub struct ScriptArgs {
     #[command(flatten)]
     pub retry: RetryArgs,
 
-    /// Only `gas_per_pubdata` is used during broadcast. Paymaster parameters,
-    /// `custom_signature`, and `factory_deps` are unused in the script path
-    /// (paymasters are set via cheatcodes; factory deps come from cheatcode
-    /// transaction metadata).
+    /// Only `gas_per_pubdata` is used in the script broadcast path.
     #[command(flatten)]
     pub zk_tx: ZkTransactionOpts,
 }

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -225,9 +225,10 @@ pub struct ScriptArgs {
     #[command(flatten)]
     pub retry: RetryArgs,
 
-    /// Only `gas_per_pubdata`, `paymaster_address`, and `paymaster_input` are used
-    /// during broadcast. `custom_signature` and `factory_deps` are unused in the
-    /// script path (factory deps come from cheatcode transaction metadata).
+    /// Only `gas_per_pubdata` is used during broadcast. Paymaster parameters,
+    /// `custom_signature`, and `factory_deps` are unused in the script path
+    /// (paymasters are set via cheatcodes; factory deps come from cheatcode
+    /// transaction metadata).
     #[command(flatten)]
     pub zk_tx: ZkTransactionOpts,
 }


### PR DESCRIPTION
# What :computer:
* Consolidate three separate ZkSync transaction option definitions (`ZkTransactionOpts` in cast, `ZkCreateArgs` in forge create, standalone `--zk-gas-per-pubdata` in forge script) into a single shared `ZkTransactionOpts` struct in `foundry_cli::opts`
* Extract `build_base_tx` from an impl method into a free function `build_zk_tx` in `cast::zksync` (struct moved to `foundry_cli` which must not depend on `alloy_zksync` types)

# Why :hand:
* The same CLI args were defined in three places with near-identical fields -- a maintenance hazard that would drift over time
* Paymaster params lived on `ZkSyncArgs` (build/compiler config) despite being transaction-time concerns, not compilation concerns

# Evidence :camera:
See `docs-zksync/refactor_unify_zk_transactions.md` for a detailed breakdown of all changes, inconsistencies, and decision justifications.

# Documentation :books:

- [x] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

CLI flag names are unchanged (`--zk-paymaster-address`, `--zk-paymaster-input`, `--zk-gas-per-pubdata`). The `--paymaster-address` / `--paymaster-input` short aliases are now available in cast commands (previously only in build args).

# Notes :memo:
* `gas_per_pubdata` type narrowed from `U256` to `u64` to align with the two existing definitions (`ZkCreateArgs`, `ScriptArgs`) and the `estimate_fee` API that all already use `u64`; the conversion to `U256` at the wire level is lossless.
* `--zk-custom-signature` and `--zk-factory-deps` are accepted but unused on `forge script` and `forge create` (documented with comments at flatten sites). Splitting the struct would recreate the duplication this PR eliminates.
* Follow-up items tracked in #1274: `cast send` / `cast mktx` gas_per_pubdata bugs. 