### PR TITLE
ci(release-please): bump reusable CI version

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -20,10 +20,13 @@ jobs:
   # Prepare the release PR with changelog updates and create github releases
   # Do not publish to crates.io or upgrade dependencies
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@v1
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@fcfe16cdf551d9a6b99d9e28d4c705faf0f4c27e
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      # Org-level secrets of the GitHub App used to mint installation tokens.
+      # API commits are auto-signed.
+      MATTERLABS_BOTS_APP_ID: ${{ secrets.MATTERLABS_BOTS_APP_ID }}
+      MATTERLABS_BOTS_PRIVATE_KEY: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
     with:
       config: '.github/release-please/config.json'     # Specify the path to the configuration file
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file


### PR DESCRIPTION
# What :computer: 
- bump version of reusable release-please workflow to support commit signing

- [ ] Check if these changes affect any documented features or workflows.
- [ ] Update the [book](https://github.com/matter-labs/foundry-zksync-book) if these changes affect any documented features or workflows.
