### PR TITLE
fix: adapt proxy test to OpenZeppelin breaking change

### DIFF
--- a/crates/forge/tests/cli/test_cmd/zksync.rs
+++ b/crates/forge/tests/cli/test_cmd/zksync.rs
@@ -1617,7 +1617,7 @@ mod proxy {
             "./script/Proxy.s.sol",
             "ProxyScript",
             Some("OpenZeppelin/openzeppelin-contracts"),
-            4,
+            3,
             Some(&["--broadcast"]),
         )
         .await;

--- a/crates/forge/tests/fixtures/zk/Proxy.s.sol
+++ b/crates/forge/tests/fixtures/zk/Proxy.s.sol
@@ -8,10 +8,12 @@ contract ProxyScript is Script {
     function run() public {
         vm.startBroadcast(0x7becc4a46e0c3b512d380ca73a4c868f790d1055a7698f38fb3ca2b2ac97efbb);
         //deploy Foo
-        ERC1967Proxy proxy = new ERC1967Proxy(address(new Foo()), "");
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(new Foo()),
+            abi.encodeCall(Foo.initialize, (msg.sender))
+        );
 
         Foo foo = Foo(payable(proxy));
-        foo.initialize(msg.sender);
 
         console.log("Foo deployed at: ", address(foo));
         console.log("Bar: ", foo.getAddress());


### PR DESCRIPTION
# What :computer: 
* OpenZeppelin now mandates initialization during ERC1967Proxy construction. Deploying with empty data reverts with ERC1967ProxyUninitialized(). Pass abi.encodeCall for initialize in the proxy constructor instead of calling it separately.

Ref: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/5906

# Why :hand:
* Make the test pass

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
