### PR TITLE
ci: remove NPM_TOKEN from CI

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -156,8 +156,6 @@ jobs:
         working-directory: ./npm
         env:
           PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}
           ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
         run: |
@@ -228,8 +226,6 @@ jobs:
           PROVENANCE: true
           VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -254,8 +250,6 @@ jobs:
     name: Publish Meta Package
     runs-on: ubuntu-latest
     env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}
     steps:
       - name: Checkout
@@ -291,6 +285,4 @@ jobs:
           PROVENANCE: true
           VERSION_NAME: ${{ env.RELEASE_VERSION }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          NPM_TOKEN: ${{ env.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
           NPM_REGISTRY_URL: ${{ env.NPM_REGISTRY_URL }}


### PR DESCRIPTION
Removes the npm publish token references from the CI workflow(s).

Per request, all npm token auth is dropped:
- the `NPM_TOKEN` env var
- `NODE_AUTH_TOKEN` sourced from the same npm secret
- the `token:` secret passed into the reusable publish workflow (where applicable)

Note: with the token gone, the publish step will no longer authenticate to npm via token. If automated publishing should continue, configure npm Trusted Publishing (OIDC) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)