### PR TITLE
fix(ci): remove dependabot config to prevent unwanted PRs in fork

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "softprops/action-gh-release"


### PR DESCRIPTION


# What :computer: 
*  Unlike workflow files which support `if: github.repository` guards, dependabot.yml is declarative and activates automatically when present. Restoring this file from upstream caused Dependabot to immediately open dependency bump PRs against this fork.

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# Documentation :books:
Please ensure the following before submitting your PR:

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
