### PR TITLE
fix: cast send ignores --zk-gas-per-pubdata flag

### DIFF
--- a/crates/cast/src/cmd/send/zksync.rs
+++ b/crates/cast/src/cmd/send/zksync.rs
@@ -61,13 +61,8 @@ where
     let mut tx = crate::zksync::build_zk_tx(&zk_tx_opts, tx, zk_code)?;
 
     // Estimate fees
-    foundry_zksync_core::estimate_fee(
-        &mut tx,
-        &zk_provider,
-        130,
-        zk_tx_opts.gas_per_pubdata.map(|v| v.to::<u64>()),
-    )
-    .await?;
+    foundry_zksync_core::estimate_fee(&mut tx, &zk_provider, 130, zk_tx_opts.gas_per_pubdata)
+        .await?;
 
     let pending_tx: PendingTransactionBuilder<Zksync> = zk_provider.send_transaction(tx).await?;
     let tx_hash = pending_tx.inner().tx_hash();

--- a/crates/cast/src/cmd/send/zksync.rs
+++ b/crates/cast/src/cmd/send/zksync.rs
@@ -60,7 +60,13 @@ where
     let mut tx = zk_tx_opts.build_base_tx(tx, zk_code)?;
 
     // Estimate fees
-    foundry_zksync_core::estimate_fee(&mut tx, &zk_provider, 130, None).await?;
+    foundry_zksync_core::estimate_fee(
+        &mut tx,
+        &zk_provider,
+        130,
+        zk_tx_opts.gas_per_pubdata.map(|v| v.to::<u64>()),
+    )
+    .await?;
 
     let pending_tx: PendingTransactionBuilder<Zksync> = zk_provider.send_transaction(tx).await?;
     let tx_hash = pending_tx.inner().tx_hash();


### PR DESCRIPTION
# What
* Pass `zk_tx_opts.gas_per_pubdata` to `estimate_fee` instead of `None` in `cast send`

# Why
* `cast send` ignored the `--zk-gas-per-pubdata` CLI flag, always overwriting it with the RPC estimate

Closes #1274

# Evidence
One-line fix: `estimate_fee` already supports the `gas_per_pubdata` override; it was simply not wired through.

# Documentation
- [x] No documented features or workflows are affected.